### PR TITLE
Dev/release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,13 +5,10 @@ on:
       - 'v*'
       - 'test/v*'
 
-# 同一个workflow + ref 只跑一份
-# 如果一个tag的release已经在跑了，再来一个同组任务不会取消当前任务，保持发版不会中断
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
 
-# 只读权限
 permissions:
   contents: read
 
@@ -23,14 +20,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      # 安装发布依赖
       - name: Install release dependencies
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements-test.txt
           pip install build twine flake8 yapf
 
-      # 验证tag版本和包版本是否一致
       - name: Validate tag version
         run: |
           TAG_VERSION="${GITHUB_REF_NAME#test/v}"
@@ -41,7 +36,6 @@ jobs:
             exit 1
           fi
 
-      # 检查整个release内容的代码格式
       - name: Check formatting with YAPF
         run: |
           diff_output=$(yapf --diff --recursive trpc_agent_sdk) || true
@@ -51,27 +45,22 @@ jobs:
             exit 1
           fi
 
-      # 检查整个release内容的代码风格
       - name: Lint with flake8
         run: |
           flake8 trpc_agent_sdk
 
-      # 运行测试  
       - name: Run tests with coverage
         run: |
           pytest --cov=trpc_agent_sdk --cov-report=xml --cov-report=term --cov-fail-under=80 tests/
 
-      # 打包
       - name: Build package
         run: |
           python -m build
 
-      # 检查打包结果  
       - name: Check package
         run: |
           twine check dist/*
 
-      # 发布到PyPI
       - name: Publish to PyPI
         if: startsWith(github.ref, 'refs/tags/v')
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,81 @@
+name: Auto Release when Tag
+on:
+  push:
+    tags:
+      - 'v*'
+      - 'test/v*'
+
+# 同一个workflow + ref 只跑一份
+# 如果一个tag的release已经在跑了，再来一个同组任务不会取消当前任务，保持发版不会中断
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+# 只读权限
+permissions:
+  contents: read
+
+jobs:
+  release:
+    runs-on: [self-hosted, trpc-agent-python-ci]
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # 安装发布依赖
+      - name: Install release dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-test.txt
+          pip install build twine flake8 yapf
+
+      # 验证tag版本和包版本是否一致
+      - name: Validate tag version
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#test/v}"
+          TAG_VERSION="${TAG_VERSION#v}"
+          PACKAGE_VERSION=$(python -c "from trpc_agent_sdk.version import __version__; print(__version__)")
+          if [ "$TAG_VERSION" != "$PACKAGE_VERSION" ]; then
+            echo "::error::Tag version '$TAG_VERSION' does not match package version '$PACKAGE_VERSION'."
+            exit 1
+          fi
+
+      # 检查整个release内容的代码格式
+      - name: Check formatting with YAPF
+        run: |
+          diff_output=$(yapf --diff --recursive trpc_agent_sdk) || true
+          if [ -n "$diff_output" ]; then
+            echo "$diff_output"
+            echo "::error::Code formatting check failed. Run 'yapf -i -r trpc_agent_sdk' to fix."
+            exit 1
+          fi
+
+      # 检查整个release内容的代码风格
+      - name: Lint with flake8
+        run: |
+          flake8 trpc_agent_sdk
+
+      # 运行测试  
+      - name: Run tests with coverage
+        run: |
+          pytest --cov=trpc_agent_sdk --cov-report=xml --cov-report=term --cov-fail-under=80 tests/
+
+      # 打包
+      - name: Build package
+        run: |
+          python -m build
+
+      # 检查打包结果  
+      - name: Check package
+        run: |
+          twine check dist/*
+
+      # 发布到PyPI
+      - name: Publish to PyPI
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          twine upload dist/*
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
## Summary
新增基于 tag 触发的 GitHub Actions release 流水线。
该流水线会：
- 在 `v*` tag 时执行正式 PyPI 发布
- 在 `test/v*` tag 时执行 dry-run 校验，不上传 PyPI
- 校验 tag 版本和 `trpc_agent_sdk.version.__version__` 一致
- 执行格式检查、flake8、pytest、构建和 `twine check`
- 仅在正式 `v*` tag 时上传 PyPI

## Testing
这个 PR 本身应该只触发现有 CI，不会触发 release。
合入后可以用 dry-run tag 测试 release 流水线