### PR TITLE
docs: 整理版权协议

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -74,6 +74,9 @@ Open Source Software Licensed under the Apache-2.0:
 1. adk
 Copyright 2025 Google LLC
 
+2. agno
+Copyright 2025-2026 Agno Inc.
+
 --------------------------------------------------------------------
 Apache License
 Version 2.0, January 2004

--- a/trpc_agent_sdk/sessions/_session_summarizer.py
+++ b/trpc_agent_sdk/sessions/_session_summarizer.py
@@ -3,11 +3,26 @@
 # Copyright (C) 2026 Tencent. All rights reserved.
 #
 # tRPC-Agent-Python is licensed under Apache-2.0.
+#
+# Below code are copy and modified from https://github.com/agno-agi/agno.git
+#
+# Copyright 2025-2026 Agno Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """Session summarizer for compressing conversation history.
 
 This module provides functionality to summarize conversation history
 to reduce memory usage and maintain context in long conversations.
-Reference: https://github.com/agno-agi/agno/blob/main/libs/agno/agno/memory/v2/summarizer.py
 """
 
 from __future__ import annotations

--- a/trpc_agent_sdk/sessions/_summarizer_manager.py
+++ b/trpc_agent_sdk/sessions/_summarizer_manager.py
@@ -3,11 +3,26 @@
 # Copyright (C) 2026 Tencent. All rights reserved.
 #
 # tRPC-Agent-Python is licensed under Apache-2.0.
+#
+# Below code are copy and modified from https://github.com/agno-agi/agno.git
+#
+# Copyright 2025-2026 Agno Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """Session summarizer manager for compressing conversation history.
 
 This module provides functionality to summarize conversation history
 to reduce memory usage and maintain context in long conversations.
-Reference: https://github.com/agno-agi/agno/blob/main/libs/agno/agno/memory/v2/summarizer.py
 """
 
 from __future__ import annotations

--- a/trpc_agent_sdk/storage/_sql_common.py
+++ b/trpc_agent_sdk/storage/_sql_common.py
@@ -1,3 +1,11 @@
+# Tencent is pleased to support the open source community by making tRPC-Agent-Python available.
+#
+# Copyright (C) 2026 Tencent. All rights reserved.
+#
+# tRPC-Agent-Python is licensed under Apache-2.0.
+#
+# Below code are copy and modified from https://github.com/google/adk-python.git
+#
 # Copyright 2025 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/trpc_agent_sdk/tools/mcp_tool/__init__.py
+++ b/trpc_agent_sdk/tools/mcp_tool/__init__.py
@@ -3,6 +3,22 @@
 # Copyright (C) 2026 Tencent. All rights reserved.
 #
 # tRPC-Agent-Python is licensed under Apache-2.0.
+#
+# Below code are copy and modified from https://github.com/google/adk-python.git
+#
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """MCP tool module for TRPC Agent framework."""
 
 from ._mcp_session_manager import MCPSessionManager

--- a/trpc_agent_sdk/tools/mcp_tool/_mcp_session_manager.py
+++ b/trpc_agent_sdk/tools/mcp_tool/_mcp_session_manager.py
@@ -4,7 +4,6 @@
 #
 # tRPC-Agent-Python is licensed under Apache-2.0.
 #
-# Directly reuse the types from adk-python
 # Below code are copy and modified from https://github.com/google/adk-python.git
 #
 # Copyright 2025 Google LLC


### PR DESCRIPTION
## 补全第三方开源代码的版权归属声明
- session summarizer 模块补全完整的 agno Apache-2.0 许可证头，并在 LICENSE 中添加 agno 的第三方声明
- mcp_tool 和 storage 模块补全adk Apache-2.0 许可证头，Tencent 版权头及完整的 Apache-2.0 原始许可证文本
- License 添加 agno 声明