### PR TITLE
fix(docs): correct README installation command syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ pip install trpc-agent-py
 Install optional capabilities as needed:
 
 ```bash
-pip install trpc-agent-py[a2a,ag-ui,knowledge,agent-claude,mem0, Mempalace, langfuse]
+pip install "trpc-agent-py[a2a,ag-ui,knowledge,agent-claude,mem0,mempalace,langfuse]"
 ```
 
 ### Develop Weather Agent

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -84,9 +84,8 @@ pip install trpc-agent-py
 按需安装扩展能力：
 
 ```bash
-pip install trpc-agent-py[a2a,ag-ui,knowledge,agent-claude,mem0, Mempalace, langfuse]
+pip install "trpc-agent-py[a2a,ag-ui,knowledge,agent-claude,mem0,mempalace,langfuse]"
 ```
-
 
 ### 开发天气查询Agent
 


### PR DESCRIPTION
hi, I found there are two small typos in README when I try to follow the instructions there
and I fix them according to other similar installation commands in other document files

Ref:
- https://github.com/trpc-group/trpc-agent-python/blob/4336564b9a0c0983ad479711a6d70eaf803f0b51/pyproject.toml#L111
- https://github.com/trpc-group/trpc-agent-python/blob/4336564b9a0c0983ad479711a6d70eaf803f0b51/INSTALL.zh_CN.md?plain=1#L68