### PR TITLE
bugfix: 解决OpenAIModel 序列化失败的问题

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.1.10](https://github.com/trpc-group/trpc-agent-python/releases/tag/v1.1.10) (2026-06-18)
+
+### Bug Fixes
+
+* Model: fix error about pickle of OpenAIModel.
+
+
 ## [1.1.9](https://github.com/trpc-group/trpc-agent-python/releases/tag/v1.1.9) (2026-06-18)
 
 ### Features

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -10,4 +10,4 @@ from trpc_agent_sdk.version import __version__
 
 def test_version():
     """Test the version module."""
-    assert __version__ == '1.1.9'
+    assert __version__ == '1.1.10'

--- a/trpc_agent_sdk/models/_openai_model.py
+++ b/trpc_agent_sdk/models/_openai_model.py
@@ -235,14 +235,15 @@ class OpenAIModel(LLMModel):
 
         logging.getLogger("httpx").setLevel(logging.WARNING)
 
-        self.client_args['http_client'] = self._http_client_factory()
+        client_args = self.client_args.copy()
+        client_args['http_client'] = self._http_client_factory()
 
         return openai.AsyncOpenAI(
             api_key=self._api_key,
             max_retries=0,  # disable retries
             organization=self.organization,
             base_url=self._base_url,
-            **self.client_args,
+            **client_args,
         )
 
     def _create_tool_prompt(self) -> ToolPrompt:

--- a/trpc_agent_sdk/version.py
+++ b/trpc_agent_sdk/version.py
@@ -9,4 +9,4 @@ TRPC Agent Version Module
 This module defines the version information for TRPC Agent
 """
 
-__version__ = '1.1.9'
+__version__ = '1.1.10'


### PR DESCRIPTION
当OpenAIModel存在httpx.AsyncClient对象的时候会序列化失败，当前把httpx.AsyncClient对象拷贝到临时字典中不进行序列化