### PR TITLE
feat: add skills code review agent example

### DIFF
--- a/examples/skills_code_review_agent/.env.example
+++ b/examples/skills_code_review_agent/.env.example
@@ -1,0 +1,32 @@
+# Code Review Agent — LLM 配置样例（复制为 .env 后按需修改）
+#
+# 所有变量均为可选；缺省即降级为 FakeLlm（不调用任何模型）。
+# 支持任意 OpenAI 兼容端点：OpenAI / Azure OpenAI / 本地 vLLM / 内部 LLM 网关。
+
+# 是否启用真实 LLM 二次研判（也可通过 CLI --enable-llm 覆盖）
+# 取值：true | false
+LLM_ENABLED=false
+
+# 供应商标识（仅用于记录/诊断，不影响端点选择）
+LLM_PROVIDER=openai
+
+# 真实模型 API Key；留空 = 禁用真实模型
+LLM_API_KEY=
+
+# OpenAI 兼容的 Chat Completions 端点基址
+#   OpenAI:      https://api.openai.com/v1
+#   Azure:       https://<res>.openai.azure.com/openai
+#   本地 vLLM:   http://localhost:8000/v1
+LLM_BASE_URL=https://api.openai.com/v1
+
+# 模型名（对应端点上的 deployment / model id）
+LLM_MODEL=gpt-4o-mini
+
+# 采样温度（越低越确定，适合判定任务）
+LLM_TEMPERATURE=0.1
+
+# 单次响应最大 token 数
+LLM_MAX_TOKENS=1024
+
+# 请求超时（秒）
+LLM_TIMEOUT=30

--- a/examples/skills_code_review_agent/README.md
+++ b/examples/skills_code_review_agent/README.md
@@ -1,0 +1,424 @@
+# Code Review Agent
+
+## 快速运行
+
+```powershell
+# 在仓库根目录执行
+$env:PYTHONPATH = "examples/skills_code_review_agent"
+python examples/skills_code_review_agent/run_agent.py --fixture security --dry-run --output-dir examples/skills_code_review_agent/out --db-path examples/skills_code_review_agent/cr_agent.db
+
+# 使用 diff 文件
+python examples/skills_code_review_agent/run_agent.py --diff-file path/to/change.diff --mode dry-run --output-dir out --db-path cr_agent.db
+
+# 审查本地 git 工作区变更
+python examples/skills_code_review_agent/run_agent.py --repo-path path/to/repo --mode dry-run --output-dir out --db-path cr_agent.db
+```
+
+## 常用参数
+
+| 参数 | 说明 |
+| --- | --- |
+| `--diff-file PATH` | 读取 unified diff / PR patch 文件。 |
+| `--repo-path PATH` | 在指定 git 仓库中读取工作区变更。 |
+| `--fixture NAME` | 使用内置 fixture，便于 dry-run 和测试。 |
+| `--skill-dir PATH` | 指定 code-review Skill 目录，默认 `skills/code-review`。 |
+| `--mode dry-run\|real` | `dry-run` 使用 fake runner；`real` 走沙箱 runtime。 |
+| `--dry-run` | `--mode dry-run` 的快捷写法。 |
+| `--output-dir DIR` | 输出 `review_report.json` 和 `review_report.md`。 |
+| `--db-path PATH` | SQLite 数据库路径。 |
+| `--require-sandbox` | real 模式下强制使用声明的沙箱，不可用则失败。 |
+| `--telemetry` | 输出 telemetry span，便于审计链路。 |
+| `--enable-llm` | 可选开启真实 LLM 二次研判；无 Key 时默认不需要。 |
+
+---
+# CR Agent 架构设计
+
+> 自动代码评审 Agent 原型 — 基于 tRPC-Agent Skill 体系
+> 本文是**整体架构设计**,不含完整实现代码,但给出可落地的契约:目录结构、建表 DDL、SKILL.md frontmatter、规则清单、监控字段、去重算法与验收标准逐条对照。
+
+---
+
+## 1. 概述
+
+目标不是"让 LLM 评论代码",而是把 **Skills、沙箱执行、数据库、Filter 治理、审查规则、结果结构化、监控审计、安全边界** 串成一个**可验证系统**。输入 git diff / PR patch / 本地变更目录,输出结构化 findings,并把审查任务、拦截记录、监控摘要、结果写入数据库,支持后续评测、监控、回放。
+
+系统采用**六层流水线**架构,数据自上而下流动,其中 Filter 治理与沙箱执行构成安全治理层,监控审计贯穿全链路。
+
+---
+
+## 2. 目录结构
+
+```
+examples/skills_code_review_agent/
+├── ARCHITECTURE.md              # 本文档
+├── README.md                    # 使用说明
+├── agent.py                     # Agent 入口(CLI 编排)
+├── skills/
+│   └── code-review/
+│       ├── SKILL.md             # Skill 契约:入口/规则/沙箱策略
+│       ├── rules/               # 6 类规则文档
+│       │   ├── security.md
+│       │   ├── async_errors.md
+│       │   ├── resource_leak.md
+│       │   ├── missing_tests.md
+│       │   ├── sensitive_info.md
+│       │   └── db_lifecycle.md
+│       └── scripts/             # 沙箱内可执行脚本
+│           ├── parse_diff.py    # unified diff 解析 → ChangeSet
+│           ├── run_checks.py    # 规则匹配 → 原始诊断
+│           ├── dedupe.py        # 去重 + 置信度分流
+│           └── mask_secrets.py  # 敏感信息脱敏
+├── db/
+│   ├── schema.sql               # 建表 DDL
+│   ├── storage.py               # 存储接口(SQLite 默认,可切 SQL 后端)
+│   └── init_db.py               # 初始化/迁移脚本
+├── sandbox/
+│   ├── runtime.py               # runtime 抽象:local/container/cube
+│   └── policy.py                # 安全边界:超时/输出/env/脱敏/失败
+├── filters/
+│   └── governance.py            # Filter 治理:四类检查 + 决策
+├── tests/
+│   ├── fixtures/                # 8 条 diff 样本
+│   │   ├── 01_clean.diff
+│   │   ├── 02_security.diff
+│   │   ├── 03_async_leak.diff
+│   │   ├── 04_db_lifecycle.diff
+│   │   ├── 05_missing_tests.diff
+│   │   ├── 06_duplicate.diff
+│   │   ├── 07_sandbox_fail.diff
+│   │   └── 08_sensitive_info.diff
+│   └── test_cr_agent.py         # 链路测试
+└── examples/
+    └── review_report.json       # 示例报告输出
+```
+
+---
+
+## 3. 分层架构
+
+系统分为六层,数据流自上而下。数据处理层(蓝)负责把 diff 变成结构化结论,安全治理层(珊瑚)在风险点与执行边界上把关,底部监控审计带贯穿全链路。
+
+| 层 | 名称 | 职责 | 关键产出 |
+|----|------|------|----------|
+| L1 | 输入解析 | 接收 `--diff-file` / `--repo-path` / fixture,解析 unified diff | `ChangeSet`(文件·hunk·行号) |
+| L2 | Skill 加载 | `skill_load` 加载 SKILL.md + 6 类规则 + 脚本目录 | `RuleSet` + 脚本清单 |
+| L3 | Filter 治理 | 脚本前置决策:高风险/禁止路径/非白名单网络/超预算 | `allow` / `deny` / `needs_human_review` |
+| L4 | 沙箱执行 | Container/Cube·E2B(默认)或本地 fallback 跑检查 | 原始诊断(已脱敏) |
+| L5 | 去重结构化 | 行级去重 + 置信度分流 + 9 字段组装 | `findings` / `warnings` / `needs_human_review` |
+| L6 | 存储输出 | 写 SQLite,生成 report.json + report.md | 数据库记录 + 双格式报告 |
+
+**监控审计(贯穿)**:总耗时、沙箱耗时、工具调用次数、拦截次数、finding 数量、severity 分布、异常类型分布。
+
+---
+
+## 4. 评审数据流
+
+一次完整 review 的主链(9 步),含两条异常分支:
+
+```
+CLI 输入 → 解析 diff → skill_load → [Filter 决策] → 沙箱执行 → 去重降噪 → 组装 findings → 落库 → 生成报告
+                                      │                  │
+                          deny/review ─┘                  └ 沙箱失败 → 降级空诊断
+                                      │                                    │
+                                      └──────────→ 都汇入去重降噪层 ←──────┘
+```
+
+- **Filter 分支**:`deny` / `needs_human_review` 时记录拦截原因,跳过沙箱,直接进入去重层(无诊断)。
+- **沙箱失败分支**:超时/崩溃时降级为空诊断,记录失败,继续评审——**异常不崩任务**。
+- **dry-run 模式**:L4 替换为本地 fake runner(直接跑规则脚本,不调真实模型 API),其余链路完全一致,无 API Key 也可验证解析→落库→报告全链路。
+
+---
+
+## 5. 数据库 Schema
+
+七张表围绕 `review_task` 聚合,`task_id` 为全局外键。SQLite 默认实现,`storage.py` 接口保留切换 SQL 后端的空间(只暴露 `ReviewStore` 抽象,底层连接可替换)。
+
+### 5.1 表关系
+
+| 主表 | 关系 | 子表 | 语义 |
+|------|------|------|------|
+| review_task | 1 — N | input_diff | 一个任务可含多个变更文件 |
+| review_task | 1 — N | sandbox_run | 一个任务可跑多次沙箱 |
+| review_task | 1 — N | finding | 一个任务产出多条 finding |
+| review_task | 1 — N | filter_block | 一个任务可有多条拦截 |
+| review_task | 1 — 1 | monitor_summary | 一个任务一条监控汇总 |
+| review_task | 1 — 1 | review_report | 一个任务一份最终报告 |
+
+### 5.2 建表 DDL(`db/schema.sql`)
+
+```sql
+CREATE TABLE IF NOT EXISTS review_task (
+  id TEXT PRIMARY KEY,
+  created_at TEXT NOT NULL,
+  status TEXT NOT NULL,           -- pending|running|done|failed
+  input_type TEXT NOT NULL,       -- diff|repo|fixture
+  input_ref TEXT,
+  mode TEXT NOT NULL,             -- dry-run|real
+  total_duration_ms INTEGER
+);
+
+CREATE TABLE IF NOT EXISTS input_diff (
+  id TEXT PRIMARY KEY,
+  task_id TEXT NOT NULL REFERENCES review_task(id),
+  file_path TEXT,
+  sha256 TEXT,
+  hunk_count INTEGER,
+  line_count INTEGER,
+  summary TEXT
+);
+
+CREATE TABLE IF NOT EXISTS sandbox_run (
+  id TEXT PRIMARY KEY,
+  task_id TEXT NOT NULL REFERENCES review_task(id),
+  runtime TEXT,                   -- local|container|cube
+  script TEXT,
+  status TEXT,                    -- ok|timeout|failed|truncated
+  duration_ms INTEGER,
+  exit_code INTEGER,
+  output_bytes INTEGER,
+  timed_out INTEGER,              -- 0|1
+  masked_count INTEGER
+);
+
+CREATE TABLE IF NOT EXISTS finding (
+  id TEXT PRIMARY KEY,
+  task_id TEXT NOT NULL REFERENCES review_task(id),
+  severity TEXT,                  -- critical|high|medium|low
+  category TEXT,
+  file TEXT,
+  line INTEGER,
+  title TEXT,
+  evidence TEXT,
+  recommendation TEXT,
+  confidence REAL,
+  source TEXT,                    -- rule|sandbox|llm
+  bucket TEXT                     -- findings|warnings|needs_human_review
+);
+CREATE INDEX IF NOT EXISTS idx_finding_dedup ON finding(task_id, file, line, category);
+CREATE INDEX IF NOT EXISTS idx_finding_task ON finding(task_id);
+
+CREATE TABLE IF NOT EXISTS filter_block (
+  id TEXT PRIMARY KEY,
+  task_id TEXT NOT NULL REFERENCES review_task(id),
+  reason TEXT,                    -- high-risk|forbidden-path|network|budget
+  target TEXT,
+  decision TEXT,                  -- deny|needs_human_review
+  detail TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_filter_task ON filter_block(task_id);
+
+CREATE TABLE IF NOT EXISTS monitor_summary (
+  id TEXT PRIMARY KEY,
+  task_id TEXT NOT NULL REFERENCES review_task(id),
+  total_duration_ms INTEGER,
+  sandbox_duration_ms INTEGER,
+  tool_calls INTEGER,
+  blocks INTEGER,
+  finding_count INTEGER,
+  sev_critical INTEGER,
+  sev_high INTEGER,
+  sev_medium INTEGER,
+  sev_low INTEGER,
+  exception_types TEXT            -- JSON,如 {"timeout":2,"oom":1}
+);
+
+CREATE TABLE IF NOT EXISTS review_report (
+  id TEXT PRIMARY KEY,
+  task_id TEXT NOT NULL REFERENCES review_task(id),
+  report_json_path TEXT,
+  report_md_path TEXT,
+  summary TEXT,
+  created_at TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_report_task ON review_report(task_id);
+```
+
+### 5.3 关键设计
+
+- **复合索引 `idx_finding_dedup (task_id, file, line, category)`**——直接服务去重查询,O(1) 命中"同文件同行同类"。
+- **`finding.bucket` 三档**——从 schema 层强制低置信度不混入高置信结论。
+- **`sandbox_run.timed_out` / `output_bytes` / `masked_count`**——把安全边界执行证据持久化,可回放可审计。
+- **`monitor_summary` severity 平铺成列**——避免运行时反序列化 JSON,监控查询直接走索引。
+- **按 task_id 查询路径**:`SELECT * FROM review_task WHERE id=?` → 关联 `sandbox_run` / `finding` / `filter_block` / `monitor_summary` / `review_report`,一次 join 取回完整审查记录。
+
+---
+
+## 6. 安全治理:Filter + 沙箱
+
+### 6.1 Filter 门禁(L3,沙箱前置)
+
+脚本清单在进入沙箱前必须经过四类检查,任一命中即按策略决策:
+
+| 检查类 | 命中条件 | 默认决策 |
+|--------|----------|----------|
+| 高风险脚本特征 | 脚本含 `rm -rf` / `sudo` / 网络下载执行 / `eval` 等危险模式 | `deny` |
+| 禁止路径 | 访问 `/etc` / `~/.ssh` / 系统目录 / 工作区外路径 | `deny` |
+| 非白名单网络 | 脚本发起非白名单域名/端口的网络请求 | `needs_human_review` |
+| 超预算执行 | 预估耗时/内存超出预算阈值 | `needs_human_review` |
+
+- `allow` → 进入沙箱。
+- `deny` / `needs_human_review` → **不进沙箱**,拦截原因写入 `filter_block` 表 + 报告。
+- 拦截记录字段:`reason` / `target` / `decision` / `detail`,可按 `task_id` 查询回放。
+
+### 6.2 沙箱 runtime(L4)
+
+| runtime | 用途 | 说明 |
+|---------|------|------|
+| Container | 生产默认 | Docker 隔离,资源限额 |
+| Cube · E2B | 生产可选 | 远程沙箱,更强隔离 |
+| 本地 fallback | 仅 dry-run / 开发 | **不能作为生产方案** |
+
+`runtime.py` 暴露统一 `SandboxRuntime.run(script, input, policy)` 接口,三种实现可切换。
+
+### 6.3 沙箱安全边界(强制五项)
+
+`policy.py` 在每次沙箱执行时强制套用,不可绕过:
+
+| 约束 | 默认值 | 失败行为 |
+|------|--------|----------|
+| 超时控制 | 30s | 中断进程,`timed_out=1`,降级空诊断 |
+| 输出大小限制 | 1MB | 截断,`status=truncated` |
+| env 白名单 | `PATH`/`HOME`/`LANG` | 非白名单变量不透传 |
+| 敏感信息脱敏 | 正则 + 熵值双检 | 输出落地前脱敏,`masked_count` 记录 |
+| 失败记录 | — | 异常写 `sandbox_run`,任务不崩 |
+
+脱敏规则覆盖:明文 API Key、token、password、私钥、连接串。脱敏检出率目标 ≥ 95%,报告和数据库中不得出现明文。
+
+---
+
+## 7. CR Skill 设计
+
+### 7.1 SKILL.md 契约
+
+```yaml
+---
+name: code-review
+description: 自动代码评审 Skill,加载 6 类规则与脚本,在沙箱中执行检查并产出结构化 findings
+version: 1.0.0
+entry: scripts/run_checks.py
+rules:
+  - rules/security.md
+  - rules/async_errors.md
+  - rules/resource_leak.md
+  - rules/missing_tests.md
+  - rules/sensitive_info.md
+  - rules/db_lifecycle.md
+sandbox:
+  default_runtime: container
+  fallback: local
+  timeout_s: 30
+  max_output_bytes: 1048576
+  env_whitelist: [PATH, HOME, LANG]
+---
+```
+
+`skill_load` 读取 frontmatter,产出 `RuleSet`(规则文档列表)+ 脚本清单,送入 Filter 门禁。
+
+### 7.2 六类规则(覆盖要求的 4 类以上)
+
+| 规则文档 | 覆盖问题 | 检测方式 | 默认 severity |
+|----------|----------|----------|---------------|
+| `security.md` | SQL 注入、命令注入、硬编码密钥、不安全反序列化 | 静态模式 + 沙箱 semgrep | critical / high |
+| `async_errors.md` | 未 await 的协程、未处理 rejection、async 资源泄漏 | AST 解析 | high / medium |
+| `resource_leak.md` | 未关闭文件/连接、try 无 finally | AST + 控制流分析 | high / medium |
+| `missing_tests.md` | 新增公开函数无对应测试 | diff 关联分析 | low |
+| `sensitive_info.md` | 明文 API key / token / password | 正则 + 熵值 | critical |
+| `db_lifecycle.md` | 连接未关闭、事务未提交/回滚、连接池泄漏 | AST | high / medium |
+
+### 7.3 脚本目录职责
+
+| 脚本 | 输入 | 输出 | 运行位置 |
+|------|------|------|----------|
+| `parse_diff.py` | diff 文本 | `ChangeSet` | 本地(L1) |
+| `run_checks.py` | `ChangeSet` + `RuleSet` | 原始诊断列表 | 沙箱(L4) |
+| `dedupe.py` | 原始诊断列表 | 分流后 findings | 本地(L5) |
+| `mask_secrets.py` | 任意文本 | 脱敏后文本 + count | 沙箱输出落地前 |
+
+---
+
+## 8. 监控审计字段
+
+每次 review 写入 `monitor_summary` 一条记录:
+
+| 字段 | 含义 | 来源层 |
+|------|------|--------|
+| `total_duration_ms` | 评审总耗时 | 全链路 |
+| `sandbox_duration_ms` | 沙箱执行总耗时(所有 run 累加) | L4 |
+| `tool_calls` | 工具/skill 调用次数 | L2 / L4 |
+| `blocks` | Filter 拦截次数 | L3 |
+| `finding_count` | finding 总数(三 bucket 合计) | L5 |
+| `sev_critical` | critical 级 finding 数 | L5 |
+| `sev_high` | high 级 finding 数 | L5 |
+| `sev_medium` | medium 级 finding 数 | L5 |
+| `sev_low` | low 级 finding 数 | L5 |
+| `exception_types` | 异常类型分布(JSON) | 全链路 |
+
+---
+
+## 9. 去重降噪策略
+
+`dedupe.py` 处理流程:
+
+1. 收集所有原始诊断(来自规则匹配 + 沙箱结果)。
+2. 按 `(file, line, category)` 三元组分组。
+3. **组内取 `confidence` 最高的一条**,其余丢弃——消除"同文件同行同类重复报"。
+4. 按置信度分流 `bucket`:
+   - `confidence < 0.6` → `needs_human_review`
+   - `0.6 ≤ confidence < 0.8` → `warnings`
+   - `confidence ≥ 0.8` → `findings`
+5. 同一行不同 `category` 的问题**保留**(不误合并不同类问题)。
+6. 低置信度问题不混入高置信 `findings`,保证误报率可控。
+
+---
+
+## 10. 方案设计说明
+
+本方案把自动代码评审拆成六层流水线:输入解析、Skill 加载、Filter 治理、沙箱执行、去重结构化、存储输出,监控审计贯穿全链路。Skill 设计上,`code-review` Skill 以 `SKILL.md` frontmatter 声明入口、六类规则清单与沙箱策略,通过 `skill_load` 产出 `RuleSet` 与脚本清单,实现规则与执行解耦。沙箱默认 Container/Cube·E2B 隔离执行,本地仅作 dry-run 与开发 fallback,绝不作为生产方案;沙箱内强制套用超时(30s)、输出限制(1MB)、env 白名单、敏感信息脱敏、失败记录五项安全边界,异常降级为空诊断而不崩任务。Filter 治理在沙箱前置,对高风险脚本、禁止路径、非白名单网络、超预算执行做 `allow`/`deny`/`needs_human_review` 决策,后两者不进沙箱,拦截原因写入报告与数据库。数据库采用七张表围绕 `review_task` 聚合的最小 schema,`task_id` 为全局外键,复合索引 `(task_id,file,line,category)` 直接服务去重查询,支持按 task_id 一次 join 取回完整审查记录;`finding.bucket` 三档从 schema 层强制低置信度不混入高置信结论。去重按 `(file,line,category)` 取最高置信,置信度低于阈值进 warnings 或 needs_human_review,保证误报率 ≤ 15%。dry-run 模式用 fake runner 跑规则脚本,无 API Key 可验证解析→沙箱→落库全链路,耗时 ≤ 2 分钟。
+
+---
+
+## 11. 验收标准对照
+
+| # | 验收标准 | 设计落点 |
+|---|----------|----------|
+| 1 | 8 条 diff 样本全部可运行并生成报告 | L1-L6 完整链路 + `tests/fixtures/` 8 个样本 |
+| 2 | 高危检出率 ≥ 80%,误报率 ≤ 15% | 6 类规则覆盖 + 置信度分流(`confidence` 阈值) |
+| 3 | DB 完整记录 task/run/finding/report,按 task_id 查询 | 七表 schema + `idx_*_task` 索引 + join 查询路径 |
+| 4 | 沙箱超时+输出限制,失败不崩任务 | `policy.py` 五项约束 + 沙箱失败降级分支 |
+| 5 | 脱敏检出率 ≥ 95%,无明文密钥 | `mask_secrets.py` 正则+熵值双检 + `masked_count` 审计 |
+| 6 | dry-run ≤ 2 分钟 | fake runner 跳过模型 API,本地跑规则脚本 |
+| 7 | 高风险先过 Filter,deny/review 不进沙箱 | `governance.py` 前置决策 + `filter_block` 落库 |
+| 8 | 报告含 findings/统计/复核/拦截/监控/沙箱/修复 | `review_report` 八段式模板(见下) |
+
+### 11.1 报告八段式模板(`review_report.json` / `.md`)
+
+```
+1. findings 摘要          — 高置信 finding 列表(9 字段)
+2. 严重级别统计           — critical/high/medium/low 计数
+3. 人工复核项             — needs_human_review 列表
+4. Filter 拦截摘要        — 拦截原因/目标/决策
+5. 监控指标               — 耗时/调用/拦截/finding 分布/异常分布
+6. 沙箱执行摘要           — runtime/状态/耗时/截断/脱敏数
+7. 可执行修复建议         — 每条 finding 附 recommendation
+8. warnings               — 低置信度问题(不混入 findings)
+```
+
+---
+
+## 12. finding 字段契约
+
+每条 finding 至少包含 9 字段:
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `severity` | string | critical / high / medium / low |
+| `category` | string | security / async / resource / tests / sensitive / db |
+| `file` | string | 文件路径 |
+| `line` | int | 行号 |
+| `title` | string | 问题标题 |
+| `evidence` | text | 代码证据(已脱敏) |
+| `recommendation` | text | 修复建议 |
+| `confidence` | float | 0.0-1.0 |
+| `source` | string | rule / sandbox / llm |
+
+---

--- a/examples/skills_code_review_agent/agent/__init__.py
+++ b/examples/skills_code_review_agent/agent/__init__.py
@@ -1,0 +1,27 @@
+"""Code Review Agent package.
+
+Thin re-export surface so callers can do::
+
+    import agent
+    await agent._async_main(ns)   # or agent.main(...)
+
+without reaching into ``agent.agent`` directly. The heavy lifting lives in
+``agent.agent`` (orchestration), with ``db/``, ``filters/``, ``llm/``,
+``sandbox/`` and ``telemetry/`` as sub-packages.
+"""
+
+from .agent import main
+from .agent import _async_main
+from .agent import skill_load
+from .agent import load_diff
+from .agent import persist_changeset
+from .agent import FIXTURES
+
+__all__ = [
+    "main",
+    "_async_main",
+    "skill_load",
+    "load_diff",
+    "persist_changeset",
+    "FIXTURES",
+]

--- a/examples/skills_code_review_agent/agent/agent.py
+++ b/examples/skills_code_review_agent/agent/agent.py
@@ -1,0 +1,876 @@
+#!/usr/bin/env python3
+# Tencent is pleased to support the open source community by making tRPC-Agent-Python available.
+#
+# Copyright (C) 2026 Tencent. All rights reserved.
+#
+# tRPC-Agent-Python is licensed under Apache-2.0.
+"""Code Review Agent — CLI entry & full orchestration (Phase 5).
+
+Phase 5 scope: a single ``agent.py`` that orchestrates the whole pipeline —
+parse a unified diff into a structured ``ChangeSet`` → load the
+``code-review`` Skill (rules + scripts + sandbox config) → run the
+``FilterGovernance`` checks (deny/review skip the sandbox) → execute the
+checks (``FakeRunner`` in dry-run, an SDK-backed sandbox otherwise —
+honoring the Skill's ``default_runtime``/``fallback`` contract, e.g. a
+``container`` backend with transparent ``local`` fallback) → dedupe &
+triage → persist to the Phase-0
+:class:`ReviewStore` → render the eight-section ``review_report.json`` /
+``.md``.
+
+Inputs supported
+----------------
+* ``--diff-file PATH``   parse a unified-diff file.
+* ``--repo-path PATH``   run ``git diff HEAD`` inside the repo (staged + unstaged).
+* ``--fixture NAME``     use a built-in sample diff (``clean`` / ``security``).
+
+The Skill is resolved relative to this file by default
+(``skills/code-review``) and can be overridden with ``--skill-dir``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# --- import wiring --------------------------------------------------------- #
+# This file lives at examples/skills_code_review_agent/agent/agent.py.
+_HERE = Path(__file__).resolve().parent  # .../agent
+_EXAMPLE_ROOT = _HERE.parent  # .../skills_code_review_agent
+# Make the `agent` package importable when run as a standalone script
+# (e.g. `python agent/agent.py`) — normally run_agent.py / tests already do this.
+if str(_EXAMPLE_ROOT) not in sys.path:
+    sys.path.insert(0, str(_EXAMPLE_ROOT))
+from agent.db import SQLiteStore  # noqa: E402
+from agent.db import ReviewStore  # noqa: E402
+
+# Make the skill scripts importable (parse_diff / run_checks / mask_secrets / dedupe).
+_SKILL_DIR_DEFAULT = _EXAMPLE_ROOT / "skills" / "code-review"
+_SCRIPTS_DIR = _SKILL_DIR_DEFAULT / "scripts"
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+from parse_diff import ChangeSet  # noqa: E402
+from parse_diff import ChangedFile  # noqa: E402
+from parse_diff import parse_diff  # noqa: E402
+
+
+# --------------------------------------------------------------------------- #
+# Built-in fixture diffs (for demo / dry-run without a real repo)
+# --------------------------------------------------------------------------- #
+FIXTURES: dict[str, str] = {
+    "clean": """\
+diff --git a/clean.py b/clean.py
+--- a/clean.py
++++ b/clean.py
+@@ -1,3 +1,5 @@
+ def add(a, b):
+-    return a + b
++    return a + b
++
++
+ def mul(a, b):
+""",
+    "security": """\
+diff --git a/app/db.py b/app/db.py
+--- a/app/db.py
++++ b/app/db.py
+@@ -20,3 +20,7 @@
+ def get_user(conn, uid):
+-    cur = conn.execute("SELECT * FROM users WHERE id=" + str(uid))
+-    return cur.fetchone()
++    # parameterized query — safe
++    cur = conn.execute("SELECT * FROM users WHERE id=?", (uid,))
++    return cur.fetchone()
+diff --git a/app/secret.py b/app/secret.py
+--- /dev/null
++++ b/app/secret.py
+@@ -0,0 +1,2 @@
++API_KEY = "sk-1234567890abcdef1234567890abcdef"
++TOKEN = "ghp_aBcDeFgHiJkLmNoPqRsTuVwXyZ1234567890"
+""",
+    "llm_probe": """\
+diff --git a/svc/client.py b/svc/client.py
+--- /dev/null
++++ b/svc/client.py
+@@ -0,0 +1,7 @@
++import requests
++
++API_KEY = "sk-abcdef1234567890abcdef1234567890ab"
++
++def call(endpoint, payload):
++    # TLS 校验关闭：有时内网有意为之，需人工确认
++    return requests.post(endpoint, json=payload, verify=False)
+""",
+}
+
+
+# --------------------------------------------------------------------------- #
+# SKILL.md frontmatter parsing
+# --------------------------------------------------------------------------- #
+def _split_frontmatter(text: str) -> tuple[dict, str]:
+    """Return (frontmatter_dict, body) from a SKILL.md text.
+
+    Frontmatter is the YAML between leading ``---`` fences. If no fences
+    are present, returns ``({}, text)``.
+    """
+    if not text.startswith("---"):
+        return {}, text
+    parts = text.split("---", 2)
+    if len(parts) < 3:
+        return {}, text
+    fm_text = parts[1].strip("\n")
+    body = parts[2].lstrip("\n")
+    return _parse_yaml(fm_text), body
+
+
+def _parse_yaml(text: str) -> dict:
+    """Minimal YAML parser for SKILL.md frontmatter.
+
+    Prefers PyYAML when available; falls back to a small indentation-aware
+    parser that handles the subset SKILL.md uses: scalars, block & flow
+    lists, nested dicts, and ``>-`` / ``>`` / ``|`` block scalars.
+    """
+    try:
+        import yaml  # type: ignore
+
+        data = yaml.safe_load(text)
+        return data if isinstance(data, dict) else {}
+    except ImportError:
+        return _parse_yaml_fallback(text)
+
+
+def _parse_yaml_fallback(text: str) -> dict:
+    """Indentation-aware YAML subset parser (no external deps)."""
+    lines = text.splitlines()
+    root: dict = {}
+    # Stack of (indent, container) where container is dict or list.
+    stack: list[tuple[int, dict | list]] = [(0, root)]
+    i = 0
+    while i < len(lines):
+        raw = lines[i]
+        stripped = raw.strip()
+        if not stripped or stripped.startswith("#"):
+            i += 1
+            continue
+        indent = len(raw) - len(raw.lstrip(" "))
+        # Pop stack to the current indent level.
+        while stack and stack[-1][0] > indent:
+            stack.pop()
+        if stack and stack[-1][0] < indent:
+            # The previous line opened a block; its container is already on
+            # top via the list/dict push below.
+            pass
+        if stripped.startswith("- "):
+            # list item
+            item_val = _coerce(stripped[2:].strip())
+            container = stack[-1][1] if stack else root
+            if isinstance(container, list):
+                container.append(item_val)
+            i += 1
+            continue
+        # key: value
+        if ":" in stripped:
+            key, _, val = stripped.partition(":")
+            key = key.strip()
+            val = val.strip()
+            container = stack[-1][1] if stack else root
+            if not isinstance(container, dict):
+                i += 1
+                continue
+            if val == "":
+                # Block follows: peek next non-empty line indent.
+                if i + 1 < len(lines):
+                    nxt = lines[i + 1]
+                    nxt_indent = len(nxt) - len(nxt.lstrip(" "))
+                    if nxt.strip().startswith("- "):
+                        new_list: list = []
+                        container[key] = new_list
+                        stack.append((nxt_indent, new_list))
+                    elif nxt_indent > indent:
+                        new_dict: dict = {}
+                        container[key] = new_dict
+                        stack.append((nxt_indent, new_dict))
+                else:
+                    container[key] = None
+            elif val in (">-", ">", "|"):
+                # Block scalar — collect deeper-indented lines.
+                collected: list[str] = []
+                j = i + 1
+                while j < len(lines):
+                    nxt = lines[j]
+                    if nxt.strip() == "":
+                        collected.append("")
+                        j += 1
+                        continue
+                    nxt_indent = len(nxt) - len(nxt.lstrip(" "))
+                    if nxt_indent <= indent:
+                        break
+                    collected.append(nxt.strip())
+                    j += 1
+                container[key] = " ".join(x for x in collected if x)
+                i = j
+                continue
+            else:
+                container[key] = _coerce(val)
+        i += 1
+    return root
+
+
+def _coerce(val: str):
+    """Coerce a YAML scalar string to int/float/bool/None/list/str."""
+    if val.startswith("[") and val.endswith("]"):
+        inner = val[1:-1].strip()
+        if not inner:
+            return []
+        return [_coerce(x.strip()) for x in inner.split(",")]
+    if val.startswith('"') and val.endswith('"'):
+        return val[1:-1]
+    if val.startswith("'") and val.endswith("'"):
+        return val[1:-1]
+    if val.lower() in ("true", "false"):
+        return val.lower() == "true"
+    if val.lower() in ("null", "~", ""):
+        return None
+    try:
+        return int(val)
+    except ValueError:
+        pass
+    try:
+        return float(val)
+    except ValueError:
+        pass
+    return val
+
+
+# --------------------------------------------------------------------------- #
+# skill_load
+# --------------------------------------------------------------------------- #
+def skill_load(skill_dir: str | Path) -> dict:
+    """Load a code-review Skill via the SDK ``FsSkillRepository``.
+
+    The SDK repository parses the SKILL.md frontmatter (name/description) and
+    loads the skill body + resources (rules/*.md). Two pieces are NOT exposed
+    by the SDK ``Skill`` object and are filled here:
+    * ``sandbox_config`` — parsed from the SKILL.md frontmatter (sandbox: block)
+    * ``scripts`` — scanned from ``scripts/*.py`` on disk
+
+    Returns::
+
+        {
+            "name": "code-review",
+            "skill_dir": "/abs/path/to/skills/code-review",
+            "rules": ["rules/security.md", ...],
+            "scripts": ["scripts/parse_diff.py", ...],
+            "sandbox_config": {default_runtime, fallback, timeout_s, ...},
+        }
+    """
+    # Lazy import: callers that don't invoke skill_load (e.g. P2 rule-engine
+    # tests importing agent for FIXTURES) aren't forced to load the SDK.
+    from trpc_agent_sdk.skills import FsSkillRepository
+
+    skill_dir = Path(skill_dir)
+    skill_md = skill_dir / "SKILL.md"
+    if not skill_md.exists():
+        raise FileNotFoundError(f"SKILL.md not found: {skill_md}")
+
+    # SDK: discover + load the skill (frontmatter name/description + body + resources).
+    repo = FsSkillRepository(str(skill_dir.parent))
+    frontmatter, _ = _split_frontmatter(skill_md.read_text(encoding="utf-8"))
+    name = frontmatter.get("name", skill_dir.name)
+    skill = repo.get(name)
+    base = Path(skill.base_dir)
+
+    # rules: prefer SDK resources (rules/*.md with content), fall back to disk scan.
+    def _res_path(r):
+        return getattr(r, "path", None) or (r.get("path") if isinstance(r, dict) else None)
+
+    rules = sorted({
+        p for r in skill.resources
+        if (p := _res_path(r)) and p.startswith("rules/")
+    }) or _rel_list(base / "rules", "*.md", base)
+
+    # scripts: scan disk (SDK resources don't include .py scripts).
+    scripts = _rel_list(base / "scripts", "*.py", base)
+
+    return {
+        "name": name,
+        "skill_dir": str(base),
+        "rules": rules,
+        "scripts": scripts,
+        "sandbox_config": frontmatter.get("sandbox", {}),
+    }
+
+
+def _rel_list(directory: Path, pattern: str, base: Path) -> list[str]:
+    """Sorted list of paths under ``directory`` matching ``pattern``, relative to ``base``."""
+    if not directory.exists():
+        return []
+    out = []
+    for p in sorted(directory.glob(pattern)):
+        rel = p.relative_to(base).as_posix()
+        out.append(rel)
+    return out
+
+
+# --------------------------------------------------------------------------- #
+# Input collection
+# --------------------------------------------------------------------------- #
+def load_diff(
+    diff_file: str | None = None,
+    repo_path: str | None = None,
+    fixture: str | None = None,
+) -> tuple[str, str, str]:
+    """Collect a diff text from one of three sources.
+
+    Returns ``(diff_text, input_type, input_ref)`` where ``input_type`` is
+    ``diff`` / ``repo`` / ``fixture`` and ``input_ref`` is a human-readable
+    reference (file path, repo path, or fixture name).
+    """
+    if diff_file:
+        path = Path(diff_file)
+        if not path.exists():
+            raise FileNotFoundError(f"diff file not found: {path}")
+        return (path.read_text(encoding="utf-8"), "diff", str(path))
+    if repo_path:
+        return (_git_diff_head(repo_path), "repo", str(repo_path))
+    if fixture:
+        if fixture not in FIXTURES:
+            raise KeyError(
+                f"unknown fixture '{fixture}', available: {list(FIXTURES)}"
+            )
+        return (FIXTURES[fixture], "fixture", fixture)
+    raise ValueError("no input source provided (use --diff-file/--repo-path/--fixture)")
+
+
+def _git_diff_head(repo_path: str) -> str:
+    """Run ``git diff HEAD`` in ``repo_path`` (staged + unstaged changes)."""
+    try:
+        proc = subprocess.run(
+            ["git", "diff", "HEAD"],
+            cwd=repo_path,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except FileNotFoundError as exc:
+        raise RuntimeError("git executable not found on PATH") from exc
+    if proc.returncode != 0 and proc.stderr:
+        # Non-fatal: empty diff on a fresh repo is fine; surface real errors.
+        if "not a git repository" in proc.stderr.lower():
+            raise RuntimeError(f"not a git repository: {repo_path}")
+    return proc.stdout
+
+
+# --------------------------------------------------------------------------- #
+# Persistence helpers
+# --------------------------------------------------------------------------- #
+def _file_sha256(file: ChangedFile, path: str) -> str:
+    """Stable SHA-256 of a changed file's diff content for dedup/identity."""
+    parts = [path]
+    for hunk in file.hunks:  # type: ignore[attr-defined]
+        for ln in hunk.lines:  # type: ignore[attr-defined]
+            parts.append(f"{ln.type}|{ln.content}")  # type: ignore[attr-defined]
+    digest = hashlib.sha256("\n".join(parts).encode("utf-8")).hexdigest()
+    return digest
+
+
+async def persist_changeset(
+    store: ReviewStore,
+    task_id: str,
+    cs: ChangeSet,
+) -> int:
+    """Write each ``ChangedFile`` as an ``input_diff`` row. Returns row count."""
+    count = 0
+    for f in cs.files:
+        summary = f"{f.hunk_count} hunks, {f.added_lines}+, {f.deleted_lines}-"
+        await store.add_input_diff(
+            task_id=task_id,
+            file_path=f.path,
+            sha256=_file_sha256(f, f.path),
+            hunk_count=f.hunk_count,
+            line_count=f.line_count,
+            summary=summary,
+        )
+        count += 1
+    return count
+
+
+# --------------------------------------------------------------------------- #
+# CLI
+# --------------------------------------------------------------------------- #
+def _build_arg_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description="Code Review Agent — parse diff, load skill, persist inputs.",
+    )
+    src = p.add_mutually_exclusive_group(required=True)
+    src.add_argument("--diff-file", help="path to a unified diff file")
+    src.add_argument("--repo-path", help="repo root to run `git diff HEAD` in")
+    src.add_argument(
+        "--fixture",
+        choices=sorted(FIXTURES.keys()),
+        help="use a built-in sample diff",
+    )
+    p.add_argument(
+        "--skill-dir",
+        default=str(_SKILL_DIR_DEFAULT),
+        help="code-review skill directory (default: skills/code-review)",
+    )
+    p.add_argument(
+        "--db-path",
+        default="cr_agent.db",
+        help="SQLite database path (default: cr_agent.db)",
+    )
+    p.add_argument(
+        "--mode",
+        choices=["dry-run", "real"],
+        default="dry-run",
+        help="review mode recorded on the task (default: dry-run)",
+    )
+    p.add_argument(
+        "--print-changeset",
+        action="store_true",
+        help="also print the parsed ChangeSet as JSON",
+    )
+    p.add_argument(
+        "--telemetry",
+        action="store_true",
+        help="enable OTel tracing (spans printed to stdout via ConsoleSpanExporter)",
+    )
+    p.add_argument(
+        "--output-dir",
+        default=".",
+        help="directory for review_report.json + review_report.md (default: .)",
+    )
+    p.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="shortcut for --mode dry-run (no model API, full pipeline)",
+    )
+    p.add_argument(
+        "--enable-llm",
+        action="store_true",
+        help="enable real-LLM second-opinion triage (also via LLM_ENABLED in .env)",
+    )
+    p.add_argument(
+        "--require-sandbox",
+        action="store_true",
+        help="production: demand the Skill's default_runtime (e.g. container) "
+             "and refuse to fall back to local — enforce an isolated sandbox",
+    )
+    p.add_argument(
+        "--llm-env",
+        default=None,
+        help="path to an explicit .env file for LLM config (default: project-root/.env)",
+    )
+    return p
+
+
+class FakeRunner:
+    """dry-run sandbox substitute: imports run_checks directly, no model API.
+
+    Used when ``mode == "dry-run"`` (or as a degradation fallback when the real
+    sandbox fails). Produces the same ``list[RawFinding]`` as the sandbox path.
+    """
+
+    async def run(self, changeset, ruleset):
+        from run_checks import run_checks as _run
+
+        return _run(changeset, ruleset)
+
+
+def _run_checks_rel(skill: dict) -> str | None:
+    """Locate the run_checks checker among the skill's declared scripts.
+
+    Returns the skill-relative path (e.g. ``scripts/run_checks.py``) or
+    ``None`` when the skill ships no checker. The Filter ``decisions`` dict is
+    keyed by these relative paths (see step 2 below), so we match on the
+    ``run_checks.py`` tail to find the decision that gates execution.
+    """
+    for s in skill.get("scripts", []):
+        if s.endswith("run_checks.py"):
+            return s
+    return None
+
+
+def _script_rel(skill: dict, name_tail: str) -> str | None:
+    """Return the skill-relative path of a declared script ending in ``name_tail``.
+
+    Used to look up a script's Filter decision by its declared relative path
+    (e.g. ``scripts/parse_diff.py``), independent of where it sits on disk.
+    """
+    for s in skill.get("scripts", []):
+        if s.endswith(name_tail):
+            return s
+    return None
+
+
+def _gate(decisions: dict, rel_path: str | None):
+    """Return the FilterDecision if it is ``deny``/``needs_human_review``, else None.
+
+    A non-allow verdict on a Skill script means that phase MUST NOT execute the
+    script. Callers should stop the phase early (emit an empty/blocked result)
+    so the denied script never enters the execution chain — this is the unified
+    gate that protects *every* declared script (parse_diff / run_checks /
+    dedupe / mask_secrets), not just run_checks.py.
+    """
+    if not rel_path:
+        return None
+    d = decisions.get(rel_path)
+    if d is not None and getattr(d, "verdict", "allow") != "allow":
+        return d
+    return None
+
+
+def build_report(
+    task_id: str,
+    dedupe_result,
+    sandbox_runs: list[dict],
+    filter_blocks: list[dict],
+    monitor: dict,
+    output_dir: str,
+) -> tuple[str, str]:
+    """Render the eight-section ``review_report.json`` + ``review_report.md``.
+
+    Returns ``(json_path, md_path)``. Both files share the same data source.
+    """
+    out = Path(output_dir)
+    out.mkdir(parents=True, exist_ok=True)
+    report = {
+        "task_id": task_id,
+        "1_findings": [f.__dict__ for f in dedupe_result.findings],
+        "2_severity_stats": dedupe_result.severity_counts(),
+        "3_needs_human_review": [f.__dict__ for f in dedupe_result.needs_human_review],
+        "4_filter_blocks": filter_blocks,
+        "5_monitor": monitor,
+        "6_sandbox_runs": sandbox_runs,
+        "7_recommendations": [
+            {"file": f.file, "line": f.line, "recommendation": f.recommendation}
+            for f in dedupe_result.findings
+        ],
+        "8_warnings": [f.__dict__ for f in dedupe_result.warnings],
+    }
+    json_path = out / "review_report.json"
+    json_path.write_text(json.dumps(report, ensure_ascii=False, indent=2), encoding="utf-8")
+    md_path = out / "review_report.md"
+    md_path.write_text(_render_report_md(report), encoding="utf-8")
+    return str(json_path), str(md_path)
+
+
+def _render_report_md(report: dict) -> str:
+    """Eight-section Markdown — human-readable, same data as the JSON."""
+    L: list[str] = [f"# Code Review Report — {report['task_id']}", ""]
+    L.append(f"## 1. Findings 摘要（{len(report['1_findings'])} 条）")
+    for f in report["1_findings"]:
+        L.append(f"- [{f['severity']}] {f['file']}:{f['line']} {f['title']} (conf={f['confidence']})")
+    L += ["", "## 2. 严重级别统计"]
+    ss = report["2_severity_stats"]
+    for sev in ("critical", "high", "medium", "low"):
+        L.append(f"- {sev}: {ss.get(sev, 0)}")
+    L.append(f"\n## 3. 人工复核项（{len(report['3_needs_human_review'])} 条）")
+    for f in report["3_needs_human_review"]:
+        L.append(f"- {f['file']}:{f['line']} {f['title']} (conf={f['confidence']})")
+    L.append(f"\n## 4. Filter 拦截摘要（{len(report['4_filter_blocks'])} 条）")
+    for b in report["4_filter_blocks"]:
+        L.append(f"- [{b['verdict']}] {b['reason']}: {b['target']} — {b['detail']}")
+    m = report["5_monitor"]
+    L += ["", "## 5. 监控指标"]
+    for k in ("total_duration_ms", "sandbox_duration_ms", "tool_calls", "blocks",
+              "finding_count", "exception_types"):
+        L.append(f"- {k}: {m.get(k)}")
+    L.append(f"\n## 6. 沙箱执行摘要（{len(report['6_sandbox_runs'])} 次）")
+    for s in report["6_sandbox_runs"]:
+        L.append(f"- {s.get('runtime','?')}: status={s.get('status','?')} "
+                 f"dur={s.get('duration_ms',0)}ms timed_out={s.get('timed_out',0)} "
+                 f"masked={s.get('masked_count',0)}")
+    L += ["", "## 7. 可执行修复建议"]
+    for r in report["7_recommendations"]:
+        L.append(f"- {r['file']}:{r['line']}: {r['recommendation']}")
+    L.append(f"\n## 8. Warnings（{len(report['8_warnings'])} 条，低置信度，不混入 findings）")
+    for f in report["8_warnings"]:
+        L.append(f"- [{f['severity']}] {f['file']}:{f['line']} {f['title']} (conf={f['confidence']})")
+    return "\n".join(L) + "\n"
+
+
+async def _async_main(args) -> int:
+    """Full pipeline: parse → skill → filter → sandbox → dedupe → persist → report.
+
+    Returns the process exit code: ``0`` on success, ``1`` when the pipeline
+    fails (so CI / acceptance harnesses can detect failure instead of a silent
+    success). Any failure is logged with ``[agent] ERROR`` and the partial
+    task is marked ``failed`` when possible.
+    """
+    from agent.telemetry import TelemetryRecorder, init_telemetry, trace_stage
+    init_telemetry(enabled=args.telemetry)
+    recorder = TelemetryRecorder()
+    task_id: str | None = None
+    exit_code = 0
+    if getattr(args, "dry_run", False):
+        args.mode = "dry-run"  # --dry-run shortcut → --mode dry-run
+
+    # 1. Load the skill (rules + scripts + sandbox config) via SDK FsSkillRepository.
+    async with trace_stage("l2_skill_load", recorder):
+        skill = skill_load(args.skill_dir)
+    print(f"[agent] skill     : {skill['name']} ({len(skill['rules'])} rules, {len(skill['scripts'])} scripts)")
+
+    # 2. Compute Filter decisions for EVERY declared Skill script (L3) BEFORE
+    #    any script executes. The gate is authoritative: a non-allow verdict on
+    #    ANY skill script must stop its phase *before* that script runs. This
+    #    now covers parse_diff (L1), run_checks (L4), dedupe (L5) and the
+    #    mask_secrets helper that dedupe / LLM triage invoke internally.
+    #    (Previously only run_checks.py was gated, so parse_diff / dedupe /
+    #    mask_secrets could still execute after a deny / needs_human_review.)
+    from agent.filters import FilterGovernance
+
+    gov = FilterGovernance()
+    decisions: dict[str, object] = {}
+    filter_blocks_meta: list[dict] = []
+    for script in skill["scripts"]:
+        sp = Path(skill["skill_dir"]) / script
+        content = sp.read_text(encoding="utf-8") if sp.exists() else ""
+        decision = gov.decide(str(sp), content, {})
+        decisions[script] = decision
+        if decision.verdict != "allow":
+            filter_blocks_meta.append(
+                {"verdict": decision.verdict, "reason": decision.reason,
+                 "target": script, "detail": decision.detail})
+
+    # 3. Collect + parse the diff (L1) — gated on parse_diff's verdict.
+    async with trace_stage("l1_parse", recorder):
+        diff_text, input_type, input_ref = load_diff(
+            diff_file=args.diff_file, repo_path=args.repo_path, fixture=args.fixture)
+        parse_rel = _script_rel(skill, "parse_diff.py")
+        parse_block = _gate(decisions, parse_rel)
+        if parse_block is not None:
+            # parse_diff is denied/reviewed → we cannot build a ChangeSet, so
+            # the entire review chain stops here. The filter_block above is the
+            # signal; nothing downstream (sandbox/dedupe) may run.
+            print(f"[agent] filter BLOCKED parse stage: {parse_block.verdict} ({parse_rel})")
+            cs = None
+        else:
+            cs = parse_diff(diff_text)
+    print(f"[agent] input     : {input_type} = {input_ref}"
+          + (f" | {cs.file_count} file(s)" if cs is not None else " | (parse blocked)"))
+    if args.print_changeset and cs is not None:
+        print(cs.to_json())
+
+    store = None
+    sandbox_runs_meta: list[dict] = []
+    raw_findings = []
+    try:
+        # 4. create_task + persist input_diff + flush recorded filter blocks.
+        store = SQLiteStore(args.db_path)
+        async with trace_stage("l6_persist", recorder):
+            task_id = await store.create_task(input_type, input_ref, args.mode)
+            await store.update_task_status(task_id, "running")
+            if cs is not None:
+                await persist_changeset(store, task_id, cs)
+            for b in filter_blocks_meta:
+                await store.add_filter_block(
+                    task_id, b["reason"], b["target"], b["verdict"], b["detail"])
+        print(f"[agent] filter    : {len(filter_blocks_meta)} block(s)")
+
+        # 5–6.5: only when we actually have a ChangeSet (parse_diff was allowed).
+        # If parse_diff was filtered, the whole sandbox/dedupe/triage chain is
+        # skipped and an empty review is emitted — no Skill script executes.
+        if cs is None:
+            from cr_models import DedupeResult
+            raw_findings = []
+            dedupe_result = DedupeResult()
+        else:
+            from agent.sandbox import (
+                SandboxPolicy,
+                build_runtime_with_fallback,
+                select_runtime,
+            )
+            policy = SandboxPolicy.from_config(skill["sandbox_config"])
+
+            # 5. Run checks (L4 sandbox).
+            # SECURITY GATE — the Filter decision on the checker is authoritative:
+            # if it is ``deny``/``needs_human_review``, the script MUST NOT be
+            # executed at all. Not in the sandbox, and NOT via the in-process
+            # FakeRunner fallback either — running a denied script "locally"
+            # outside the sandbox would silently defeat the gate. We emit no raw
+            # findings, keep the recorded filter_block as the signal, and mark
+            # the (non-) execution as ``blocked`` in the report/DB.
+            rc_rel = _run_checks_rel(skill)
+            rc_path = str(Path(skill["skill_dir"]) / rc_rel) if rc_rel else ""
+            rc_decision = decisions.get(rc_rel) if rc_rel else None
+            async with trace_stage("l4_sandbox", recorder):
+                try:
+                    if rc_decision is not None and rc_decision.verdict != "allow":
+                        # Filter blocked the checker → skip execution entirely.
+                        # CRITICAL: we do NOT import run_checks here at all, so
+                        # neither its module top-level nor load_rules() ever run
+                        # for a denied/needs_human_review script.
+                        raw_findings = []
+                        verdict = rc_decision.verdict  # "deny" | "needs_human_review"
+                        sandbox_runs_meta.append(
+                            {"runtime": "blocked", "status": verdict, "duration_ms": 0,
+                             "exit_code": 0, "output_bytes": 0, "timed_out": 0, "masked_count": 0})
+                        # P1-1: the DB must fully record every sandbox-execution
+                        # decision, including a blocked one — otherwise the chain
+                        # is not testable.
+                        await store.add_sandbox_run(
+                            task_id, "blocked", rc_rel or "run_checks.py", verdict,
+                            0, 0, 0, 0, 0)
+                    else:
+                        # Allowed → only NOW import the checker module (its
+                        # top-level + load_rules run exclusively on the allow
+                        # path; a denied checker never reaches this branch).
+                        from run_checks import load_rules
+                        rules_by_cat = load_rules(skill["skill_dir"], skill["rules"])
+                        if args.mode == "dry-run":
+                            raw_findings = await FakeRunner().run(cs, {"_rules": rules_by_cat})
+                            sandbox_runs_meta.append(
+                                {"runtime": "fake", "status": "ok", "duration_ms": 0,
+                                 "exit_code": 0, "output_bytes": 0, "timed_out": 0, "masked_count": 0})
+                            # P1-1: the DB must fully record every sandbox execution,
+                            # including dry-run — otherwise the chain is not testable.
+                            await store.add_sandbox_run(
+                                task_id, "fake", rc_rel or "run_checks.py", "ok", 0, 0, 0, 0, 0)
+                        else:
+                            # Real mode: honor the skill's declared sandbox contract.
+                            # G1 fix — previously hardcoded to LocalRuntime, ignoring
+                            # `default_runtime`/`fallback` from sandbox_config. Now we
+                            # try default_runtime (container) and transparently fall
+                            # back to `fallback` (local) when it can't be provisioned.
+                            sb_cfg = skill["sandbox_config"]
+                            default_kind = sb_cfg.get("default_runtime", "local")
+                            fallback_kind = sb_cfg.get("fallback", "local")
+                            if getattr(args, "require_sandbox", False):
+                                # Production: the Skill's declared default_runtime is
+                                # the isolated sandbox contract (e.g. container). Do
+                                # NOT silently fall back to local — if it can't be
+                                # provisioned, fail loudly so the violation is visible.
+                                runtime = select_runtime(default_kind, policy)
+                                runtime.ensure_available()
+                                actual_kind = default_kind
+                            else:
+                                runtime, actual_kind = build_runtime_with_fallback(
+                                    default_kind, fallback_kind, policy)
+                            rr = await runtime.run(
+                                rc_path, {"changeset": cs.to_dict(), "rules": rules_by_cat}, policy)
+                            await store.add_sandbox_run(
+                                task_id, actual_kind, rc_rel or "run_checks.py", rr.status, rr.duration_ms,
+                                rr.exit_code, rr.output_bytes, int(rr.timed_out), rr.masked_count)
+                            sandbox_runs_meta.append(
+                                {"runtime": actual_kind, "status": rr.status, "duration_ms": rr.duration_ms,
+                                 "exit_code": rr.exit_code, "output_bytes": rr.output_bytes,
+                                 "timed_out": int(rr.timed_out), "masked_count": rr.masked_count})
+                            if rr.status == "ok" and rr.stdout:
+                                from run_checks import RawFinding
+                                raw_findings = [RawFinding(**d) for d in json.loads(rr.stdout)]
+                            else:
+                                raw_findings = await FakeRunner().run(cs, {"_rules": rules_by_cat})
+                except Exception as exc:
+                    # Sandbox failure degrades to FakeRunner — pipeline never
+                    # crashes. (Only reachable when the checker was *allowed*; a
+                    # denied checker never reaches this point, so it stays
+                    # unexecuted.)
+                    recorder.record_exception(type(exc).__name__)
+                    raw_findings = await FakeRunner().run(cs, {"_rules": rules_by_cat})
+                    sandbox_runs_meta.append(
+                        {"runtime": "degraded", "status": "failed", "duration_ms": 0,
+                         "exit_code": -1, "output_bytes": 0, "timed_out": 0, "masked_count": 0})
+                    await store.add_sandbox_run(
+                        task_id, "degraded", rc_rel or "run_checks.py", "failed", 0, -1, 0, 0, 0)
+            print(f"[agent] sandbox   : {len(raw_findings)} raw findings")
+
+            # 6. Dedupe (L5) — gated on dedupe AND mask_secrets verdicts.
+            # Running dedupe executes mask_secrets on every finding's evidence;
+            # if either script is deny/needs_human_review we must NOT run it, so
+            # we emit an empty DedupeResult instead (no findings leaked through).
+            # Compute the gate FIRST, then import the script module only on allow
+            # — otherwise importing ``dedupe`` (a filtered script) would execute
+            # its top-level even when the gate is denying it.
+            dedupe_block = _gate(decisions, _script_rel(skill, "dedupe.py")) \
+                or _gate(decisions, _script_rel(skill, "mask_secrets.py"))
+            if dedupe_block is not None:
+                from cr_models import DedupeResult
+                print(f"[agent] filter BLOCKED dedupe stage: {dedupe_block.verdict} "
+                      f"({dedupe_block.target})")
+                dedupe_result = DedupeResult()
+            else:
+                from cr_models import DedupeResult
+                from dedupe import dedupe
+                dedupe_result = dedupe(raw_findings)
+            print(f"[agent] dedupe    : {len(dedupe_result.findings)} findings | "
+                  f"{len(dedupe_result.warnings)} warnings | "
+                  f"{len(dedupe_result.needs_human_review)} review")
+
+            # 6.5 LLM second-opinion triage (optional, Phase 7).
+            # Gated on mask_secrets: the diff is masked before leaving the
+            # process, so if mask_secrets is deny/needs_human_review we MUST NOT
+            # send the unmasked diff to the model — skip triage entirely.
+            async with trace_stage("l5b_llm_triage", recorder):
+                from agent.llm import LlmTriage, get_llm_client
+                llm_client = get_llm_client(
+                    enable=getattr(args, "enable_llm", False),
+                    env_path=getattr(args, "llm_env", None))
+                ms_block = _gate(decisions, _script_rel(skill, "mask_secrets.py"))
+                if llm_client.is_enabled and ms_block is None:
+                    dedupe_result = await LlmTriage(llm_client).run(
+                        dedupe_result, diff_text)
+                    print(f"[agent] llm triage: {llm_client.kind} enabled | "
+                          f"{len(dedupe_result.needs_human_review)} still need review")
+                elif ms_block is not None:
+                    print(f"[agent] llm triage: SKIPPED — mask_secrets blocked "
+                          f"({ms_block.verdict})")
+                else:
+                    print("[agent] llm triage: disabled (LLM_ENABLED=false or no API key)")
+
+        # 7. Persist findings + monitor + report (L6).
+        async with trace_stage("l6_persist2", recorder):
+            for finding, bucket in dedupe_result.all_with_bucket():
+                await store.add_finding(
+                    task_id, finding.severity, finding.category, finding.file,
+                    finding.line, finding.title, finding.evidence,
+                    finding.recommendation, finding.confidence, finding.source, bucket)
+            monitor = recorder.to_monitor_summary(
+                finding_count=dedupe_result.total,
+                sev_counts=dedupe_result.severity_counts(),
+                blocks=len(filter_blocks_meta))
+            await store.set_monitor_summary(task_id, monitor)
+            json_path, md_path = build_report(
+                task_id, dedupe_result, sandbox_runs_meta, filter_blocks_meta,
+                monitor, args.output_dir)
+            summary = (f"{len(dedupe_result.findings)} findings, "
+                       f"{len(dedupe_result.warnings)} warnings, "
+                       f"{len(dedupe_result.needs_human_review)} review")
+            await store.set_report(task_id, json_path, md_path, summary)
+            await store.update_task_status(task_id, "done", total_duration_ms=monitor["total_duration_ms"])
+
+        print(f"[agent] task      : {task_id} (done)")
+        print(f"[agent] report    : {json_path}")
+        print(f"[agent] telemetry : total={monitor['total_duration_ms']}ms exceptions={monitor['exception_types']}")
+    except Exception as exc:
+        # Top-level fail-safe: record exception, mark task failed, still emit a report.
+        # P2-1: signal failure to the caller via a non-zero exit code.
+        exit_code = 1
+        recorder.record_exception(type(exc).__name__)
+        if task_id:
+            try:
+                await store.update_task_status(task_id, "failed")
+                await store.set_monitor_summary(task_id, recorder.to_monitor_summary())
+            except Exception:
+                pass
+        print(f"[agent] ERROR     : {type(exc).__name__}: {exc}")
+    finally:
+        if store is not None:
+            await store.close()
+    return exit_code
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_arg_parser().parse_args(argv)
+    return asyncio.run(_async_main(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/skills_code_review_agent/agent/db/__init__.py
+++ b/examples/skills_code_review_agent/agent/db/__init__.py
@@ -1,0 +1,17 @@
+# Tencent is pleased to support the open source community by making tRPC-Agent-Python available.
+#
+# Copyright (C) 2026 Tencent. All rights reserved.
+#
+# tRPC-Agent-Python is licensed under Apache-2.0.
+"""Code Review Agent — persistence foundation (Phase 0).
+
+Exposes the :class:`ReviewStore` protocol and the default
+:class:`SQLiteStore` implementation. Downstream phases (P1–P6) interact
+with persisted review data exclusively through this package so that the
+storage backend can be swapped without touching the orchestration layer.
+"""
+
+from .storage import ReviewStore
+from .storage import SQLiteStore
+
+__all__ = ["ReviewStore", "SQLiteStore"]

--- a/examples/skills_code_review_agent/agent/db/init_db.py
+++ b/examples/skills_code_review_agent/agent/db/init_db.py
@@ -1,0 +1,108 @@
+# Tencent is pleased to support the open source community by making tRPC-Agent-Python available.
+#
+# Copyright (C) 2026 Tencent. All rights reserved.
+#
+# tRPC-Agent-Python is licensed under Apache-2.0.
+"""Initialize the Code Review Agent database (SDK-backed, async).
+
+Table creation is driven by the ORM metadata in :mod:`db.models` via the
+SDK's :class:`SqlStorage` (``metadata.create_all``). Idempotent — safe to
+run repeatedly. SQLite ``PRAGMA foreign_keys=ON`` is applied automatically
+by the SDK storage layer.
+
+Usage
+-----
+    python agent/db/init_db.py                  # default ./cr_agent.db
+    python agent/db/init_db.py --db-path /tmp/cr.db
+    python -m examples.skills_code_review_agent.agent.db.init_db --db-path cr.db
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+from pathlib import Path
+
+# Allow running as a script (no package context).
+_HERE = Path(__file__).resolve().parent  # .../agent/db
+if str(_HERE.parent.parent) not in sys.path:
+    sys.path.insert(0, str(_HERE.parent.parent))  # project root
+
+from agent.db import SQLiteStore  # noqa: E402
+from agent.db.models import CRBase  # noqa: E402
+
+_EXPECTED_TABLES = (
+    "review_task",
+    "input_diff",
+    "sandbox_run",
+    "finding",
+    "filter_block",
+    "monitor_summary",
+    "review_report",
+)
+
+
+async def init_db(db_path: str | Path = "cr_agent.db", *, verbose: bool = True) -> None:
+    """Create/upgrade the CR Agent database at ``db_path``.
+
+    Safe to call repeatedly — ``metadata.create_all`` only adds missing
+    tables, and the SDK applies forward-only column migrations.
+    """
+    store = SQLiteStore(db_path)
+    try:
+        # create_sql_engine() runs metadata.create_all + sqlite pragmas.
+        await store._ensure_engine()
+
+        if verbose:
+            await _report(store, db_path)
+    finally:
+        await store.close()
+
+
+async def _report(store: "SQLiteStore", db_path: str | Path) -> None:
+    """Print a concise summary of tables now present."""
+    from sqlalchemy import inspect as sa_inspect
+
+    await store._ensure_engine()
+    engine = store.storage._db_engine  # underlying async engine
+    # Run sync inspect via the async engine.
+    def _sync_inspect(conn):
+        return sa_inspect(conn).get_table_names()
+
+    async with engine.connect() as conn:
+        tables = await conn.run_sync(_sync_inspect)
+    table_set = {t for t in tables if not t.startswith("sqlite_")}
+    missing = [t for t in _EXPECTED_TABLES if t not in table_set]
+
+    print(f"[init_db] database : {db_path}")
+    print(f"[init_db] tables   : {len(table_set)} ({', '.join(sorted(table_set))})")
+    if missing:
+        print(f"[init_db] WARNING missing tables: {missing}", file=sys.stderr)
+    else:
+        print(f"[init_db] all {len(_EXPECTED_TABLES)} expected tables present")
+    print("[init_db] foreign_keys = ON (set by SDK SqlStorage)")
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Initialize the Code Review Agent SQLite database (SDK-backed).",
+    )
+    parser.add_argument(
+        "--db-path", default="cr_agent.db",
+        help="Path to the SQLite database file (default: cr_agent.db).",
+    )
+    parser.add_argument(
+        "--quiet", action="store_true", help="Suppress the summary report.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_arg_parser().parse_args(argv)
+    asyncio.run(init_db(args.db_path, verbose=not args.quiet))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/skills_code_review_agent/agent/db/models.py
+++ b/examples/skills_code_review_agent/agent/db/models.py
@@ -1,0 +1,170 @@
+# Tencent is pleased to support the open source community by making tRPC-Agent-Python available.
+#
+# Copyright (C) 2026 Tencent. All rights reserved.
+#
+# tRPC-Agent-Python is licensed under Apache-2.0.
+"""SQLAlchemy ORM models for the Code Review Agent (Phase 0, SDK-backed).
+
+The seven business tables are declared as a custom ``CRBase(DeclarativeBase)``
+metadata and persisted through the SDK's generic :class:`SqlStorage` layer
+(``SqlStorage(metadata=CRBase.metadata)``). This replaces the original
+hand-rolled ``sqlite3`` implementation while keeping the same schema and
+the same :class:`ReviewStore` protocol surface.
+
+Table layout mirrors ``db/schema.sql`` (ARCHITECTURE.md §5.2): seven tables
+aggregated around ``review_task`` with ``task_id`` as the global FK. The
+composite index ``idx_finding_dedup (task_id, file, line, category)`` is
+declared on :class:`Finding` to serve the Phase-4 dedupe lookup.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import ForeignKey
+from sqlalchemy import Float
+from sqlalchemy import Index
+from sqlalchemy import Integer
+from sqlalchemy import String
+from sqlalchemy import Text
+from sqlalchemy.orm import DeclarativeBase
+from sqlalchemy.orm import Mapped
+from sqlalchemy.orm import mapped_column
+
+
+class CRBase(DeclarativeBase):
+    """Declarative base for all CR Agent business tables.
+
+    Passed to ``SqlStorage(metadata=CRBase.metadata)`` so the SDK storage
+    layer creates/manages exactly these tables (independent of the SDK's own
+    session/memory tables).
+    """
+
+
+class ReviewTask(CRBase):
+    """L6 master table — one row per review run."""
+
+    __tablename__ = "review_task"
+
+    id: Mapped[str] = mapped_column(String, primary_key=True)
+    created_at: Mapped[str] = mapped_column(String, nullable=False)
+    status: Mapped[str] = mapped_column(String, nullable=False)  # pending|running|done|failed
+    input_type: Mapped[str] = mapped_column(String, nullable=False)  # diff|repo|fixture
+    input_ref: Mapped[str | None] = mapped_column(String, nullable=True)
+    mode: Mapped[str] = mapped_column(String, nullable=False)  # dry-run|real
+    total_duration_ms: Mapped[int | None] = mapped_column(Integer, nullable=True)
+
+
+class InputDiff(CRBase):
+    """L1 parsed diff per changed file (summary only, never the full blob)."""
+
+    __tablename__ = "input_diff"
+    __table_args__ = (Index("idx_input_diff_task", "task_id"),)
+
+    id: Mapped[str] = mapped_column(String, primary_key=True)
+    task_id: Mapped[str] = mapped_column(String, ForeignKey("review_task.id"), nullable=False)
+    file_path: Mapped[str | None] = mapped_column(String, nullable=True)
+    sha256: Mapped[str | None] = mapped_column(String, nullable=True)
+    hunk_count: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    line_count: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    summary: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+
+class SandboxRun(CRBase):
+    """L4 sandbox execution evidence (replayable / auditable)."""
+
+    __tablename__ = "sandbox_run"
+    __table_args__ = (Index("idx_sandbox_run_task", "task_id"),)
+
+    id: Mapped[str] = mapped_column(String, primary_key=True)
+    task_id: Mapped[str] = mapped_column(String, ForeignKey("review_task.id"), nullable=False)
+    runtime: Mapped[str | None] = mapped_column(String, nullable=True)  # local|container|cube
+    script: Mapped[str | None] = mapped_column(String, nullable=True)
+    status: Mapped[str | None] = mapped_column(String, nullable=True)  # ok|timeout|failed|truncated
+    duration_ms: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    exit_code: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    output_bytes: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    timed_out: Mapped[int | None] = mapped_column(Integer, nullable=True)  # 0|1 (no native bool)
+    masked_count: Mapped[int | None] = mapped_column(Integer, nullable=True)
+
+
+class Finding(CRBase):
+    """L5 structured findings (bucket enforces confidence tiering)."""
+
+    __tablename__ = "finding"
+    # Composite index directly serves L5 dedupe: O(1) "same file/line/category".
+    __table_args__ = (
+        Index("idx_finding_dedup", "task_id", "file", "line", "category"),
+        Index("idx_finding_task", "task_id"),
+    )
+
+    id: Mapped[str] = mapped_column(String, primary_key=True)
+    task_id: Mapped[str] = mapped_column(String, ForeignKey("review_task.id"), nullable=False)
+    severity: Mapped[str | None] = mapped_column(String, nullable=True)  # critical|high|medium|low
+    category: Mapped[str | None] = mapped_column(String, nullable=True)
+    file: Mapped[str | None] = mapped_column(String, nullable=True)
+    line: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    title: Mapped[str | None] = mapped_column(String, nullable=True)
+    evidence: Mapped[str | None] = mapped_column(Text, nullable=True)
+    recommendation: Mapped[str | None] = mapped_column(Text, nullable=True)
+    confidence: Mapped[float | None] = mapped_column(Float, nullable=True)  # 0.0-1.0
+    source: Mapped[str | None] = mapped_column(String, nullable=True)  # rule|sandbox|llm
+    bucket: Mapped[str | None] = mapped_column(String, nullable=True)  # findings|warnings|needs_human_review
+
+
+class FilterBlock(CRBase):
+    """L3 filter governance blocks (deny / needs_human_review skip sandbox)."""
+
+    __tablename__ = "filter_block"
+    __table_args__ = (Index("idx_filter_block_task", "task_id"),)
+
+    id: Mapped[str] = mapped_column(String, primary_key=True)
+    task_id: Mapped[str] = mapped_column(String, ForeignKey("review_task.id"), nullable=False)
+    reason: Mapped[str | None] = mapped_column(String, nullable=True)  # high-risk|forbidden-path|network|budget
+    target: Mapped[str | None] = mapped_column(String, nullable=True)
+    decision: Mapped[str | None] = mapped_column(String, nullable=True)  # deny|needs_human_review
+    detail: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+
+class MonitorSummary(CRBase):
+    """Per-task telemetry rollup (severity flattened to columns for indexed reads)."""
+
+    __tablename__ = "monitor_summary"
+    __table_args__ = (Index("idx_monitor_summary_task", "task_id"),)
+
+    id: Mapped[str] = mapped_column(String, primary_key=True)
+    task_id: Mapped[str] = mapped_column(String, ForeignKey("review_task.id"), nullable=False)
+    total_duration_ms: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    sandbox_duration_ms: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    tool_calls: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    blocks: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    finding_count: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    sev_critical: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    sev_high: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    sev_medium: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    sev_low: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    exception_types: Mapped[str | None] = mapped_column(Text, nullable=True)  # JSON string
+
+
+class ReviewReport(CRBase):
+    """Final report artefact paths + human-readable summary."""
+
+    __tablename__ = "review_report"
+    __table_args__ = (Index("idx_review_report_task", "task_id"),)
+
+    id: Mapped[str] = mapped_column(String, primary_key=True)
+    task_id: Mapped[str] = mapped_column(String, ForeignKey("review_task.id"), nullable=False)
+    report_json_path: Mapped[str | None] = mapped_column(String, nullable=True)
+    report_md_path: Mapped[str | None] = mapped_column(String, nullable=True)
+    summary: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[str | None] = mapped_column(String, nullable=True)
+
+
+__all__ = [
+    "CRBase",
+    "ReviewTask",
+    "InputDiff",
+    "SandboxRun",
+    "Finding",
+    "FilterBlock",
+    "MonitorSummary",
+    "ReviewReport",
+]

--- a/examples/skills_code_review_agent/agent/db/schema.sql
+++ b/examples/skills_code_review_agent/agent/db/schema.sql
@@ -1,0 +1,100 @@
+-- Code Review Agent — schema (Phase 0)
+-- Seven tables aggregated around `review_task`; `task_id` is the global FK.
+-- All statements use `IF NOT EXISTS` so the script is idempotent.
+-- See ../docs/skills_code_review_agent/ARCHITECTURE.md §5.2 for the contract.
+
+-- L6 master table: one row per review run.
+CREATE TABLE IF NOT EXISTS review_task (
+  id TEXT PRIMARY KEY,
+  created_at TEXT NOT NULL,
+  status TEXT NOT NULL,           -- pending|running|done|failed
+  input_type TEXT NOT NULL,       -- diff|repo|fixture
+  input_ref TEXT,
+  mode TEXT NOT NULL,             -- dry-run|real
+  total_duration_ms INTEGER
+);
+
+-- L1 parsed diff per changed file (summary only, never the full diff blob).
+CREATE TABLE IF NOT EXISTS input_diff (
+  id TEXT PRIMARY KEY,
+  task_id TEXT NOT NULL REFERENCES review_task(id),
+  file_path TEXT,
+  sha256 TEXT,
+  hunk_count INTEGER,
+  line_count INTEGER,
+  summary TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_input_diff_task ON input_diff(task_id);
+
+-- L4 sandbox execution evidence (replayable / auditable).
+CREATE TABLE IF NOT EXISTS sandbox_run (
+  id TEXT PRIMARY KEY,
+  task_id TEXT NOT NULL REFERENCES review_task(id),
+  runtime TEXT,                   -- local|container|cube
+  script TEXT,
+  status TEXT,                    -- ok|timeout|failed|truncated
+  duration_ms INTEGER,
+  exit_code INTEGER,
+  output_bytes INTEGER,
+  timed_out INTEGER,              -- 0|1 (SQLite has no native bool)
+  masked_count INTEGER
+);
+CREATE INDEX IF NOT EXISTS idx_sandbox_run_task ON sandbox_run(task_id);
+
+-- L5 structured findings (bucket enforces confidence tiering at schema level).
+CREATE TABLE IF NOT EXISTS finding (
+  id TEXT PRIMARY KEY,
+  task_id TEXT NOT NULL REFERENCES review_task(id),
+  severity TEXT,                  -- critical|high|medium|low
+  category TEXT,                  -- security|async|resource|tests|sensitive|db
+  file TEXT,
+  line INTEGER,
+  title TEXT,
+  evidence TEXT,
+  recommendation TEXT,
+  confidence REAL,                -- 0.0-1.0
+  source TEXT,                    -- rule|sandbox|llm
+  bucket TEXT                     -- findings|warnings|needs_human_review
+);
+-- Composite index directly serves L5 dedupe lookup: O(1) "same file/line/category".
+CREATE INDEX IF NOT EXISTS idx_finding_dedup ON finding(task_id, file, line, category);
+CREATE INDEX IF NOT EXISTS idx_finding_task ON finding(task_id);
+
+-- L3 filter governance blocks (deny / needs_human_review do not enter sandbox).
+CREATE TABLE IF NOT EXISTS filter_block (
+  id TEXT PRIMARY KEY,
+  task_id TEXT NOT NULL REFERENCES review_task(id),
+  reason TEXT,                    -- high-risk|forbidden-path|network|budget
+  target TEXT,
+  decision TEXT,                  -- deny|needs_human_review
+  detail TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_filter_block_task ON filter_block(task_id);
+
+-- Per-task telemetry rollup (severity flattened to columns for indexed reads).
+CREATE TABLE IF NOT EXISTS monitor_summary (
+  id TEXT PRIMARY KEY,
+  task_id TEXT NOT NULL REFERENCES review_task(id),
+  total_duration_ms INTEGER,
+  sandbox_duration_ms INTEGER,
+  tool_calls INTEGER,
+  blocks INTEGER,
+  finding_count INTEGER,
+  sev_critical INTEGER,
+  sev_high INTEGER,
+  sev_medium INTEGER,
+  sev_low INTEGER,
+  exception_types TEXT            -- JSON, e.g. {"timeout":2,"oom":1}
+);
+CREATE INDEX IF NOT EXISTS idx_monitor_summary_task ON monitor_summary(task_id);
+
+-- Final report artefact paths + human-readable summary.
+CREATE TABLE IF NOT EXISTS review_report (
+  id TEXT PRIMARY KEY,
+  task_id TEXT NOT NULL REFERENCES review_task(id),
+  report_json_path TEXT,
+  report_md_path TEXT,
+  summary TEXT,
+  created_at TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_review_report_task ON review_report(task_id);

--- a/examples/skills_code_review_agent/agent/db/storage.py
+++ b/examples/skills_code_review_agent/agent/db/storage.py
@@ -1,0 +1,419 @@
+# Tencent is pleased to support the open source community by making tRPC-Agent-Python available.
+#
+# Copyright (C) 2026 Tencent. All rights reserved.
+#
+# tRPC-Agent-Python is licensed under Apache-2.0.
+"""Storage abstraction for the Code Review Agent (Phase 0, SDK-backed).
+
+Defines the :class:`ReviewStore` protocol — the single persistence surface
+every downstream phase (P1–P6) talks to — plus the default
+:class:`SQLiteStore` implementation backed by the SDK's generic
+:class:`trpc_agent_sdk.storage.SqlStorage` layer.
+
+Design notes
+------------
+* The seven business tables are declared in :mod:`db.models` as a custom
+  ``CRBase(DeclarativeBase)`` metadata and handed to
+  ``SqlStorage(metadata=CRBase.metadata)``. The SDK storage layer manages
+  table creation (``metadata.create_all``) and SQLite pragmas
+  (``PRAGMA foreign_keys=ON``) automatically.
+* All methods are ``async`` — the SDK storage is async-first. Downstream
+  orchestration (``agent.py``) runs under ``asyncio``.
+* Swapping SQLite for Postgres only requires a different ``db_url`` (e.g.
+  ``postgresql+asyncpg://...``) — the protocol and ORM stay unchanged.
+* Identifiers are ``uuid4().hex``; ``executemany``-style bulk inserts use
+  ``session.add_all``.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import datetime
+from datetime import timezone
+from pathlib import Path
+from typing import Any
+from typing import Protocol
+from typing import runtime_checkable
+
+from sqlalchemy import delete as sa_delete
+from sqlalchemy import select
+from sqlalchemy import text
+from sqlalchemy import update as sa_update
+from sqlalchemy.pool import StaticPool
+
+from trpc_agent_sdk.storage import SqlCondition
+from trpc_agent_sdk.storage import SqlKey
+from trpc_agent_sdk.storage import SqlStorage
+
+from .models import CRBase
+from .models import FilterBlock
+from .models import Finding
+from .models import InputDiff
+from .models import MonitorSummary
+from .models import ReviewReport
+from .models import ReviewTask
+from .models import SandboxRun
+
+# monitor_summary columns that map 1:1 from the summary dict (exception_types
+# is JSON-encoded separately).
+_MONITOR_COLUMNS = (
+    "total_duration_ms",
+    "sandbox_duration_ms",
+    "tool_calls",
+    "blocks",
+    "finding_count",
+    "sev_critical",
+    "sev_high",
+    "sev_medium",
+    "sev_low",
+)
+
+
+def _now_iso() -> str:
+    """ISO-8601 UTC timestamp — single source for `created_at`."""
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _new_id() -> str:
+    """Hex UUID4 — the id format for every table row."""
+    return uuid.uuid4().hex
+
+
+def _to_dict(obj) -> dict:
+    """Convert an ORM instance to a plain dict (column name → value)."""
+    if obj is None:
+        return None
+    return {c.name: getattr(obj, c.name) for c in obj.__table__.columns}
+
+
+def _build_db_url(db_path: str) -> tuple[str, dict]:
+    """Return (db_url, extra_kwargs) for SqlStorage.
+
+    ``:memory:`` needs ``StaticPool`` so every connection shares one DB
+    (async sqlite otherwise gives each connection its own private memory DB).
+    """
+    if db_path == ":memory:":
+        return (
+            "sqlite+aiosqlite://",
+            {"poolclass": StaticPool, "connect_args": {"check_same_thread": False}},
+        )
+    return f"sqlite+aiosqlite:///{db_path}", {}
+
+
+@runtime_checkable
+class ReviewStore(Protocol):
+    """Async persistence surface for one code-review pipeline run.
+
+    All seven tables are written/read through this protocol. ``get_task``
+    returns the fully joined record so a single call reconstructs an
+    entire review (task + inputs + sandbox runs + findings + filter blocks
+    + telemetry + report).
+    """
+
+    # —— task lifecycle ——
+    async def create_task(self, input_type: str, input_ref: str, mode: str) -> str: ...
+    async def update_task_status(
+        self, task_id: str, status: str, total_duration_ms: int | None = None
+    ) -> None: ...
+
+    # —— child-table writes (each returns the new row id) ——
+    async def add_input_diff(
+        self, task_id, file_path, sha256, hunk_count, line_count, summary
+    ) -> str: ...
+    async def add_sandbox_run(
+        self, task_id, runtime, script, status, duration_ms, exit_code,
+        output_bytes, timed_out, masked_count,
+    ) -> str: ...
+    async def add_finding(
+        self, task_id, severity, category, file, line, title, evidence,
+        recommendation, confidence, source, bucket,
+    ) -> str: ...
+    async def add_filter_block(
+        self, task_id, reason, target, decision, detail
+    ) -> str: ...
+    async def set_monitor_summary(self, task_id: str, summary: dict) -> None: ...
+    async def set_report(
+        self, task_id: str, json_path: str, md_path: str, summary: str
+    ) -> str: ...
+
+    # —— query ——
+    async def get_task(self, task_id: str) -> dict: ...
+
+
+class SQLiteStore:
+    """Async :class:`ReviewStore` over a single SQLite file via SDK SqlStorage.
+
+    Pass ``db_path=":memory:"`` for an ephemeral in-memory DB (tests).
+    """
+
+    def __init__(self, db_path: str | Path = "cr_agent.db"):
+        self.db_path = str(db_path)
+        self._db_url, self._extra_kwargs = _build_db_url(self.db_path)
+        self._storage = SqlStorage(
+            is_async=True,
+            db_url=self._db_url,
+            metadata=CRBase.metadata,
+            **self._extra_kwargs,
+        )
+        self._engine_ready = False
+
+    # ------------------------------------------------------------------ #
+    # engine / lifecycle
+    # ------------------------------------------------------------------ #
+    async def _ensure_engine(self) -> None:
+        """Create the async engine + tables (idempotent).
+
+        Also explicitly enables ``PRAGMA foreign_keys=ON``: the SDK's
+        connect-event hook doesn't always fire for ``:memory:`` + StaticPool,
+        so we set it on the pooled connection to be safe.
+        """
+        if not self._engine_ready:
+            await self._storage.create_sql_engine()
+            engine = self._storage._db_engine
+            async with engine.begin() as conn:
+                await conn.execute(text("PRAGMA foreign_keys=ON"))
+            self._engine_ready = True
+
+    @property
+    def storage(self) -> SqlStorage:
+        """Underlying SDK storage (for advanced callers)."""
+        return self._storage
+
+    async def close(self) -> None:
+        await self._storage.close()
+        self._engine_ready = False
+
+    async def __aenter__(self) -> "SQLiteStore":
+        await self._ensure_engine()
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        await self.close()
+
+    # ------------------------------------------------------------------ #
+    # internal helpers
+    # ------------------------------------------------------------------ #
+    def _session(self):
+        """An async session context manager (``async with store._session() as db``)."""
+        return self._storage.create_db_session()
+
+    @staticmethod
+    def _query_all(db, model, task_id: str, order_col=None):
+        """Select all rows of ``model`` for ``task_id``, ordered."""
+        stmt = select(model).where(model.task_id == task_id)
+        if order_col is not None:
+            stmt = stmt.order_by(order_col)
+        return db.execute(stmt).scalars().all()
+
+    # ------------------------------------------------------------------ #
+    # task lifecycle
+    # ------------------------------------------------------------------ #
+    async def create_task(self, input_type: str, input_ref: str, mode: str) -> str:
+        await self._ensure_engine()
+        task_id = _new_id()
+        task = ReviewTask(
+            id=task_id,
+            created_at=_now_iso(),
+            status="pending",
+            input_type=input_type,
+            input_ref=input_ref,
+            mode=mode,
+        )
+        async with self._session() as db:
+            await self._storage.add(db, task)
+            await self._storage.commit(db)
+        return task_id
+
+    async def update_task_status(
+        self, task_id: str, status: str, total_duration_ms: int | None = None
+    ) -> None:
+        await self._ensure_engine()
+        async with self._session() as db:
+            await db.execute(
+                sa_update(ReviewTask)
+                .where(ReviewTask.id == task_id)
+                .values(status=status, total_duration_ms=total_duration_ms)
+            )
+            await self._storage.commit(db)
+
+    # ------------------------------------------------------------------ #
+    # child-table writes
+    # ------------------------------------------------------------------ #
+    async def add_input_diff(
+        self, task_id, file_path, sha256, hunk_count, line_count, summary
+    ) -> str:
+        await self._ensure_engine()
+        diff_id = _new_id()
+        obj = InputDiff(
+            id=diff_id, task_id=task_id, file_path=file_path, sha256=sha256,
+            hunk_count=hunk_count, line_count=line_count, summary=summary,
+        )
+        async with self._session() as db:
+            await self._storage.add(db, obj)
+            await self._storage.commit(db)
+        return diff_id
+
+    async def add_sandbox_run(
+        self, task_id, runtime, script, status, duration_ms, exit_code,
+        output_bytes, timed_out, masked_count,
+    ) -> str:
+        await self._ensure_engine()
+        run_id = _new_id()
+        obj = SandboxRun(
+            id=run_id, task_id=task_id, runtime=runtime, script=script,
+            status=status, duration_ms=duration_ms, exit_code=exit_code,
+            output_bytes=output_bytes, timed_out=timed_out, masked_count=masked_count,
+        )
+        async with self._session() as db:
+            await self._storage.add(db, obj)
+            await self._storage.commit(db)
+        return run_id
+
+    async def add_finding(
+        self, task_id, severity, category, file, line, title, evidence,
+        recommendation, confidence, source, bucket,
+    ) -> str:
+        await self._ensure_engine()
+        finding_id = _new_id()
+        obj = Finding(
+            id=finding_id, task_id=task_id, severity=severity, category=category,
+            file=file, line=line, title=title, evidence=evidence,
+            recommendation=recommendation, confidence=confidence,
+            source=source, bucket=bucket,
+        )
+        async with self._session() as db:
+            await self._storage.add(db, obj)
+            await self._storage.commit(db)
+        return finding_id
+
+    async def add_findings(self, task_id: str, findings: list[dict]) -> list[str]:
+        """Bulk-insert findings via ``session.add_all`` — one round-trip.
+
+        A review can emit hundreds of findings, so this is preferred over
+        looping :meth:`add_finding`.
+        """
+        if not findings:
+            return []
+        await self._ensure_engine()
+        ids = [_new_id() for _ in findings]
+        rows = [
+            Finding(
+                id=fid, task_id=task_id,
+                severity=f["severity"], category=f["category"], file=f["file"],
+                line=f["line"], title=f["title"], evidence=f["evidence"],
+                recommendation=f["recommendation"], confidence=f["confidence"],
+                source=f["source"], bucket=f["bucket"],
+            )
+            for fid, f in zip(ids, findings)
+        ]
+        async with self._session() as db:
+            db.add_all(rows)
+            await self._storage.commit(db)
+        return ids
+
+    async def add_filter_block(
+        self, task_id, reason, target, decision, detail
+    ) -> str:
+        await self._ensure_engine()
+        block_id = _new_id()
+        obj = FilterBlock(
+            id=block_id, task_id=task_id, reason=reason, target=target,
+            decision=decision, detail=detail,
+        )
+        async with self._session() as db:
+            await self._storage.add(db, obj)
+            await self._storage.commit(db)
+        return block_id
+
+    async def set_monitor_summary(self, task_id: str, summary: dict) -> None:
+        """Upsert the 1:1 telemetry rollup row for a task."""
+        await self._ensure_engine()
+        exc = summary.get("exception_types")
+        if isinstance(exc, dict):
+            exc = json.dumps(exc, ensure_ascii=False)
+        async with self._session() as db:
+            # 1:1 relationship — delete any existing row first.
+            await db.execute(
+                sa_delete(MonitorSummary).where(MonitorSummary.task_id == task_id)
+            )
+            summary_id = _new_id()
+            values = {col: summary.get(col) for col in _MONITOR_COLUMNS}
+            obj = MonitorSummary(id=summary_id, task_id=task_id, exception_types=exc, **values)
+            await self._storage.add(db, obj)
+            await self._storage.commit(db)
+
+    async def set_report(
+        self, task_id: str, json_path: str, md_path: str, summary: str
+    ) -> str:
+        """Upsert the 1:1 report row for a task, return its id."""
+        await self._ensure_engine()
+        async with self._session() as db:
+            existing = await db.execute(
+                select(ReviewReport).where(ReviewReport.task_id == task_id)
+            )
+            row = existing.scalars().one_or_none()
+            if row is not None:
+                row.report_json_path = json_path
+                row.report_md_path = md_path
+                row.summary = summary
+                row.created_at = _now_iso()
+                report_id = row.id
+            else:
+                report_id = _new_id()
+                obj = ReviewReport(
+                    id=report_id, task_id=task_id, report_json_path=json_path,
+                    report_md_path=md_path, summary=summary, created_at=_now_iso(),
+                )
+                await self._storage.add(db, obj)
+            await self._storage.commit(db)
+        return report_id
+
+    # ------------------------------------------------------------------ #
+    # query
+    # ------------------------------------------------------------------ #
+    async def get_task(self, task_id: str) -> dict:
+        """Reconstruct the full review record via per-table queries.
+
+        One session, one query per child table — keeps the result a clean
+        nested dict with stable ordering.
+        """
+        await self._ensure_engine()
+        async with self._session() as db:
+            task_row = await db.execute(
+                select(ReviewTask).where(ReviewTask.id == task_id)
+            )
+            task = task_row.scalars().one_or_none()
+            if task is None:
+                raise KeyError(f"review_task not found: {task_id}")
+
+            input_diffs = (await db.execute(
+                select(InputDiff).where(InputDiff.task_id == task_id).order_by(InputDiff.id)
+            )).scalars().all()
+            sandbox_runs = (await db.execute(
+                select(SandboxRun).where(SandboxRun.task_id == task_id).order_by(SandboxRun.id)
+            )).scalars().all()
+            findings = (await db.execute(
+                select(Finding).where(Finding.task_id == task_id).order_by(Finding.id)
+            )).scalars().all()
+            filter_blocks = (await db.execute(
+                select(FilterBlock).where(FilterBlock.task_id == task_id).order_by(FilterBlock.id)
+            )).scalars().all()
+            ms_row = await db.execute(
+                select(MonitorSummary).where(MonitorSummary.task_id == task_id)
+            )
+            monitor_summary = ms_row.scalars().one_or_none()
+            rep_row = await db.execute(
+                select(ReviewReport).where(ReviewReport.task_id == task_id)
+            )
+            report = rep_row.scalars().one_or_none()
+
+        return {
+            "task": _to_dict(task),
+            "input_diffs": [_to_dict(x) for x in input_diffs],
+            "sandbox_runs": [_to_dict(x) for x in sandbox_runs],
+            "findings": [_to_dict(x) for x in findings],
+            "filter_blocks": [_to_dict(x) for x in filter_blocks],
+            "monitor_summary": _to_dict(monitor_summary),
+            "report": _to_dict(report),
+        }

--- a/examples/skills_code_review_agent/agent/filters/__init__.py
+++ b/examples/skills_code_review_agent/agent/filters/__init__.py
@@ -1,0 +1,11 @@
+# Tencent is pleased to support the open source community by making tRPC-Agent-Python available.
+#
+# Copyright (C) 2026 Tencent. All rights reserved.
+#
+# tRPC-Agent-Python is licensed under Apache-2.0.
+"""Filters package — governance gate (Phase 3)."""
+from .governance import CrGovernanceFilter
+from .governance import FilterDecision
+from .governance import FilterGovernance
+
+__all__ = ["FilterDecision", "FilterGovernance", "CrGovernanceFilter"]

--- a/examples/skills_code_review_agent/agent/filters/governance.py
+++ b/examples/skills_code_review_agent/agent/filters/governance.py
@@ -1,0 +1,199 @@
+# Tencent is pleased to support the open source community by making tRPC-Agent-Python available.
+#
+# Copyright (C) 2026 Tencent. All rights reserved.
+#
+# tRPC-Agent-Python is licensed under Apache-2.0.
+"""Filter governance — pre-sandbox gate (Phase 3, L3).
+
+Four check classes run BEFORE a script enters the sandbox. ``deny`` and
+``needs_human_review`` never reach the sandbox — the orchestrator (P5)
+records the block in ``filter_block`` and skips execution.
+
+This module provides two layers:
+* :class:`FilterGovernance` — the spec contract: a synchronous ``decide()``
+  that inspects script content + budget and returns a :class:`FilterDecision`.
+* :class:`CrGovernanceFilter` — an SDK :class:`BaseFilter` adapter that wraps
+  ``FilterGovernance`` so the same checks run when the Skill is invoked via
+  the SDK tool pipeline (``register_tool_filter``). The four check *strategies*
+  are self-implemented (the SDK ships no built-in policy filters).
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+from trpc_agent_sdk.filter import BaseFilter
+from trpc_agent_sdk.filter import FilterResult
+from trpc_agent_sdk.filter import register_tool_filter
+
+
+@dataclass
+class FilterDecision:
+    """Outcome of a governance check."""
+
+    verdict: str  # allow|deny|needs_human_review
+    reason: str  # high-risk|forbidden-path|network|budget|ok
+    target: str  # the script path / target inspected
+    detail: str
+
+
+# --- high-risk script patterns (deny) ---
+# Kept precise to avoid false positives on docs/comments: e.g. `rm -rf` only
+# fires when followed by a path sigil (/, ~), not bare prose.
+_HIGH_RISK_PATTERNS = [
+    (re.compile(r"rm\s+-rf?\s+[/~]"), "rm -rf targeting a root/home path"),
+    (re.compile(r"\bsudo\b\s+\w"), "sudo invocation"),
+    (re.compile(r"\bcurl\b\s+https?://|\bwget\b\s+https?://"), "remote download+exec pattern (curl/wget)"),
+    (re.compile(r"\beval\s*\("), "eval() arbitrary code execution"),
+    (re.compile(r"os\.system\s*\(\s*['\"].*['\"]\s*\+"), "os.system with string concatenation (injection)"),
+    (re.compile(r"subprocess\.(?:call|run|Popen)\s*\([^)]*shell\s*=\s*True[^)]*\+"), "shell=True with concatenation (injection)"),
+]
+
+# --- forbidden paths (deny) ---
+_FORBIDDEN_PATH_PATTERNS = [
+    re.compile(r"['\"]/etc/"),
+    re.compile(r"['\"]~/.ssh"),
+    re.compile(r"['\"]/?root/\."),
+    re.compile(r"['\"]/?var/log"),
+    re.compile(r"['\"]C:\\\\?Windows"),
+    re.compile(r"['\"]/?proc/"),
+]
+
+# --- network access (needs_human_review) ---
+_NETWORK_PATTERNS = [
+    re.compile(r"\bsocket\.connect\s*\("),
+    re.compile(r"\brequests\.(?:get|post|put|delete|patch|head)\s*\("),
+    re.compile(r"\burllib\.request\.urlopen\s*\("),
+    re.compile(r"\baiohttp\.ClientSession\s*\("),
+    re.compile(r"\bhttpx\.(?:get|post|Client)\s*\("),
+]
+# Domains that are always allowed (won't trigger network review).
+_NETWORK_WHITELIST = re.compile(r"localhost|127\.0\.0\.1|0\.0\.0\.0|::1")
+
+# Budget thresholds (over → needs_human_review).
+_BUDGET_DURATION_S = 60
+_BUDGET_MEMORY_MB = 1024
+
+
+class FilterGovernance:
+    """Synchronous four-class governance check.
+
+    Call :meth:`decide` with the script path + content + budget estimate.
+    The orchestrator records ``deny``/``needs_human_review`` into
+    ``filter_block`` and skips the sandbox for those verdicts.
+    """
+
+    def decide(
+        self,
+        script_path: str,
+        script_content: str,
+        budget: dict | None = None,
+    ) -> FilterDecision:
+        target = script_path
+        budget = budget or {}
+
+        # Strip comment lines (first non-space char is '#') to reduce false
+        # positives — a doc/comment mentioning `rm -rf` should NOT trigger a
+        # deny. Simple heuristic; P6 can refine with AST-aware comment skip.
+        code = "\n".join(
+            ln for ln in script_content.splitlines()
+            if not ln.lstrip().startswith("#")
+        )
+
+        # 1. high-risk script features → deny
+        for pat, desc in _HIGH_RISK_PATTERNS:
+            m = pat.search(code)
+            if m:
+                return FilterDecision(
+                    verdict="deny",
+                    reason="high-risk",
+                    target=target,
+                    detail=f"{desc}: matched /{pat.pattern}/ → {m.group(0)!r}",
+                )
+
+        # 2. forbidden paths → deny
+        for pat in _FORBIDDEN_PATH_PATTERNS:
+            m = pat.search(code)
+            if m:
+                return FilterDecision(
+                    verdict="deny",
+                    reason="forbidden-path",
+                    target=target,
+                    detail=f"access to forbidden path: {m.group(0)!r}",
+                )
+
+        # 3. non-whitelisted network → needs_human_review
+        for pat in _NETWORK_PATTERNS:
+            m = pat.search(code)
+            if m:
+                # allow if the match context mentions a whitelisted host
+                window = code[max(0, m.start() - 40): m.end() + 60]
+                if _NETWORK_WHITELIST.search(window):
+                    continue
+                return FilterDecision(
+                    verdict="needs_human_review",
+                    reason="network",
+                    target=target,
+                    detail=f"non-whitelisted network access: {m.group(0)!r}",
+                )
+
+        # 4. over-budget → needs_human_review
+        est_dur = float(budget.get("estimated_duration_s", 0) or 0)
+        est_mem = float(budget.get("estimated_memory_mb", 0) or 0)
+        if est_dur > _BUDGET_DURATION_S or est_mem > _BUDGET_MEMORY_MB:
+            return FilterDecision(
+                verdict="needs_human_review",
+                reason="budget",
+                target=target,
+                detail=f"over budget: duration={est_dur}s (>{_BUDGET_DURATION_S}), memory={est_mem}MB (>{_BUDGET_MEMORY_MB})",
+            )
+
+        return FilterDecision(
+            verdict="allow", reason="ok", target=target, detail="passed all governance checks"
+        )
+
+
+# --------------------------------------------------------------------------- #
+# SDK BaseFilter adapter — same checks run when the Skill is invoked via the
+# SDK tool pipeline. Registered as "cr_governance" tool filter.
+# --------------------------------------------------------------------------- #
+@register_tool_filter("cr_governance")
+class CrGovernanceFilter(BaseFilter):
+    """SDK tool filter wrapping :class:`FilterGovernance`.
+
+    When a skill_run/skill_exec tool call carries a script to execute, this
+    filter runs the four-class governance check in ``_before``. A ``deny``
+    verdict sets ``is_continue=False`` so the call never reaches the sandbox;
+    ``needs_human_review`` likewise blocks (the orchestrator records it).
+    The block reason is surfaced via ``rsp.error``.
+    """
+
+    def __init__(self, governance: "FilterGovernance | None" = None):
+        self._gov = governance or FilterGovernance()
+
+    async def _before(self, ctx, req, rsp: FilterResult) -> None:
+        # Extract script info from the tool-call request. The exact req shape
+        # depends on the SDK tool pipeline; we try common accessors and fall
+        # back to allow when no script is identifiable (P5 orchestrator wires
+        # the real script_path into the request args).
+        script_path = None
+        script_content = None
+        for attr in ("script_path", "path", "file"):
+            script_path = getattr(req, attr, None)
+            if script_path:
+                break
+        if script_path is None and isinstance(req, dict):
+            script_path = req.get("script_path") or req.get("path")
+        if script_path is None:
+            return  # nothing to inspect → allow
+        try:
+            script_content = Path(script_path).read_text(encoding="utf-8")
+        except Exception:
+            script_content = ""
+        decision = self._gov.decide(str(script_path), script_content, {})
+        if decision.verdict in ("deny", "needs_human_review"):
+            rsp.is_continue = False
+            rsp.error = ValueError(
+                f"[cr_governance] {decision.verdict}: {decision.reason} — {decision.detail}"
+            )

--- a/examples/skills_code_review_agent/agent/llm/__init__.py
+++ b/examples/skills_code_review_agent/agent/llm/__init__.py
@@ -1,0 +1,22 @@
+"""LLM integration for the Code Review Agent (Phase 7, optional).
+
+Real model calls are OFF by default. Configuration lives in ``.env``
+(see ``.env.example``). When ``LLM_ENABLED`` is false or no API key is
+present, :func:`get_llm_client` returns a :class:`FakeLlm` that is a safe
+no-op — the deterministic parse -> sandbox -> persist chain (and
+``dry-run``) keep working with **zero model dependency**, so tests without
+a real API key still exercise parsing, the sandbox, and the storage layer.
+"""
+from .client import FakeLlm, LlmClient, RealLlm, get_llm_client
+from .config import LlmConfig, load_llm_config
+from .triage import LlmTriage
+
+__all__ = [
+    "LlmConfig",
+    "load_llm_config",
+    "LlmClient",
+    "FakeLlm",
+    "RealLlm",
+    "get_llm_client",
+    "LlmTriage",
+]

--- a/examples/skills_code_review_agent/agent/llm/client.py
+++ b/examples/skills_code_review_agent/agent/llm/client.py
@@ -1,0 +1,179 @@
+"""LLM client + factory (Phase 7).
+
+The real client wraps the OpenAI SDK, which is OpenAI-compatible — it works
+with OpenAI, Azure OpenAI, local vLLM, and internal gateways by simply
+changing ``LLM_BASE_URL``/``LLM_API_KEY`` in ``.env``. The fake client is a
+safe no-op used when the model is disabled or unconfigured.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import re
+from abc import ABC, abstractmethod
+from typing import Optional
+
+from .config import LlmConfig, load_llm_config
+
+logger = logging.getLogger("cr_agent.llm")
+
+
+class LlmClient(ABC):
+    """Async client that judges low-confidence candidate findings."""
+
+    is_enabled: bool = True
+    kind: str = "base"
+
+    @abstractmethod
+    async def triage(self, findings, diff_text: str) -> list[dict]:
+        """Return verdicts: list of
+        ``{"index": int, "verdict": "real"|"false_positive",
+            "confidence": float, "explanation": str}``.
+
+        An empty list means "no change" (degrade to no-op).
+        """
+        ...
+
+
+class FakeLlm(LlmClient):
+    """No-op client — used when the model is disabled / no API key."""
+
+    is_enabled = False
+    kind = "fake"
+
+    async def triage(self, findings, diff_text: str) -> list[dict]:
+        return []
+
+
+_SYSTEM_PROMPT = (
+    "You are a senior static-analysis code reviewer. You will receive a code "
+    "diff and a list of candidate issues found by automated rules. For each "
+    "candidate, decide whether it is a REAL issue or a FALSE POSITIVE. "
+    "Respond with STRICT JSON only: "
+    '{"verdicts":[{"index":int,"verdict":"real"|"false_positive",'
+    '"confidence":float 0-1,"explanation":str}]}. '
+    "Only include entries you can judge with confidence; omit uncertain ones "
+    "(they stay unchanged). 'confidence' should reflect your own certainty "
+    "for real issues."
+)
+
+_USER_TEMPLATE = (
+    "## Code diff (secrets masked)\n"
+    "```\n{diff}\n```\n\n"
+    "## Candidate issues (index = position)\n"
+    "{items}\n\n"
+    "Return the JSON verdicts now."
+)
+
+
+class RealLlm(LlmClient):
+    """Real OpenAI-compatible client. Lazily imports ``openai``."""
+
+    kind = "real"
+
+    def __init__(self, config: LlmConfig, client=None):
+        self.config = config
+        self._client = client
+
+    def _make_client(self):
+        from openai import AsyncOpenAI
+
+        kwargs = {
+            "api_key": self.config.api_key,
+            "timeout": self.config.timeout,
+        }
+        if self.config.base_url:
+            kwargs["base_url"] = self.config.base_url
+        return AsyncOpenAI(**kwargs)
+
+    @property
+    def client(self):
+        if self._client is None:
+            self._client = self._make_client()
+        return self._client
+
+    async def _chat(self, messages):
+        resp = await self.client.chat.completions.create(
+            model=self.config.model,
+            messages=messages,
+            temperature=self.config.temperature,
+            max_tokens=self.config.max_tokens,
+        )
+        return resp
+
+    async def triage(self, findings, diff_text: str) -> list[dict]:
+        if not findings:
+            return []
+        payload = [
+            {
+                "index": i,
+                "file": f.file,
+                "line": f.line,
+                "category": f.category,
+                "title": f.title,
+                "evidence": f.evidence,
+            }
+            for i, f in enumerate(findings)
+        ]
+        messages = [
+            {"role": "system", "content": _SYSTEM_PROMPT},
+            {
+                "role": "user",
+                "content": _USER_TEMPLATE.format(
+                    diff=diff_text,
+                    items=json.dumps(payload, ensure_ascii=False, indent=2),
+                ),
+            },
+        ]
+        try:
+            resp = await self._chat(messages)
+            content = resp.choices[0].message.content or ""
+            return _parse_verdicts(content)
+        except Exception as exc:  # network / parse / timeout -> degrade
+            logger.warning("llm triage failed, degrading to no-op: %s", exc)
+            return []
+
+
+def _parse_verdicts(content: str) -> list[dict]:
+    """Best-effort JSON parse of the model response (handles code fences)."""
+    try:
+        s = content.strip()
+        if s.startswith("```"):
+            s = re.sub(r"^```[a-zA-Z]*\n?", "", s)
+            s = s.rstrip("`").strip()
+        data = json.loads(s)
+        vs = data.get("verdicts") or []
+    except Exception:
+        return []
+    out: list[dict] = []
+    for v in vs:
+        try:
+            idx = int(v["index"])
+            verdict = str(v.get("verdict", "real")).lower()
+            conf = float(v.get("confidence", 0.5))
+            conf = max(0.0, min(1.0, conf))
+            out.append(
+                {
+                    "index": idx,
+                    "verdict": verdict,
+                    "confidence": conf,
+                    "explanation": str(v.get("explanation", "")),
+                }
+            )
+        except (KeyError, ValueError, TypeError):
+            continue
+    return out
+
+
+def get_llm_client(enable=None, env_path: Optional[str] = None) -> LlmClient:
+    """Return a :class:`RealLlm` when enabled + keyed, else :class:`FakeLlm`.
+
+    ``enable`` (e.g. from ``--enable-llm``) overrides the ``.env`` flag when
+    not ``None``. Without an API key the real client is never instantiated,
+    guaranteeing the no-key test path stays model-free.
+    """
+    cfg = load_llm_config(env_path)
+    on = cfg.enabled if enable is None else enable
+    if not on or not cfg.has_key:
+        return FakeLlm()
+    return RealLlm(cfg)

--- a/examples/skills_code_review_agent/agent/llm/config.py
+++ b/examples/skills_code_review_agent/agent/llm/config.py
@@ -1,0 +1,62 @@
+"""LLM configuration loaded from ``.env`` (Phase 7).
+
+All configuration is sourced from environment variables (a ``.env`` file
+is auto-loaded via ``python-dotenv`` from the project root). Missing or
+empty values fall back to safe defaults so the agent stays runnable with
+no model configured.
+"""
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+# Default location: <project_root>/.env  (llm/ lives under agent/llm).
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+_DEFAULT_ENV = _PROJECT_ROOT / ".env"
+
+
+@dataclass
+class LlmConfig:
+    """Resolved LLM settings."""
+
+    enabled: bool
+    provider: str
+    api_key: str
+    base_url: str
+    model: str
+    temperature: float
+    max_tokens: int
+    timeout: int
+
+    @property
+    def has_key(self) -> bool:
+        return bool(self.api_key.strip())
+
+
+def _truthy(value: str | None) -> bool:
+    return str(value or "").strip().lower() in ("1", "true", "yes", "on")
+
+
+def load_llm_config(env_path: str | None = None) -> LlmConfig:
+    """Read LLM_* settings from the environment (auto-loading ``.env``).
+
+    ``env_path`` lets callers point at an explicit ``.env`` (e.g. via the
+    ``--llm-env`` CLI flag); otherwise the project-root ``.env`` is used.
+    """
+    dotenv_path = _DEFAULT_ENV if env_path is None else os.path.expanduser(env_path)
+    # override=False so an already-exported real env var wins over the file.
+    load_dotenv(dotenv_path=dotenv_path, override=False)
+
+    return LlmConfig(
+        enabled=_truthy(os.getenv("LLM_ENABLED")),
+        provider=(os.getenv("LLM_PROVIDER") or "openai").strip(),
+        api_key=(os.getenv("LLM_API_KEY") or "").strip(),
+        base_url=(os.getenv("LLM_BASE_URL") or "").strip(),
+        model=(os.getenv("LLM_MODEL") or "gpt-4o-mini").strip(),
+        temperature=float(os.getenv("LLM_TEMPERATURE") or "0.1"),
+        max_tokens=int(os.getenv("LLM_MAX_TOKENS") or "1024"),
+        timeout=int(os.getenv("LLM_TIMEOUT") or "30"),
+    )

--- a/examples/skills_code_review_agent/agent/llm/triage.py
+++ b/examples/skills_code_review_agent/agent/llm/triage.py
@@ -1,0 +1,73 @@
+"""LLM second-opinion triage over low-confidence findings (Phase 7).
+
+Runs *after* dedupe and *before* persistence. The model only sees the
+``needs_human_review`` bucket (low confidence). Verdicts are applied to:
+
+* **false_positive** -> dropped entirely
+* **real** -> confidence updated, ``source`` tagged ``+llm``, explanation
+  appended to ``recommendation``, and re-bucketed by the (model-given)
+  confidence (>=0.8 -> findings, >=0.6 -> warnings, else stays in review).
+
+When the client is disabled or the call fails, the original
+:class:`DedupeResult` is returned unchanged (no-op degradation).
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from cr_models import DedupeResult
+    from .client import LlmClient
+
+
+def _apply_verdicts(dr: "DedupeResult", verdicts: list[dict]) -> "DedupeResult":
+    by_idx = {v["index"]: v for v in verdicts}
+    kept: list = []
+    promoted_findings: list = []
+    promoted_warnings: list = []
+
+    for i, f in enumerate(dr.needs_human_review):
+        v = by_idx.get(i)
+        if v is None:
+            kept.append(f)
+            continue
+        if v.get("verdict") == "false_positive":
+            continue  # drop
+        conf = v.get("confidence", f.confidence)
+        f.confidence = max(0.0, min(1.0, conf))
+        if "llm" not in f.source:
+            f.source = (f.source + "+llm") if f.source else "llm"
+        expl = (v.get("explanation") or "").strip()
+        if expl:
+            f.recommendation = f.recommendation + f"\n[LLM] {expl}"
+        if f.confidence >= 0.8:
+            promoted_findings.append(f)
+        elif f.confidence >= 0.6:
+            promoted_warnings.append(f)
+        else:
+            kept.append(f)
+
+    dr.findings = list(dr.findings) + promoted_findings
+    dr.warnings = list(dr.warnings) + promoted_warnings
+    dr.needs_human_review = kept
+    return dr
+
+
+class LlmTriage:
+    """Drives the optional LLM second-opinion pass."""
+
+    def __init__(self, client: "LlmClient"):
+        self.client = client
+
+    async def run(self, dedupe_result: "DedupeResult", diff_text: str) -> "DedupeResult":
+        nh = dedupe_result.needs_human_review
+        if not nh or not self.client.is_enabled:
+            return dedupe_result
+        # Mask secrets before sending the diff to the model.
+        from mask_secrets import mask_secrets
+
+        masked, _ = mask_secrets(diff_text or "")
+        verdicts = await self.client.triage(nh, masked)
+        if not verdicts:
+            return dedupe_result
+        return _apply_verdicts(dedupe_result, verdicts)

--- a/examples/skills_code_review_agent/agent/sandbox/__init__.py
+++ b/examples/skills_code_review_agent/agent/sandbox/__init__.py
@@ -1,0 +1,27 @@
+# Tencent is pleased to support the open source community by making tRPC-Agent-Python available.
+#
+# Copyright (C) 2026 Tencent. All rights reserved.
+#
+# tRPC-Agent-Python is licensed under Apache-2.0.
+"""Sandbox package — isolated script execution (Phase 3)."""
+from .policy import SandboxPolicy
+from .runtime import ContainerRuntime
+from .runtime import CubeRuntime
+from .runtime import LocalRuntime
+from .runtime import RunResult
+from .runtime import RuntimeUnavailable
+from .runtime import SandboxRuntime
+from .runtime import build_runtime_with_fallback
+from .runtime import select_runtime
+
+__all__ = [
+    "SandboxPolicy",
+    "RunResult",
+    "SandboxRuntime",
+    "LocalRuntime",
+    "ContainerRuntime",
+    "CubeRuntime",
+    "RuntimeUnavailable",
+    "select_runtime",
+    "build_runtime_with_fallback",
+]

--- a/examples/skills_code_review_agent/agent/sandbox/policy.py
+++ b/examples/skills_code_review_agent/agent/sandbox/policy.py
@@ -1,0 +1,53 @@
+# Tencent is pleased to support the open source community by making tRPC-Agent-Python available.
+#
+# Copyright (C) 2026 Tencent. All rights reserved.
+#
+# tRPC-Agent-Python is licensed under Apache-2.0.
+"""Sandbox security policy (Phase 3).
+
+The five mandatory safety boundaries applied on every sandbox execution:
+timeout, output-size cap, env-variable whitelist, secret masking, and
+fail-safe (no crash on error). Built from the Skill's ``sandbox_config``.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from dataclasses import field
+
+
+@dataclass
+class SandboxPolicy:
+    """Five mandatory sandbox safety boundaries.
+
+    Defaults match the code-review Skill's ``sandbox:`` frontmatter
+    (ARCHITECTURE.md §6.3). A policy is built per-run from the loaded
+    Skill config so the boundaries are always enforced, never bypassed.
+    """
+
+    timeout_s: int = 30
+    """Max execution time; over-run → ``timed_out=True``, degraded to empty."""
+
+    max_output_bytes: int = 1_048_576
+    """1 MB output cap; excess is truncated, ``status=truncated``."""
+
+    env_whitelist: list[str] = field(
+        default_factory=lambda: ["PATH", "HOME", "LANG"]
+    )
+    """Only these env vars are passed into the sandbox; others dropped."""
+
+    mask_secrets: bool = True
+    """Redact secrets in stdout/stderr before truncation & persistence."""
+
+    @classmethod
+    def from_config(cls, sandbox_config: dict | None) -> "SandboxPolicy":
+        """Build a policy from the Skill's ``sandbox_config`` dict.
+
+        Unknown keys are ignored; missing keys fall back to the safe defaults.
+        """
+        cfg = sandbox_config or {}
+        return cls(
+            timeout_s=int(cfg.get("timeout_s", 30)),
+            max_output_bytes=int(cfg.get("max_output_bytes", 1_048_576)),
+            env_whitelist=list(cfg.get("env_whitelist", ["PATH", "HOME", "LANG"])),
+            mask_secrets=True,
+        )

--- a/examples/skills_code_review_agent/agent/sandbox/runtime.py
+++ b/examples/skills_code_review_agent/agent/sandbox/runtime.py
@@ -1,0 +1,613 @@
+# Tencent is pleased to support the open source community by making tRPC-Agent-Python available.
+#
+# Copyright (C) 2026 Tencent. All rights reserved.
+#
+# tRPC-Agent-Python is licensed under Apache-2.0.
+"""Sandbox runtime — isolated script execution (Phase 3, L4).
+
+Adapter over the SDK's execution backends: the code-review scripts
+(``run_checks.py`` etc.) are staged into an isolated workspace and executed,
+returning raw stdout/stderr/exit_code. We map that to the CR Agent's
+:class:`RunResult` and apply the five safety boundaries from
+:class:`SandboxPolicy` (timeout, output cap, env whitelist, secret masking,
+fail-safe).
+
+Runtime selection (G1 fix)
+--------------------------
+The skill's ``sandbox_config`` declares ``default_runtime`` / ``fallback``
+(e.g. ``default_runtime: container``, ``fallback: local``). The agent no
+longer hardcodes ``LocalRuntime`` — it honors that contract via
+:func:`build_runtime_with_fallback`, which probes ``default_runtime`` first
+and transparently degrades to ``fallback`` when the requested backend cannot
+be provisioned (e.g. the docker daemon is absent). The *actual* runtime used
+is returned so the pipeline can record it truthfully in ``sandbox_run``.
+
+Backends
+--------
+* ``LocalRuntime`` — SDK ``create_local_workspace_runtime`` (process isolation,
+  dev / fallback). No external dependency.
+* ``ContainerRuntime`` — SDK ``ContainerClient`` (real docker isolation).
+  Raises :class:`RuntimeUnavailable` when docker is not reachable so the agent
+  can fall back to ``LocalRuntime``.
+* ``CubeRuntime`` — SDK ``CubeSandboxClient`` (remote Cube/E2B sandbox). Raises
+  :class:`RuntimeUnavailable` when the cube extra / credentials are missing.
+
+Shared notes
+------------
+* The whole script directory is staged (not just one file) so the script can
+  ``import`` sibling modules (``run_checks.py`` imports ``parse_diff``).
+* Secrets are masked **before** truncation so masking never misses bytes.
+* Any exception is caught → ``status="failed"`` with empty stdout; the
+  pipeline never crashes on a sandbox failure.
+"""
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import logging
+import os
+import re
+import time
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Protocol
+from typing import runtime_checkable
+
+# Wire the skill scripts dir onto sys.path so we can import mask_secrets
+# (shared with the sensitive_info rule set) for output redaction.
+_HERE = Path(__file__).resolve().parent  # .../agent/sandbox
+_SCRIPTS_DIR = _HERE.parent.parent / "skills" / "code-review" / "scripts"
+if str(_SCRIPTS_DIR) not in __import__("sys").path:
+    __import__("sys").path.insert(0, str(_SCRIPTS_DIR))
+from mask_secrets import mask_secrets  # noqa: E402
+
+from .policy import SandboxPolicy  # noqa: E402
+
+logger = logging.getLogger(__name__)
+
+
+class RuntimeUnavailable(RuntimeError):
+    """The requested sandbox runtime cannot be provisioned in this environment.
+
+    Raised by a runtime's ``ensure_available()`` probe (e.g. docker daemon
+    absent, cube not configured). The agent catches it and falls back to the
+    configured ``fallback`` runtime.
+    """
+
+
+@dataclass
+class RunResult:
+    """One sandbox execution outcome, persisted to ``sandbox_run``."""
+
+    status: str  # ok|timeout|failed|truncated
+    stdout: str
+    stderr: str
+    duration_ms: int
+    exit_code: int
+    output_bytes: int
+    timed_out: bool
+    masked_count: int
+
+
+@runtime_checkable
+class SandboxRuntime(Protocol):
+    """Execute a script in an isolated workspace under a policy."""
+
+    async def run(
+        self, script_path: str, input: dict, policy: "SandboxPolicy"
+    ) -> RunResult: ...
+
+
+# --------------------------------------------------------------------------- #
+# Shared post-processing — mask + truncate + status mapping (all backends)
+# --------------------------------------------------------------------------- #
+def _finalize(
+    stdout: str,
+    stderr: str,
+    exit_code: int,
+    timed_out: bool,
+    duration_s: float,
+    policy: SandboxPolicy,
+) -> RunResult:
+    """Apply the safety boundaries shared by every backend and build RunResult."""
+    masked_count = 0
+    if policy.mask_secrets:
+        stdout, n1 = mask_secrets(stdout)
+        stderr, n2 = mask_secrets(stderr)
+        masked_count = n1 + n2
+
+    # Truncate to max_output_bytes (applied to stdout only; stderr kept).
+    truncated = len(stdout.encode("utf-8")) > policy.max_output_bytes
+    if truncated:
+        stdout = stdout.encode("utf-8")[: policy.max_output_bytes].decode(
+            "utf-8", errors="ignore"
+        )
+
+    # Map to RunResult.status: timeout > truncated > failed > ok.
+    if timed_out:
+        status = "timeout"
+    elif truncated:
+        status = "truncated"
+    elif exit_code != 0:
+        status = "failed"
+    else:
+        status = "ok"
+
+    return RunResult(
+        status=status,
+        stdout=stdout,
+        stderr=stderr,
+        duration_ms=int(round((duration_s or 0) * 1000)),
+        exit_code=exit_code,
+        output_bytes=len(stdout.encode("utf-8")),
+        timed_out=bool(timed_out),
+        masked_count=masked_count,
+    )
+
+
+# Non-secret, platform-essential environment variables that the OS / python
+# interpreter needs merely to *start* a subprocess on the host. Passing these
+# into the local sandbox does NOT weaken the whitelist security boundary —
+# the boundary is about not leaking arbitrary host vars (secrets, config,
+# credentials). These are generic, non-sensitive process-start requirements.
+_SYSTEM_REQUIRED = (
+    "PATH", "SYSTEMROOT", "SYSTEMDRIVE", "WINDIR", "TEMP", "TMP",
+    "COMSPEC", "USERPROFILE", "USERNAME", "USER", "HOME", "LANG",
+    "LC_ALL", "PATHEXT", "PROCESSOR_ARCHITECTURE", "NUMBER_OF_PROCESSORS",
+    "LOGNAME", "TERM",
+)
+
+
+def _restrict_env_to_whitelist(policy: "SandboxPolicy") -> dict:
+    """Temporarily shrink ``os.environ`` to the whitelist + platform-required vars.
+
+    The SDK local runtime builds the child env from ``os.environ.copy()`` and
+    then merges ``spec.env`` — so the *only* way to drop non-whitelisted host
+    variables is to shrink ``os.environ`` itself for the duration of the
+    subprocess. We keep exactly:
+
+      * variables named in ``policy.env_whitelist`` (the Skill's declared
+        contract), and
+      * a small set of non-secret platform-required vars (``_SYSTEM_REQUIRED``)
+        without which python cannot even start on the host OS.
+
+    Everything else (including ``CR_P3_VISIBLE``, ``OPENAI_API_KEY``, …) is
+    dropped, so it can never leak into the sandbox. The full host env is always
+    restored by the caller's ``finally`` block. CR Agent runs sandboxes
+    serially (awaited), so this global mutation is safe.
+    """
+    _saved = dict(os.environ)
+    allowed = {
+        k: v for k, v in os.environ.items()
+        if k in policy.env_whitelist or k in _SYSTEM_REQUIRED
+    }
+    os.environ.clear()
+    os.environ.update(allowed)
+    return _saved
+
+
+def _restore_env(saved: dict) -> None:
+    """Restore ``os.environ`` from a previously saved copy, tolerating vars
+    that the OS cannot hold.
+
+    On Windows, ``os.environ`` rejects any value longer than 32767 characters
+    (``SetEnvironmentVariableW`` limit) — yet a process can *inherit* such a
+    var from its parent. Some desktop-agent environments ship a multi-hundred-
+    KB context var (e.g. ``ACC_PRODUCT_CONFIG_V3``). We must restore the host
+    env after a sandbox run, but re-setting an oversized var raises
+    ``ValueError``. We set each var individually and silently skip the ones the
+    OS refuses, so the restore never crashes the pipeline (the un-settable var
+    was already dropped during restriction and the sandbox never needed it).
+    """
+    os.environ.clear()
+    for k, v in saved.items():
+        try:
+            os.environ[k] = v
+        except (ValueError, OSError):
+            continue
+
+
+# --------------------------------------------------------------------------- #
+# LocalRuntime — SDK create_local_workspace_runtime
+# --------------------------------------------------------------------------- #
+class LocalRuntime:
+    """Sandbox backed by the SDK's local workspace runtime (process isolation).
+
+    Creates a fresh workspace per run, stages the script directory, runs
+    ``python <script>`` with the input JSON on stdin, masks + truncates
+    output, and tears the workspace down. Always available (no external
+    dependency) — this is the natural ``fallback`` backend.
+    """
+
+    def __init__(self, work_root: str | Path | None = None):
+        self._work_root = str(work_root) if work_root else None
+
+    def ensure_available(self) -> bool:
+        """Local backend is always provisionable."""
+        return True
+
+    async def run(
+        self, script_path: str, input: dict, policy: SandboxPolicy | None = None
+    ) -> RunResult:
+        policy = policy or SandboxPolicy()
+        exec_id = f"cr-{uuid.uuid4().hex[:8]}"
+        try:
+            return await self._run(script_path, input, policy, exec_id)
+        except Exception as exc:  # fail-safe: never crash the pipeline
+            return RunResult(
+                status="failed",
+                stdout="",
+                stderr=str(exc)[:4096],
+                duration_ms=0,
+                exit_code=-1,
+                output_bytes=0,
+                timed_out=False,
+                masked_count=0,
+            )
+
+    async def _run(
+        self, script_path: str, input: dict, policy: SandboxPolicy, exec_id: str
+    ) -> RunResult:
+        from trpc_agent_sdk.code_executors import (
+            WorkspacePutFileInfo,
+            WorkspaceRunProgramSpec,
+            create_local_workspace_runtime,
+        )
+
+        # P1-2: enforce the env-variable whitelist for the ENTIRE sandbox
+        # operation. The SDK's workspace creation, file staging, AND program
+        # execution may each spawn subprocess that inherit os.environ; a single
+        # oversized host var (e.g. ``ACC_PRODUCT_CONFIG_V3`` on some Windows
+        # desktops — >300k chars) would otherwise break ``CreateProcess`` with
+        # "the environment variable is longer than 32767 characters". Restricting
+        # up front keeps every spawned process clean. Container / Cube backends
+        # don't inherit the host env, so they skip this step. The full host env
+        # is always restored in the ``finally`` block below.
+        mgr = None
+        _saved = _restrict_env_to_whitelist(policy)
+        try:
+            rt = create_local_workspace_runtime(
+                work_root=self._work_root or str(_HERE.parent / ".ws_work")
+            )
+            mgr, fs, runner = rt.manager(), rt.fs(), rt.runner()
+            ws = await mgr.create_workspace(exec_id)
+
+            # Stage the whole script directory so sibling imports resolve
+            # (run_checks.py does `from parse_diff import ...`).
+            script = Path(script_path)
+            script_dir = script.parent
+            files = [
+                WorkspacePutFileInfo(path=p.name, content=p.read_bytes(), mode=0o644)
+                for p in sorted(script_dir.glob("*.py"))
+            ]
+            if files:
+                await fs.put_files(ws, files)
+
+            spec = WorkspaceRunProgramSpec(
+                cmd=__import__("sys").executable,
+                args=[script.name],
+                env={},  # SDK merges the (already-restricted) os.environ copy
+                cwd="",
+                stdin=json.dumps(input, ensure_ascii=False),
+                timeout=float(policy.timeout_s),
+            )
+            res = await runner.run_program(ws, spec)
+        finally:
+            _restore_env(_saved)  # restore the full host env (tolerates oversized vars)
+            try:
+                if mgr is not None:
+                    await mgr.cleanup(exec_id)
+            except Exception:
+                pass
+
+        return _finalize(
+            res.stdout or "", res.stderr or "", res.exit_code,
+            res.timed_out, res.duration, policy,
+        )
+
+
+# --------------------------------------------------------------------------- #
+# ContainerRuntime — real docker isolation via SDK ContainerClient (G1 fix)
+# --------------------------------------------------------------------------- #
+class ContainerRuntime:
+    """Sandbox backed by the SDK's docker ``ContainerClient``.
+
+    G1 fix: this is now a real adapter (previously a ``NotImplementedError``
+    stub). It provisions a docker container per run, stages the script
+    directory, runs ``python <script>`` with the input JSON on stdin, and maps
+    the result to :class:`RunResult` with the same five safety boundaries as
+    :class:`LocalRuntime`. The container does **not** inherit the host env, so
+    there is no secret-leak surface.
+
+    If docker is unavailable (SDK/daemon missing) it raises
+    :class:`RuntimeUnavailable` from :meth:`ensure_available`, letting the
+    agent fall back to ``LocalRuntime`` per the skill's ``fallback`` config.
+    """
+
+    def __init__(
+        self,
+        policy: SandboxPolicy | None = None,
+        work_root: str | Path | None = None,
+        image: str | None = None,
+    ):
+        self._policy = policy or SandboxPolicy()
+        self._work_root = work_root
+        self._image = image
+
+    def ensure_available(self) -> bool:
+        """Lightweight probe: is the docker backend usable here?"""
+        try:
+            import docker  # noqa: F401  (import fails if SDK extra absent)
+        except Exception as exc:
+            raise RuntimeUnavailable(f"docker SDK not installed: {exc}") from exc
+        try:
+            client = docker.from_env()
+            client.ping()
+        except Exception as exc:
+            raise RuntimeUnavailable(f"docker daemon not reachable: {exc}") from exc
+        return True
+
+    async def run(
+        self, script_path: str, input: dict, policy: SandboxPolicy | None = None
+    ) -> RunResult:
+        policy = policy or self._policy
+        exec_id = f"cr-{uuid.uuid4().hex[:8]}"
+        try:
+            return await self._run(script_path, input, policy, exec_id)
+        except RuntimeUnavailable:
+            raise  # let the agent's fallback logic decide
+        except Exception as exc:  # fail-safe: never crash the pipeline
+            return RunResult(
+                status="failed",
+                stdout="",
+                stderr=str(exc)[:4096],
+                duration_ms=0,
+                exit_code=-1,
+                output_bytes=0,
+                timed_out=False,
+                masked_count=0,
+            )
+
+    async def _run(
+        self, script_path: str, input: dict, policy: SandboxPolicy, exec_id: str
+    ) -> RunResult:
+        try:
+            from trpc_agent_sdk.code_executors.container._container_cli import (
+                CommandArgs,
+                ContainerClient,
+                ContainerConfig,
+            )
+        except Exception as exc:
+            raise RuntimeUnavailable(f"container SDK unavailable: {exc}") from exc
+
+        image = self._image or os.environ.get("CR_CONTAINER_IMAGE") or "python:3-slim"
+        network_mode = os.environ.get("CR_CONTAINER_NETWORK", "none")
+        workdir = "/workspace"
+        client = ContainerClient(
+            ContainerConfig(
+                image=image,
+                host_config={
+                    "working_dir": workdir,
+                    "network_mode": network_mode,
+                    "auto_remove": True,
+                    "command": ["tail", "-f", "/dev/null"],
+                    "stdin": True,
+                },
+            )
+        )
+        try:
+            # Stage the whole script directory into the container. We transfer
+            # each file as base64 on the command line — deliberately NOT via the
+            # SDK's stdin exec path, which has a socket-reuse bug in the vendored
+            # ContainerClient. The no-stdin `exec_run` branch is robust. The
+            # container does not inherit the host env, so no secrets leak in.
+            script = Path(script_path)
+            script_dir = script.parent
+            for p in sorted(script_dir.glob("*.py")):
+                b64 = base64.b64encode(p.read_bytes()).decode("ascii")
+                stage = await client.exec_run(
+                    ["sh", "-c",
+                     f"mkdir -p {workdir} && echo {b64} | base64 -d > {workdir}/{p.name}"],
+                    CommandArgs(timeout=30),
+                )
+                if stage.exit_code != 0:
+                    raise RuntimeError(f"staging {p.name} failed: {stage.stderr}")
+
+            # Stage the JSON input as a file too (avoids the stdin exec bug).
+            in_b64 = base64.b64encode(
+                json.dumps(input, ensure_ascii=False).encode("utf-8")
+            ).decode("ascii")
+            stage_in = await client.exec_run(
+                ["sh", "-c", f"echo {in_b64} | base64 -d > {workdir}/_input.json"],
+                CommandArgs(timeout=30),
+            )
+            if stage_in.exit_code != 0:
+                raise RuntimeError(f"staging input failed: {stage_in.stderr}")
+
+            # Run the checker, feeding the staged input via a stdin redirect
+            # inside the container (no docker-level stdin involved).
+            started = time.monotonic()
+            res = await client.exec_run(
+                ["sh", "-c",
+                 f"python {workdir}/{script.name} < {workdir}/_input.json"],
+                CommandArgs(timeout=float(policy.timeout_s)),
+            )
+            duration = time.monotonic() - started
+            return _finalize(
+                res.stdout or "", res.stderr or "", res.exit_code,
+                res.is_timeout, duration, policy,
+            )
+        finally:
+            try:
+                client._cleanup_container()  # stop + remove
+            except Exception:
+                pass
+
+
+# --------------------------------------------------------------------------- #
+# CubeRuntime — real remote Cube/E2B sandbox via SDK CubeSandboxClient
+# --------------------------------------------------------------------------- #
+class CubeRuntime:
+    """Sandbox backed by the SDK's remote Cube/E2B ``CubeSandboxClient``.
+
+    G1 fix: this is now a real adapter (previously a stub). It opens a remote
+    sandbox, uploads the script directory, runs ``python <script>`` with the
+    input JSON on stdin, and maps the structured result to :class:`RunResult`.
+    The remote sandbox is destroyed after each run.
+
+    Requires the ``[cube]`` extra and credentials. If the extra is missing or
+    credentials are unset, :meth:`ensure_available` raises
+    :class:`RuntimeUnavailable` so the agent falls back to ``LocalRuntime``.
+    """
+
+    def __init__(
+        self,
+        policy: SandboxPolicy | None = None,
+        work_root: str | Path | None = None,
+    ):
+        self._policy = policy or SandboxPolicy()
+        self._work_root = work_root
+
+    def ensure_available(self) -> bool:
+        """Lightweight probe: is the cube backend configured here?"""
+        try:
+            from trpc_agent_sdk.code_executors.cube._sandbox import (  # noqa: F401
+                create_cube_sandbox_client,
+            )
+        except Exception as exc:
+            raise RuntimeUnavailable(f"cube SDK (e2b) unavailable: {exc}") from exc
+        if not os.environ.get("CR_CUBE_API_KEY"):
+            raise RuntimeUnavailable("cube backend not configured (CR_CUBE_API_KEY unset)")
+        if not (os.environ.get("CR_CUBE_TEMPLATE") or os.environ.get("CR_CUBE_SANDBOX_ID")):
+            raise RuntimeUnavailable(
+                "cube backend not configured (need CR_CUBE_TEMPLATE or CR_CUBE_SANDBOX_ID)"
+            )
+        return True
+
+    async def run(
+        self, script_path: str, input: dict, policy: SandboxPolicy | None = None
+    ) -> RunResult:
+        policy = policy or self._policy
+        exec_id = f"cr-{uuid.uuid4().hex[:8]}"
+        try:
+            return await self._run(script_path, input, policy, exec_id)
+        except RuntimeUnavailable:
+            raise
+        except Exception as exc:  # fail-safe: never crash the pipeline
+            return RunResult(
+                status="failed",
+                stdout="",
+                stderr=str(exc)[:4096],
+                duration_ms=0,
+                exit_code=-1,
+                output_bytes=0,
+                timed_out=False,
+                masked_count=0,
+            )
+
+    async def _run(
+        self, script_path: str, input: dict, policy: SandboxPolicy, exec_id: str
+    ) -> RunResult:
+        try:
+            from trpc_agent_sdk.code_executors.cube._sandbox import (
+                create_cube_sandbox_client,
+            )
+            from trpc_agent_sdk.code_executors.cube._types import CubeClientConfig
+        except Exception as exc:
+            raise RuntimeUnavailable(f"cube SDK unavailable: {exc}") from exc
+
+        workdir = "/home/user"
+        cfg = CubeClientConfig(
+            template=os.environ.get("CR_CUBE_TEMPLATE"),
+            api_url=os.environ.get("CR_CUBE_API_URL"),
+            api_key=os.environ.get("CR_CUBE_API_KEY"),
+            sandbox_id=os.environ.get("CR_CUBE_SANDBOX_ID") or None,
+            execute_timeout=float(policy.timeout_s),
+            idle_timeout=300,
+        )
+        client = await create_cube_sandbox_client(cfg)
+        try:
+            # Upload the script directory.
+            script = Path(script_path)
+            script_dir = script.parent
+            for p in sorted(script_dir.glob("*.py")):
+                await client.write_file_bytes(f"{workdir}/{p.name}", p.read_bytes())
+
+            started = time.monotonic()
+            res = await client.commands_run(
+                f"python {workdir}/{script.name}",
+                cwd=workdir,
+                env={},  # remote sandbox never inherits host secrets
+                stdin=json.dumps(input, ensure_ascii=False).encode("utf-8"),
+                timeout=float(policy.timeout_s),
+            )
+            duration = time.monotonic() - started
+            return _finalize(
+                res.stdout or "", res.stderr or "", res.exit_code,
+                res.timed_out, duration, policy,
+            )
+        finally:
+            try:
+                await client.destroy()
+            except Exception:
+                pass
+
+
+# --------------------------------------------------------------------------- #
+# Runtime selection — honor default_runtime / fallback (G1 fix)
+# --------------------------------------------------------------------------- #
+def select_runtime(
+    kind: str,
+    policy: SandboxPolicy | None = None,
+    work_root: str | Path | None = None,
+    image: str | None = None,
+) -> "SandboxRuntime":
+    """Construct a single sandbox runtime by kind (local|container|cube)."""
+    kind = (kind or "local").lower()
+    if kind in ("container", "docker"):
+        return ContainerRuntime(policy=policy, work_root=work_root, image=image)
+    if kind == "cube":
+        return CubeRuntime(policy=policy, work_root=work_root)
+    return LocalRuntime(work_root=work_root)
+
+
+def build_runtime_with_fallback(
+    default_kind: str | None,
+    fallback_kind: str | None,
+    policy: SandboxPolicy | None = None,
+    work_root: str | Path | None = None,
+    image: str | None = None,
+) -> tuple["SandboxRuntime", str]:
+    """Pick the sandbox runtime honoring ``default_runtime``/``fallback``.
+
+    Tries ``default_kind`` first (probing availability); on
+    :class:`RuntimeUnavailable` (docker/cube absent) it transparently falls
+    back to ``fallback_kind`` (typically ``local``). Returns
+    ``(runtime, actual_kind)`` so the caller records which runtime actually
+    executed. If even the fallback is unavailable the raw error propagates —
+    the agent's outer handler then degrades to ``FakeRunner``.
+    """
+    tried: list[str] = []
+    for kind in (default_kind, fallback_kind):
+        if not kind:
+            continue
+        kind = kind.lower()
+        if kind in tried:
+            continue
+        tried.append(kind)
+        try:
+            rt = select_runtime(kind, policy, work_root, image)
+            rt.ensure_available()
+            logger.info("sandbox runtime selected: %s", kind)
+            return rt, kind
+        except RuntimeUnavailable as e:
+            logger.warning(
+                "sandbox runtime %r unavailable (%s); trying fallback", kind, e
+            )
+            continue
+    raise RuntimeUnavailable(
+        f"No sandbox runtime available for default={default_kind!r} "
+        f"fallback={fallback_kind!r}"
+    )

--- a/examples/skills_code_review_agent/agent/telemetry/__init__.py
+++ b/examples/skills_code_review_agent/agent/telemetry/__init__.py
@@ -1,0 +1,12 @@
+# Tencent is pleased to support the open source community by making tRPC-Agent-Python available.
+#
+# Copyright (C) 2026 Tencent. All rights reserved.
+#
+# tRPC-Agent-Python is licensed under Apache-2.0.
+"""Telemetry package — OTel tracing + monitor_summary recorder."""
+from .tracing import TelemetryRecorder
+from .tracing import get_tracer
+from .tracing import init_telemetry
+from .tracing import trace_stage
+
+__all__ = ["init_telemetry", "get_tracer", "trace_stage", "TelemetryRecorder"]

--- a/examples/skills_code_review_agent/agent/telemetry/tracing.py
+++ b/examples/skills_code_review_agent/agent/telemetry/tracing.py
@@ -1,0 +1,127 @@
+# Tencent is pleased to support the open source community by making tRPC-Agent-Python available.
+#
+# Copyright (C) 2026 Tencent. All rights reserved.
+#
+# tRPC-Agent-Python is licensed under Apache-2.0.
+"""Telemetry — OpenTelemetry tracing for the review pipeline (SDK reuse).
+
+Initialises an OTel ``TracerProvider`` and wraps each pipeline stage in a
+span via :func:`trace_stage`. A :class:`TelemetryRecorder` collects per-stage
+durations and exception-type distribution, then folds them into the
+``monitor_summary`` row (total/sandbox duration, exception_types JSON).
+
+The SDK auto-instruments LLM/tool/agent calls when running under its
+standard agent pipeline; this module covers the CR Agent's own pipeline
+stages (L1–L6) with explicit spans + a recorder, since CR Agent is a
+programmatic orchestrator (not an LLM-driven agent loop).
+"""
+from __future__ import annotations
+
+import time
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from dataclasses import field
+from typing import Any
+
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import ConsoleSpanExporter
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+
+_TRACER_NAME = "cr_agent"
+_initialized = False
+
+
+def init_telemetry(exporter: Any | None = None, *, enabled: bool = True) -> None:
+    """Initialise the OTel tracer provider (idempotent).
+
+    ``exporter=None`` defaults to :class:`ConsoleSpanExporter` (spans printed
+    to stdout). Pass a custom exporter (e.g. ``OTLPSpanExporter``) for
+    production. When ``enabled=False`` the global NoOp tracer is kept —
+    :func:`trace_stage` still works but records nothing.
+    """
+    global _initialized
+    if _initialized or not enabled:
+        return
+    provider = TracerProvider()
+    exp = exporter if exporter is not None else ConsoleSpanExporter()
+    provider.add_span_processor(SimpleSpanProcessor(exp))
+    trace.set_tracer_provider(provider)
+    _initialized = True
+
+
+def get_tracer():
+    """Return the CR Agent tracer (NoOp until :func:`init_telemetry`)."""
+    return trace.get_tracer(_TRACER_NAME)
+
+
+@asynccontextmanager
+async def trace_stage(name: str, recorder: "TelemetryRecorder | None" = None):
+    """Wrap a pipeline stage in an OTel span + measure duration.
+
+    On exception, records it on the span (``record_exception`` + ERROR status)
+    and on the recorder's ``exception_types`` tally, then re-raises. The
+    duration (ms) is set as a span attribute and forwarded to the recorder.
+    """
+    tracer = get_tracer()
+    start = time.monotonic()
+    # try/except/finally must live INSIDE the `with span` so attributes and
+    # record_exception are set while the span is still active (before it ends
+    # on context exit).
+    with tracer.start_as_current_span(name) as span:
+        try:
+            yield span
+        except Exception as exc:
+            span.record_exception(exc)
+            span.set_status(trace.Status(trace.StatusCode.ERROR, str(exc)))
+            if recorder is not None:
+                recorder.record_exception(type(exc).__name__)
+            raise
+        finally:
+            duration_ms = int((time.monotonic() - start) * 1000)
+            span.set_attribute("duration_ms", duration_ms)
+            if recorder is not None:
+                recorder.record_stage(name, duration_ms)
+
+
+@dataclass
+class TelemetryRecorder:
+    """Collects per-stage durations + exception distribution for monitor_summary."""
+
+    stages: dict[str, int] = field(default_factory=dict)
+    exceptions: dict[str, int] = field(default_factory=dict)
+    tool_calls: int = 0
+    sandbox_duration_ms: int = 0
+
+    def record_stage(self, name: str, duration_ms: int) -> None:
+        self.stages[name] = duration_ms
+        # Any stage tagged l4/sandbox contributes to sandbox_duration_ms.
+        if "l4" in name or "sandbox" in name:
+            self.sandbox_duration_ms += duration_ms
+
+    def record_exception(self, exc_type: str) -> None:
+        self.exceptions[exc_type] = self.exceptions.get(exc_type, 0) + 1
+
+    def to_monitor_summary(
+        self,
+        finding_count: int = 0,
+        sev_counts: dict[str, int] | None = None,
+        blocks: int = 0,
+    ) -> dict:
+        """Build the ``monitor_summary`` payload from collected telemetry.
+
+        ``exception_types`` is emitted as a dict (the store JSON-encodes it).
+        """
+        sev = sev_counts or {}
+        return {
+            "total_duration_ms": sum(self.stages.values()),
+            "sandbox_duration_ms": self.sandbox_duration_ms,
+            "tool_calls": self.tool_calls,
+            "blocks": blocks,
+            "finding_count": finding_count,
+            "sev_critical": sev.get("critical", 0),
+            "sev_high": sev.get("high", 0),
+            "sev_medium": sev.get("medium", 0),
+            "sev_low": sev.get("low", 0),
+            "exception_types": dict(self.exceptions),
+        }

--- a/examples/skills_code_review_agent/docs/DESIGN.md
+++ b/examples/skills_code_review_agent/docs/DESIGN.md
@@ -1,0 +1,22 @@
+# 方案设计说明（CR Agent）
+
+## Skill 设计
+`skills/code-review` 是一个标准 tRPC-Agent Skill：`SKILL.md` 声明 6 类规则（`security`、`async_errors`、`resource_leak`、`missing_tests`、`sensitive_info`、`db_lifecycle`，已覆盖要求中 6 类问题里的 6 类）与 4 个脚本（`parse_diff` / `run_checks` / `dedupe` / `mask_secrets`）。规则正文为 Markdown 说明，检查逻辑由 `run_checks.py` 基于正则 + AST 实现，纯确定性、可离线、可复现。
+
+## 沙箱隔离策略
+沙箱执行通过 SDK `WorkspaceRuntime` 实现。运行时按 `SKILL.md` 的 `default_runtime`/`fallback` 选择：`ContainerRuntime`（Docker 容器）为默认生产方案，`CubeRuntime`（Cube/E2B 远程）为可选项，`LocalRuntime` 仅作开发 fallback，绝不设为默认。选择失败透明回退并记录真实落地后端。超时 30s、输出上限 1MB、env 白名单（`PATH`/`HOME`/`LANG`）、stdout/stderr 落地前脱敏，五道边界由 `sandbox/policy.py` 强制套用、不可绕过。
+
+## Filter 策略
+`filters/governance.py` 在脚本进入沙箱前做四类前置拦截：高风险命令（`rm -rf`/`sudo`/`eval`/`os.system`+拼接等）、禁止路径（`/etc`、`~/.ssh`、`/proc` 等）、非白名单网络访问、超预算（`>60s` 或 `>1024MB`）。`deny`/`needs_human_review` 不进入沙箱，拦截原因写入 `filter_block` 表与报告。
+
+## 监控字段
+`telemetry/tracing.py` 用 OTel 包裹各阶段，`monitor_summary` 记录：总耗时、沙箱耗时、工具调用次数、拦截次数、finding 数、各 severity 分布、异常类型分布。
+
+## 数据库 schema
+七张表围绕 `review_task`（`task_id` 全局外键）：`input_diff`（变更摘要）、`sandbox_run`（执行证据）、`finding`（含 severity/category/file/line/title/evidence/recommendation/confidence/source 九字段 + bucket 分流）、`filter_block`、`monitor_summary`、`review_report`。基于 SDK `SqlStorage`（SqlAlchemy ORM），`ReviewStore` 为 Protocol，保留切换 SQL 后端空间。
+
+## 去重降噪
+`dedupe.py` 按 `(file, line, category)` 分组，同组取最高 confidence、合并多源；按置信度分流：`findings`(≥0.8) / `warnings`(0.6–0.8) / `needs_human_review`(<0.6)，低置信度绝不混入高置信 findings。
+
+## 安全边界
+除沙箱五边界外，敏感信息经 `mask_secrets`（已知格式 + 香农熵 >4.5）双重识别，报告与落库均脱敏；沙箱异常整体 `except→FakeRunner` 降级，流水线不崩溃。

--- a/examples/skills_code_review_agent/docs/G1_OVERVIEW.md
+++ b/examples/skills_code_review_agent/docs/G1_OVERVIEW.md
@@ -1,0 +1,33 @@
+# G1 修复概述 — 沙箱 runtime 选择对齐 PRD 契约
+
+## 问题（PRD 原则冲突）
+- SKILL.md 声明 `default_runtime: container` / `fallback: local`，但 `agent.py` 真实模式**硬编码 `LocalRuntime()`**，完全无视该契约。
+- `ContainerRuntime` 此前是 `NotImplementedError` stub，生产级容器隔离从未真正接入。
+
+## 修复内容
+### `sandbox/runtime.py`
+- 抽出共享 `_finalize(...)`：脱敏 + 输出截断 + status 映射（`timeout > truncated > failed > ok`），三个后端复用，避免逻辑分叉。
+- `LocalRuntime`（SDK `create_local_workspace_runtime`，进程隔离，作为 fallback，永远 available）保留。
+- `ContainerRuntime` 从 stub → **SDK `ContainerClient` 真实适配**：建 docker 容器 → base64 暂存脚本目录 → `python run_checks.py` + stdin → 映射 `RunResult`。容器内不继承宿主 env，无密钥泄露面。docker 不可用时 `ensure_available()` 抛 `RuntimeUnavailable`。
+- 新增 `CubeRuntime`：**SDK `CubeSandboxClient` 真实适配**（远程 Cube/E2B），`write_file_bytes` 上传 + `commands_run` 执行；缺 `[cube]` extra / 未配 `CR_CUBE_*` 时 `ensure_available()` 抛 `RuntimeUnavailable`。
+- 新增 `RuntimeUnavailable` / `select_runtime(kind)` / `build_runtime_with_fallback(default, fallback, policy)`：先试 default，捕获 `RuntimeUnavailable` 后**透明回退** fallback，返回 `(runtime, actual_kind)`。
+
+### `agent.py`（step5 真实模式）
+- 从 `skill["sandbox_config"]` 读取 `default_runtime` / `fallback` → `build_runtime_with_fallback(...)`。
+- 用返回的 `actual_kind` 落 `sandbox_run.runtime`，DB 记录**真实落地**的后端（`local`/`container`/`cube`）。
+
+### 其他
+- `sandbox/__init__.py` 导出新符号。
+- README 第 3/4/7 节与 `agent.py` 顶部 docstring 同步（不再称 container 为 stub）。
+
+## 验证
+- 真实模式冒烟（`--fixture security --mode real`）：
+  日志 `sandbox runtime 'container' unavailable (docker daemon not reachable); trying fallback` → 回退 `local`，`sandbox_run.runtime=local, status=ok`，pipeline `done`。
+  证明 default→fallback 链路真实生效、且记录真实后端。
+- 新增 `TestRuntimeSelection`（4 用例）锁定选择/回退逻辑（stub 注入，不依赖 docker）。
+- **全量回归 162 用例 0 失败**（原 158 + 新增 4）。
+
+## 剩余 PRD 差距
+- G5：Filter 超预算检查仍 no-op（`gov.decide(..., {})` 传空 budget）。
+- G6：security 规则未用 semgrep（正则+AST 替代，检出达标）。
+- G7：Cube/E2B 已留真实适配，需装 `[cube]` extra + 配 `CR_CUBE_*` 才能启用（§6.2「生产可选」）。

--- a/examples/skills_code_review_agent/docs/PHASE0_OVERVIEW.md
+++ b/examples/skills_code_review_agent/docs/PHASE0_OVERVIEW.md
@@ -1,0 +1,63 @@
+# Phase 0 — 基础设施层交付概览
+
+> 自动代码评审 Agent · Phase 0 (Foundation)
+> 基于 tRPC-Agent Skill 体系 · 完成日期 2026-07-07
+
+## 完成内容
+
+按 `docs/skills_code_review_agent/specs/phase-0-foundation.md` 的契约，落地了 CR Agent 的持久化基础设施层，为 P1–P6 全部后续阶段提供统一的存储接口。
+
+### 交付物
+
+| 文件 | 职责 | 行数 |
+|------|------|------|
+| `examples/skills_code_review_agent/db/__init__.py` | 包导出 `ReviewStore` / `SQLiteStore` | — |
+| `examples/skills_code_review_agent/db/schema.sql` | 七表 DDL + 7 索引，全部 `IF NOT EXISTS` 可重复执行 | ~95 |
+| `examples/skills_code_review_agent/db/storage.py` | `ReviewStore` Protocol + `SQLiteStore` 实现 | ~430 |
+| `examples/skills_code_review_agent/db/init_db.py` | 初始化脚本（CLI 可调用，幂等） | ~115 |
+| `examples/skills_code_review_agent/tests/test_phase0_foundation.py` | Phase 0 验收测试（20 用例） | ~330 |
+
+### 架构落点对照
+
+- **七表 schema**：`review_task` / `input_diff` / `sandbox_run` / `finding` / `filter_block` / `monitor_summary` / `review_report`，围绕 `review_task` 聚合，`task_id` 为全局外键。
+- **复合索引 `idx_finding_dedup (task_id, file, line, category)`**：直接服务 P4 去重查询，O(1) 命中"同文件同行同类"。
+- **`finding.bucket` 三档**：从 schema 层强制低置信度不混入高置信结论。
+- **`sandbox_run.timed_out`**：INTEGER 0/1（SQLite 无原生 bool）。
+- **`finding.confidence`**：REAL（浮点）。
+- **`monitor_summary.exception_types`**：JSON 字符串（如 `{"timeout":2,"oom":1}`）。
+- **外键约束**：每次连接 `PRAGMA foreign_keys = ON`，孤儿 finding 写入被 `IntegrityError` 拦截。
+
+## 关键设计决策
+
+1. **原生 `sqlite3` 而非 SDK 的 SQLAlchemy 抽象**：SDK `storage` 模块是面向 session/memory 的通用重型抽象；CR Agent 的七张业务表用标准库 `sqlite3` + `row_factory = sqlite3.Row` 实现更轻量、更贴合 phase-0 契约，且 `ReviewStore` Protocol 保留了切换 Postgres 的空间。
+2. **`ReviewStore` 为 `runtime_checkable` Protocol**：结构性子类型，`SQLiteStore` 及任何新后端（如 `PostgresStore`）只要实现同方法即满足，上层无感。
+3. **批量 finding 用 `executemany`**：单次评审可能产数百条 finding，提供 `add_findings(task_id, list[dict])` 批量方法，一次 round-trip 写入；同时保留单条 `add_finding` 满足契约。
+4. **`set_monitor_summary` / `set_report` 为 upsert**：与 task 1:1 关系，重复调用替换而非堆叠。
+5. **`get_task` 用分表查询而非巨型 LEFT JOIN**：各子表基数不同，分表查询 + 组装成嵌套 dict，输出更干净稳定。
+6. **`_now_iso` 用 timezone-aware**：`datetime.now(timezone.utc)`，规避 3.12+ `utcnow()` 弃用警告，兼容 python>=3.10。
+
+## 验收结果（DoD 全部达成）
+
+| # | 验收标准 | 状态 | 证据 |
+|---|----------|------|------|
+| 1 | `init_db.py` 能建库建表，重复执行不报错 | ✅ | `test_init_is_idempotent_repeated_runs` + CLI 二次执行 exit=0 |
+| 2 | `create_task` 返回 task_id，`update_task_status` 可改状态 | ✅ | `TestTaskLifecycle` 2 用例 |
+| 3 | 七个 `add_*` / `set_*` 方法可写入对应表 | ✅ | `TestChildWrites` 8 用例（含批量 executemany） |
+| 4 | `get_task(task_id)` 能 join 返回完整记录 | ✅ | `test_full_join_record_shape` 验证七段式结构 |
+| 5 | `SQLiteStore` 实现同一 Protocol，可替换后端 | ✅ | `TestProtocolConformance` + `TestInMemoryStore`（FakeStore 通过 isinstance 校验） |
+
+**测试统计**：20 用例全部通过（0.78s），含外键约束拦截验证。
+
+## 运行方式
+
+```bash
+# 建库（幂等）
+python examples/skills_code_review_agent/db/init_db.py --db-path cr_agent.db
+
+# 跑验收测试
+python examples/skills_code_review_agent/tests/test_phase0_foundation.py
+```
+
+## 下游影响
+
+P1–P6 全部阶段通过 `from db import ReviewStore, SQLiteStore` 获取存储句柄，不直接触碰 SQLite API。后续阶段只需关注业务逻辑（diff 解析、规则引擎、沙箱执行、去重、编排、报告），持久化层已就绪。

--- a/examples/skills_code_review_agent/docs/PHASE1_OVERVIEW.md
+++ b/examples/skills_code_review_agent/docs/PHASE1_OVERVIEW.md
@@ -1,0 +1,85 @@
+# Phase 1 — 输入与 Skill 加载 交付概览
+
+> 自动代码评审 Agent · Phase 1 (Input & Skill loading)
+> 基于 tRPC-Agent Skill 体系 · 完成日期 2026-07-07
+
+## 完成内容
+
+按 `docs/skills_code_review_agent/specs/phase-1-input-skill.md` 契约，实现了 unified diff 解析器与 code-review Skill 加载器，产出结构化 `ChangeSet` 与 `RuleSet`，并将解析结果落库到 Phase 0 的 `input_diff` 表。
+
+### 交付物
+
+| 文件 | 职责 |
+|------|------|
+| `skills/code-review/SKILL.md` | Skill 契约 frontmatter（name/entry/rules/sandbox） |
+| `skills/code-review/scripts/parse_diff.py` | unified diff → `ChangeSet`（数据结构 + 解析器 + CLI） |
+| `skills/code-review/rules/*.md` | 6 类规则骨架（security/async_errors/resource_leak/missing_tests/sensitive_info/db_lifecycle） |
+| `agent.py` | `skill_load()` + 输入采集 + 落库编排 + CLI |
+| `tests/test_phase1_input_skill.py` | Phase 1 验收测试（30 用例） |
+
+### 数据结构（`parse_diff.py`）
+
+```
+ChangeSet
+ └─ files: list[ChangedFile]
+     ├─ path, status(added|modified|deleted), hunks
+     ├─ added_lines / deleted_lines / line_count / hunk_count (property)
+     └─ hunks: list[Hunk]
+         ├─ old_start/new_start/old_count/new_count
+         └─ lines: list[DiffLine]
+             └─ type(add|del|ctx), content, new_line_no(add/ctx 有, del=None)
+```
+
+**行号规则**：`new_line_no` 从 hunk 头 `@@ -a,b +c,d @@` 的 `c` 开始，仅在 add/ctx 行递增，del 行为 `None`。
+
+## 关键设计决策
+
+1. **`skill_load` 扫描文件系统而非读 frontmatter 声明**：rules/scripts 清单来自 `rules/*.md` 和 `scripts/*.py` 的实际磁盘扫描（排序相对路径），frontmatter 只提供 `name` 和 `sandbox_config`。这样 P2/P3/P4 新增脚本时自动出现在清单中，无需同步改 SKILL.md。
+
+2. **零依赖 YAML frontmatter 解析**：环境无 pyyaml。`skill_load` 优先 `import yaml`，失败回退到内置缩进感知解析器（处理标量/块 list/嵌套 dict/`>-` 多行/行内 `[a,b]`/int 推断）。验证了 sandbox_config 的 `timeout_s=30`、`max_output_bytes=1048576` 为 int，`env_whitelist` 为 list。
+
+3. **解析器单遍行迭代 + 状态机**：按 `diff --git` / `--- ` / `+++ ` / `@@ ` 推进状态，避免全量字符串复制（大 diff 性能）。容错跳过 binary/rename/mode-change/meta 行，空 diff 返回空 `ChangeSet`，`@@ -1 +1 @@` 无逗号计数默认 1。
+
+4. **`ChangedFile` 内置统计 property**：`added_lines`/`deleted_lines`/`line_count`/`hunk_count` 直接服务落库，`agent.persist_changeset` 一次性写入 `input_diff`（file_path/sha256/hunk_count/line_count/summary），sha256 基于文件变更内容规范化文本计算，用于去重标识。
+
+5. **三种输入模式统一 `load_diff()`**：
+   - `--diff-file`：读文件
+   - `--repo-path`：`git diff HEAD`（含已暂存，subprocess 容错）
+   - `--fixture`：内置 `clean`/`security` 样本（dry-run 无需真实 diff）
+
+## 验收结果（DoD 全部达成）
+
+| # | 验收标准 | 状态 | 证据 |
+|---|----------|------|------|
+| 1 | `parse_diff` 解析标准 unified diff（文件/hunk/行号） | ✅ | `TestParseDiff` 9 用例 |
+| 2 | add 行 `new_line_no` 正确 | ✅ | `TestParseDiffLineNumbers` 4 用例（含多 hunk 独立、del=None） |
+| 3 | `skill_load` 读 frontmatter 产出 rules+scripts+sandbox_config | ✅ | `TestSkillLoad` 5 用例（含类型断言） |
+| 4 | ChangeSet 落库 input_diff 表 | ✅ | `TestChangeSetPersist` 3 用例 + `get_task` join 验证 |
+| 5 | 支持 --diff-file / --repo-path / fixture | ✅ | `TestInputModes` 6 用例（含真实 git repo 集成） + `TestCLIIntegration` 2 端到端 |
+
+**测试统计**：Phase 1 共 30 用例全部通过（1.7s）；Phase 0 回归 20 用例全过。累计 50 用例 0 失败。
+
+## 运行方式
+
+```bash
+# fixture 模式（dry-run 演示）
+python examples/skills_code_review_agent/agent.py --fixture security --db-path cr.db
+
+# diff 文件模式
+python examples/skills_code_review_agent/agent.py --diff-file my.diff --db-path cr.db
+
+# repo 模式（git diff HEAD）
+python examples/skills_code_review_agent/agent.py --repo-path /path/to/repo --db-path cr.db
+
+# 解析器 CLI（stdin/file → JSON）
+python examples/skills_code_review_agent/skills/code-review/scripts/parse_diff.py < my.diff
+
+# 验收测试
+python examples/skills_code_review_agent/tests/test_phase1_input_skill.py
+```
+
+## 下游影响
+
+- **P2（规则引擎）**：消费 `ChangeSet`，按 6 类 `rules/*.md` 跑静态检查，规则骨架已就位待填充检测逻辑。
+- **P3（沙箱 + Filter）**：消费 `skill_load` 的 `scripts` 清单送入 Filter 门禁，`sandbox_config` 驱动沙箱策略。
+- 落库的 `input_diff` 行已带 sha256/hunk_count/line_count/summary，供 P4 去重与 P6 报告引用。

--- a/examples/skills_code_review_agent/docs/PHASE2_OVERVIEW.md
+++ b/examples/skills_code_review_agent/docs/PHASE2_OVERVIEW.md
@@ -1,0 +1,79 @@
+# Phase 2 — 规则引擎 交付概览
+
+> 自动代码评审 Agent · Phase 2 (Rules engine)
+> 基于 tRPC-Agent Skill 体系 · 完成日期 2026-07-07
+
+## 完成内容
+
+按 `docs/skills_code_review_agent/specs/phase-2-rules-engine.md` 契约，实现了 6 类规则文档（每类≥3 条）、`run_checks.py` 规则匹配引擎（产出 `RawFinding`）和 `mask_secrets.py` 敏感信息脱敏器。本阶段产出的是**未去重、未分流**的原始诊断，交 P4 处理。
+
+### 交付物
+
+| 文件 | 职责 |
+|------|------|
+| `skills/code-review/rules/*.md` | 6 类规则文档，每类含机器可读 ```yaml 规则块（共 22 条规则） |
+| `skills/code-review/scripts/run_checks.py` | `RawFinding` + `load_rules` + `run_checks` + 6 个 checker + AST 增强 + CLI |
+| `skills/code-review/scripts/mask_secrets.py` | `mask_secrets(text)->(masked, count)` + 正则集 + Shannon 熵值 + CLI |
+| `tests/test_phase2_rules_engine.py` | Phase 2 验收测试（40 用例） |
+
+### 规则统计
+
+| 类别 | 规则数 | 检测方式 |
+|------|--------|----------|
+| security | 4 (SEC001-004) | pattern：SQL注入/命令注入/硬编码密钥/不安全反序列化 |
+| sensitive | 6 (SEN001-006) + 熵值 | pattern：AKIA/sk-/ghp_/password/私钥/连接串 + Shannon熵>4.5 |
+| async | 3 (ASY001-003) | ast：gather未await/ClientSession未async with/async函数裸调用 |
+| resource | 3 (RES001-003) | ast：open未with/connect未with/try无finally |
+| db | 3 (DB001-003) | ast：connect未with/cursor未close/begin无rollback |
+| tests | 3 (TST001-003) | diff：新增公开函数/类/路由无对应测试 |
+
+**合计 22 条规则，每类≥3 条，满足 DoD。**
+
+## 关键设计决策
+
+1. **规则文档双格式**：人类可读 Markdown 说明 + ```yaml 机器可读规则块（id/pattern/severity_hint/confidence/type/description）。`run_checks.load_rules` 解析 yaml 块，pattern 预编译为正则。规则文档可读性与机器可读性兼得。
+
+2. **内置 YAML 子集解析器（零依赖）**：环境无 pyyaml，`run_checks._parse_rules_yaml` 专门处理规则文档的 list-of-dict 结构，正确处理单引号 `''` 转义（让含 `["']` 的正则 pattern 能正确解析）、float 推断。优先 `import yaml`，失败回退内置。
+
+3. **只分析 add 行 + confidence 分层控误报**：del 行不报新问题。精确/已知格式命中 `confidence` 0.9+（→P4 findings），启发式 AST/pattern 0.6-0.75（→P4 warnings）。规格意图：低置信让 P4 分流，避免污染高置信结论。
+
+4. **pattern 为主 + AST best-effort 增强**：所有规则都有 pattern 正则（可靠、可测、高性能 re.compile）。async/resource/db 额外做 best-effort AST 分析（`textwrap.dedent` + `ast.parse`，失败静默跳过），确认命中提升 confidence 到 0.8+。diff add 行常不完整，AST 为增强而非依赖。
+
+5. **降误报过滤**：resource/db 的 `open()/connect()` 若 add 行含 `with` 前缀则跳过；async 的 `gather/create_task` 若含 `await` 则跳过。sensitive 的熵值检测对已知格式命中的行去重（token 是已命中 evidence 的子串则不重复报 SEN_ENT）。
+
+6. **missing_tests 跨文件关联**：从所有非测试文件的 add 行提取新增 `def`/`class`，在测试文件（`test_*.py`/`tests?/`）的 add 行里找 `test_<fn>`/`<fn>(` 引用，未命中 → finding。私有（`_` 前缀）不报。
+
+7. **mask_secrets 与 sensitive 规则共享正则**：脱敏器的正则集（AKIA/sk-/ghp_/password/私钥/连接串）与 SEN001-006 一致，确保"检出什么就脱敏什么"。熵值检测共享 `_TOKEN_RE` + `_shannon_entropy`。
+
+## 验收结果（DoD 全部达成）
+
+| # | 验收标准 | 状态 | 证据 |
+|---|----------|------|------|
+| 1 | 6 类规则文档齐全，每类≥3 条 | ✅ | `TestRuleDocs` 4 用例（22 条规则，字段完整） |
+| 2 | run_checks 每类样本检出 | ✅ | security/sensitive/async/resource/db/tests 各类检出用例（含 `with`/`await` 过滤） |
+| 3 | RawFinding 字段齐全，confidence 合理 | ✅ | `TestRawFindingFields` 3 用例（精确≥0.9，启发≤0.75） |
+| 4 | mask_secrets 脱敏 + count 正确 | ✅ | `TestMaskSecrets` 10 用例（6 格式 + 多密钥计数 + 熵值 + 空文本） |
+| 5 | 无问题 diff 产空列表 | ✅ | `TestCleanDiff` 3 用例（clean fixture / trivial diff / 空 changeset） |
+
+**测试统计**：Phase 2 共 40 用例通过（0.13s）；Phase 0/1 回归全过。累计 **90 用例 0 失败**。
+
+## 运行方式
+
+```bash
+# 规则引擎 CLI（diff 文件 → findings JSON）
+python examples/skills_code_review_agent/skills/code-review/scripts/run_checks.py \
+  --skill-dir examples/skills_code_review_agent/skills/code-review \
+  --diff-file my.diff
+
+# 脱敏器 CLI（stdin → 脱敏文本 + count）
+python examples/skills_code_review_agent/skills/code-review/scripts/mask_secrets.py < input.txt
+
+# 验收测试
+python examples/skills_code_review_agent/tests/test_phase2_rules_engine.py
+```
+
+## 下游影响
+
+- **P3（沙箱 + Filter）**：`run_checks.py` 与 `mask_secrets.py` 是沙箱内可执行脚本，`skill_load` 的 `scripts` 清单已自动包含它们；Filter 门禁将审查这些脚本。沙箱输出落地前用 `mask_secrets` 脱敏。
+- **P4（去重结构化）**：消费 `RawFinding` 列表，按 `(file, line, category)` 去重取最高 confidence，按置信度阈值分流到 findings/warnings/needs_human_review。本阶段的 confidence 分层直接服务 P4 分流。
+- `agent.py` 的 `skill_load` 已加 `skill_dir` 字段，P3/P4 可直接定位规则文档与脚本。

--- a/examples/skills_code_review_agent/docs/PHASE7_LLM_OVERVIEW.md
+++ b/examples/skills_code_review_agent/docs/PHASE7_LLM_OVERVIEW.md
@@ -1,0 +1,42 @@
+# Phase 7 — 接入真实 LLM（可选，配置在 `.env`）
+
+## 做了什么
+
+让 Code Review Agent **能够接入真实 LLM 做二次研判**，同时保证：
+**没有真实模型 API Key 时，解析 / 沙箱 / 落库链路（含 `--dry-run`）照常工作，所有测试无 Key 跑通。**
+
+### 新增 `llm/` 包
+- **`llm/config.py`** — `LlmConfig` + `load_llm_config(env_path)`：用 `python-dotenv` 从项目根 `.env` 读取 `LLM_ENABLED` / `LLM_PROVIDER` / `LLM_API_KEY` / `LLM_BASE_URL` / `LLM_MODEL` / `LLM_TEMPERATURE` / `LLM_MAX_TOKENS` / `LLM_TIMEOUT`。
+- **`llm/client.py`** — `RealLlm`（懒加载 `openai.AsyncOpenAI`，**任意 OpenAI 兼容端点**：OpenAI / Azure / 本地 vLLM / 内部网关）+ `FakeLlm`（no-op）+ 工厂 `get_llm_client(enable, env_path)`。**无 Key 或 `LLM_ENABLED=false` → 自动返回 FakeLlm**，绝不实例化真实 client。`_parse_verdicts` 对 code fence / 乱码做容错降级。
+- **`llm/triage.py`** — `LlmTriage.run(dedupe_result, diff_text)`：只研判 `needs_human_review` 低置信度档位。
+  - `false_positive` → 丢弃
+  - `real` → 更新置信度、`source` 打 `llm` 标、模型解释追加进 `recommendation`、按新置信度重新分桶（≥0.8→findings / ≥0.6→warnings）
+  - 调用失败 / 未启用 → 原样返回（**no-op 降级**）
+  - 喂模型前的 diff 先经 `mask_secrets` 脱敏，密钥不外泄
+
+### `agent.py` 接入
+- 新增 CLI：`--enable-llm`（覆盖 `.env`）、`--llm-env`（指定 `.env` 路径）
+- 在 dedupe（step6）与落库（step7）之间插入 **step 6.5 `l5b_llm_triage`**（trace_stage 包裹，`is_enabled=False` 时打印 disabled 并跳过）
+
+### 配置文件
+- `.env`（安全默认值：`LLM_ENABLED=false` + 空 Key）
+- `.env.example`（全量变量 + 注释说明）
+- `README.md` §3 注记 + 新增 **§4.5 LLM 二次研判（可选）**
+
+## 验证
+- **全量回归 175 用例 / 0 失败**（原 162 + 新增 Phase7 13）
+  - 无 Key → FakeLlm、FakeLlm 透传/短路、`_parse_verdicts`（fence/乱码/clamp）、RealLlm 注入 mock 验证提级+丢弃+失败降级+脱敏外发
+- 真实模式冒烟（fixture=security，**无 Key**）：日志 `llm triage: disabled (LLM_ENABLED=false or no API key)`，task done、报告产出、`exceptions={}`
+
+## 用法
+```bash
+# 1. 复制并填写 .env
+cp .env.example .env
+# 编辑：LLM_ENABLED=true，填入 LLM_API_KEY、LLM_BASE_URL、LLM_MODEL
+
+# 2. 跑（.env 启用后自动接真实模型）
+$VENV agent.py --diff-file ./my_change.diff --mode real --db-path ./cr.db
+
+# 或 CLI 临时开启（覆盖 .env）
+$VENV agent.py --fixture security --enable-llm
+```

--- a/examples/skills_code_review_agent/review_report.json
+++ b/examples/skills_code_review_agent/review_report.json
@@ -1,0 +1,103 @@
+{
+  "task_id": "70c2a283fdb8468cac5a31908a348a2c",
+  "1_findings": [
+    {
+      "severity": "high",
+      "category": "security",
+      "file": "app/secret.py",
+      "line": 1,
+      "title": "SEC003: 硬编码密钥 — 密钥类变量直接赋字面量,应从环境变量/密钥管理读取",
+      "evidence": "API_KEY = \"***REDACTED***\"",
+      "recommendation": "使用参数化查询/参数列表替代字符串拼接；密钥从环境变量或密钥管理服务读取",
+      "confidence": 0.8,
+      "source": "rule"
+    },
+    {
+      "severity": "high",
+      "category": "security",
+      "file": "app/secret.py",
+      "line": 2,
+      "title": "SEC003: 硬编码密钥 — 密钥类变量直接赋字面量,应从环境变量/密钥管理读取",
+      "evidence": "TOKEN = \"***REDACTED***\"",
+      "recommendation": "使用参数化查询/参数列表替代字符串拼接；密钥从环境变量或密钥管理服务读取",
+      "confidence": 0.8,
+      "source": "rule"
+    },
+    {
+      "severity": "critical",
+      "category": "sensitive",
+      "file": "app/secret.py",
+      "line": 1,
+      "title": "SEN002: OpenAI API key 明文",
+      "evidence": "API_KEY = \"***REDACTED***\"",
+      "recommendation": "立即轮换该凭证并从代码中移除，改用密钥管理服务注入",
+      "confidence": 0.95,
+      "source": "rule"
+    },
+    {
+      "severity": "critical",
+      "category": "sensitive",
+      "file": "app/secret.py",
+      "line": 2,
+      "title": "SEN003: GitHub personal access token 明文",
+      "evidence": "TOKEN = \"***REDACTED***\"",
+      "recommendation": "立即轮换该凭证并从代码中移除，改用密钥管理服务注入",
+      "confidence": 0.95,
+      "source": "rule"
+    }
+  ],
+  "2_severity_stats": {
+    "critical": 2,
+    "high": 2,
+    "medium": 0,
+    "low": 0
+  },
+  "3_needs_human_review": [],
+  "4_filter_blocks": [],
+  "5_monitor": {
+    "total_duration_ms": 5994,
+    "sandbox_duration_ms": 14,
+    "tool_calls": 0,
+    "blocks": 0,
+    "finding_count": 4,
+    "sev_critical": 2,
+    "sev_high": 2,
+    "sev_medium": 0,
+    "sev_low": 0,
+    "exception_types": {}
+  },
+  "6_sandbox_runs": [
+    {
+      "runtime": "fake",
+      "status": "ok",
+      "duration_ms": 0,
+      "exit_code": 0,
+      "output_bytes": 0,
+      "timed_out": 0,
+      "masked_count": 0
+    }
+  ],
+  "7_recommendations": [
+    {
+      "file": "app/secret.py",
+      "line": 1,
+      "recommendation": "使用参数化查询/参数列表替代字符串拼接；密钥从环境变量或密钥管理服务读取"
+    },
+    {
+      "file": "app/secret.py",
+      "line": 2,
+      "recommendation": "使用参数化查询/参数列表替代字符串拼接；密钥从环境变量或密钥管理服务读取"
+    },
+    {
+      "file": "app/secret.py",
+      "line": 1,
+      "recommendation": "立即轮换该凭证并从代码中移除，改用密钥管理服务注入"
+    },
+    {
+      "file": "app/secret.py",
+      "line": 2,
+      "recommendation": "立即轮换该凭证并从代码中移除，改用密钥管理服务注入"
+    }
+  ],
+  "8_warnings": []
+}

--- a/examples/skills_code_review_agent/review_report.md
+++ b/examples/skills_code_review_agent/review_report.md
@@ -1,0 +1,36 @@
+# Code Review Report — 70c2a283fdb8468cac5a31908a348a2c
+
+## 1. Findings 摘要（4 条）
+- [high] app/secret.py:1 SEC003: 硬编码密钥 — 密钥类变量直接赋字面量,应从环境变量/密钥管理读取 (conf=0.8)
+- [high] app/secret.py:2 SEC003: 硬编码密钥 — 密钥类变量直接赋字面量,应从环境变量/密钥管理读取 (conf=0.8)
+- [critical] app/secret.py:1 SEN002: OpenAI API key 明文 (conf=0.95)
+- [critical] app/secret.py:2 SEN003: GitHub personal access token 明文 (conf=0.95)
+
+## 2. 严重级别统计
+- critical: 2
+- high: 2
+- medium: 0
+- low: 0
+
+## 3. 人工复核项（0 条）
+
+## 4. Filter 拦截摘要（0 条）
+
+## 5. 监控指标
+- total_duration_ms: 5994
+- sandbox_duration_ms: 14
+- tool_calls: 0
+- blocks: 0
+- finding_count: 4
+- exception_types: {}
+
+## 6. 沙箱执行摘要（1 次）
+- fake: status=ok dur=0ms timed_out=0 masked=0
+
+## 7. 可执行修复建议
+- app/secret.py:1: 使用参数化查询/参数列表替代字符串拼接；密钥从环境变量或密钥管理服务读取
+- app/secret.py:2: 使用参数化查询/参数列表替代字符串拼接；密钥从环境变量或密钥管理服务读取
+- app/secret.py:1: 立即轮换该凭证并从代码中移除，改用密钥管理服务注入
+- app/secret.py:2: 立即轮换该凭证并从代码中移除，改用密钥管理服务注入
+
+## 8. Warnings（0 条，低置信度，不混入 findings）

--- a/examples/skills_code_review_agent/run_agent.py
+++ b/examples/skills_code_review_agent/run_agent.py
@@ -1,0 +1,46 @@
+# Tencent is pleased to support the open source community by making tRPC-Agent-Python available.
+#
+# Copyright (C) 2026 Tencent. All rights reserved.
+#
+# tRPC-Agent-Python is licensed under Apache-2.0.
+"""
+Code Review Agent — CLI entry point.
+
+Thin launcher that mirrors the layout of other tRPC-Agent examples:
+``run_agent.py`` (this file) sits at the example root and delegates to the
+real implementation in ``agent/agent.py``. Configuration (including the
+optional LLM integration) is read from the project-root ``.env``.
+
+Examples
+--------
+    # Dry-run on a built-in fixture (no model API, full pipeline):
+    python run_agent.py --fixture security --dry-run
+
+    # Real sandbox run with an LLM second-opinion triage enabled:
+    python run_agent.py --diff-file ./my_change.diff --mode real --enable-llm
+"""
+
+import asyncio
+import sys
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+# Ensure the example root (and thus the ``agent`` package) is importable
+# even when invoked as a bare script.
+_EXAMPLE_ROOT = Path(__file__).resolve().parent
+if str(_EXAMPLE_ROOT) not in sys.path:
+    sys.path.insert(0, str(_EXAMPLE_ROOT))
+
+load_dotenv(_EXAMPLE_ROOT / ".env")
+
+
+def main() -> int:
+    """Parse CLI args and run the orchestration pipeline."""
+    from agent.agent import main as _agent_main
+
+    return _agent_main()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/skills_code_review_agent/skills/code-review/SKILL.md
+++ b/examples/skills_code_review_agent/skills/code-review/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: code-review
+description: >-
+  自动代码评审 Skill,加载 6 类规则与脚本,在沙箱中执行检查并产出结构化 findings。
+version: 1.0.0
+entry: scripts/run_checks.py
+rules:
+  - rules/security.md
+  - rules/async_errors.md
+  - rules/resource_leak.md
+  - rules/missing_tests.md
+  - rules/sensitive_info.md
+  - rules/db_lifecycle.md
+sandbox:
+  default_runtime: container
+  fallback: local
+  timeout_s: 30
+  max_output_bytes: 1048576
+  env_whitelist: [PATH, HOME, LANG]
+---
+
+# code-review Skill
+
+把 `ChangeSet`(unified diff 解析产物)送进沙箱,按 6 类规则做静态检查,
+产出结构化 finding,再由编排层去重、分流、落库。
+
+## 入口
+
+- `scripts/parse_diff.py` —— unified diff → `ChangeSet`(本地 L1 执行)
+- `scripts/run_checks.py` —— `ChangeSet` + `RuleSet` → 原始诊断(沙箱 L4 执行)
+- `scripts/dedupe.py` —— 原始诊断 → 分流后 findings(本地 L5)
+- `scripts/mask_secrets.py` —— 输出落地前脱敏(沙箱输出落地前)
+
+> Phase 1 只落地 `parse_diff.py` 与本契约;`run_checks.py` / `dedupe.py` /
+> `mask_secrets.py` 由 P2/P3/P4 实现。`skill_load` 通过扫描 `scripts/*.py`
+> 收集当前已存在的脚本清单。
+
+## 规则清单
+
+| 规则 | 覆盖问题 | 默认 severity |
+|------|----------|---------------|
+| `rules/security.md` | SQL 注入、命令注入、硬编码密钥、不安全反序列化 | critical / high |
+| `rules/async_errors.md` | 未 await 协程、未处理 rejection、async 资源泄漏 | high / medium |
+| `rules/resource_leak.md` | 未关闭文件/连接、try 无 finally | high / medium |
+| `rules/missing_tests.md` | 新增公开函数无对应测试 | low |
+| `rules/sensitive_info.md` | 明文 API key / token / password | critical |
+| `rules/db_lifecycle.md` | 连接未关闭、事务未提交/回滚、连接池泄漏 | high / medium |
+
+## 沙箱策略
+
+- 默认 `container`,本地仅作 dry-run / 开发 fallback。
+- 超时 30s,输出上限 1MB,env 白名单 `PATH`/`HOME`/`LANG`。
+- 五项安全边界由 `sandbox/policy.py`(P3)强制套用,不可绕过。

--- a/examples/skills_code_review_agent/skills/code-review/rules/async_errors.md
+++ b/examples/skills_code_review_agent/skills/code-review/rules/async_errors.md
@@ -1,0 +1,33 @@
+# async_errors — 异步错误规则
+
+> 覆盖未 await 的协程、未处理 rejection、async 资源泄漏。
+> 检测方式:AST 解析(主)+ 模式匹配(fallback)。diff add 行常不完整,AST 为 best-effort。
+
+## finding 字段约定
+
+- `category`: `async`
+- `source`: `rule`
+- AST 确认 `confidence` 0.8+,模式启发式 0.6-0.7(P4 分流到 warnings)
+
+## 规则
+
+```yaml
+- id: ASY001
+  pattern: '\.create_task\s*\(|asyncio\.gather\s*\('
+  severity_hint: high
+  confidence: 0.65
+  type: ast
+  description: 疑似未 await 的协程任务 — create_task/gather 返回值需 await 或存入 task
+- id: ASY002
+  pattern: 'aiohttp\.ClientSession\s*\(|httpx\.AsyncClient\s*\('
+  severity_hint: high
+  confidence: 0.65
+  type: ast
+  description: async 资源未 async with — ClientSession/AsyncClient 应在 async with 中使用
+- id: ASY003
+  pattern: 'async\s+def\s+([a-zA-Z_][a-zA-Z0-9_]*)\s*\('
+  severity_hint: medium
+  confidence: 0.6
+  type: ast
+  description: async 函数定义 — checker 据此检测同 diff 内对该函数的裸调用(未 await)
+```

--- a/examples/skills_code_review_agent/skills/code-review/rules/db_lifecycle.md
+++ b/examples/skills_code_review_agent/skills/code-review/rules/db_lifecycle.md
@@ -1,0 +1,33 @@
+# db_lifecycle — 数据库生命周期规则
+
+> 覆盖连接未关闭、事务未提交/回滚、连接池泄漏。
+> 检测方式:AST(主)+ 模式匹配(fallback)。
+
+## finding 字段约定
+
+- `category`: `db`
+- `source`: `rule`
+- 连接/游标未关闭 `confidence` 0.7,事务路径 0.65
+
+## 规则
+
+```yaml
+- id: DB001
+  pattern: '(?:engine|conn|connection|db)\.connect\s*\('
+  severity_hint: high
+  confidence: 0.7
+  type: ast
+  description: 数据库连接未用 with — connect() 应在 with 中或显式 close
+- id: DB002
+  pattern: '\.cursor\s*\('
+  severity_hint: medium
+  confidence: 0.65
+  type: ast
+  description: 游标未关闭 — cursor() 应在 with 中或显式 close
+- id: DB003
+  pattern: '\.begin\s*\('
+  severity_hint: high
+  confidence: 0.7
+  type: ast
+  description: 事务未提交/回滚 — begin() 后所有异常路径需 rollback,正常路径需 commit
+```

--- a/examples/skills_code_review_agent/skills/code-review/rules/missing_tests.md
+++ b/examples/skills_code_review_agent/skills/code-review/rules/missing_tests.md
@@ -1,0 +1,33 @@
+# missing_tests — 缺失测试规则
+
+> 覆盖新增公开函数无对应测试的检测。
+> 检测方式:diff 关联分析 — 从 add 行提取新增顶层 `def`(非 `_` 前缀),在同 diff 的测试文件中搜索 `test_<fn>` 或 `<fn>(` 调用,未命中 → finding。
+
+## finding 字段约定
+
+- `category`: `tests`
+- `source`: `rule`
+- `confidence` 0.6(需人工确认是否真需测试),`severity_hint` low → P4 分流到 warnings
+
+## 规则
+
+```yaml
+- id: TST001
+  pattern: 'def\s+([a-zA-Z][a-zA-Z0-9_]*)\s*\('
+  severity_hint: low
+  confidence: 0.6
+  type: diff
+  description: 新增公开函数无对应测试 — 提取 add 行的新 def 名,在测试文件中找 test_<fn>
+- id: TST002
+  pattern: 'class\s+([A-Z][a-zA-Z0-9_]*)\s*(?:\(|:)'
+  severity_hint: low
+  confidence: 0.55
+  type: diff
+  description: 新增公开类无对应测试 — 提取 add 行的新 class 名,在测试文件中找 Test<cls>
+- id: TST003
+  pattern: '\.route\s*\(|@app\.(?:get|post|put|delete|route)'
+  severity_hint: low
+  confidence: 0.5
+  type: diff
+  description: 新增路由/接口端点无测试 — API 端点应有对应集成测试
+```

--- a/examples/skills_code_review_agent/skills/code-review/rules/resource_leak.md
+++ b/examples/skills_code_review_agent/skills/code-review/rules/resource_leak.md
@@ -1,0 +1,33 @@
+# resource_leak — 资源泄漏规则
+
+> 覆盖未关闭文件/连接、try 无 finally。
+> 检测方式:AST + 控制流(主)+ 模式匹配(fallback)。checker 会检查 add 行是否已含 `with` 前缀以降低误报。
+
+## finding 字段约定
+
+- `category`: `resource`
+- `source`: `rule`
+- `with` 缺失命中 `confidence` 0.7,try/finally 启发式 0.6
+
+## 规则
+
+```yaml
+- id: RES001
+  pattern: 'open\s*\('
+  severity_hint: high
+  confidence: 0.7
+  type: ast
+  description: 文件未用 with — open() 调用应放入 with 语句确保关闭
+- id: RES002
+  pattern: '\.connect\s*\('
+  severity_hint: high
+  confidence: 0.7
+  type: ast
+  description: 连接未用 with — connect() 返回的连接/游标应在 with 中或显式 close
+- id: RES003
+  pattern: 'try\s*:'
+  severity_hint: medium
+  confidence: 0.6
+  type: ast
+  description: try 无 finally — 资源在 try 中打开时,异常路径需 finally 释放
+```

--- a/examples/skills_code_review_agent/skills/code-review/rules/security.md
+++ b/examples/skills_code_review_agent/skills/code-review/rules/security.md
@@ -1,0 +1,45 @@
+# security — 安全风险规则
+
+> 覆盖 SQL 注入、命令注入、硬编码密钥、不安全反序列化等高危安全问题。
+> 检测方式:静态模式匹配(本地 L4),沙箱内可叠加 semgrep(P3)。
+
+## finding 字段约定
+
+- `category`: `security`
+- `source`: `rule`(静态) 或 `sandbox`(semgrep)
+- 精确命中 `confidence` 0.9+,启发式 0.6-0.75(P4 分流到 warnings)
+
+## 规则
+
+```yaml
+- id: SEC001
+  pattern: '(?:execute|executemany)\s*\([^)]*\+'
+  severity_hint: critical
+  confidence: 0.9
+  type: pattern
+  description: SQL 注入 — execute() 调用含字符串拼接(+),应改用参数化查询
+- id: SEC002
+  pattern: '(?:os\.system|os\.popen)\s*\([^)]*\+|subprocess\.(?:call|run|Popen)\s*\([^)]*shell\s*=\s*True[^)]*\+'
+  severity_hint: critical
+  confidence: 0.9
+  type: pattern
+  description: 命令注入 — 系统调用拼接外部输入或 shell=True 拼接,应改用参数列表
+- id: SEC003
+  pattern: '(?:API_KEY|SECRET_KEY|ACCESS_KEY|PRIVATE_KEY|TOKEN)\s*=\s*["''][^"'']{8,}["'']'
+  severity_hint: high
+  confidence: 0.8
+  type: pattern
+  description: 硬编码密钥 — 密钥类变量直接赋字面量,应从环境变量/密钥管理读取
+- id: SEC004
+  pattern: 'pickle\.loads?\s*\(|yaml\.load\s*\([^)]*Loader\s*=\s*Loader'
+  severity_hint: high
+  confidence: 0.85
+  type: pattern
+  description: 不安全反序列化 — pickle.loads 或 yaml.load(Loader=Loader) 可执行任意代码,应改用 safe_load
+- id: SEC005
+  pattern: 'verify\s*=\s*False'
+  severity_hint: medium
+  confidence: 0.5
+  type: pattern
+  description: TLS 证书校验被关闭 (verify=False) — 存在中间人攻击风险,需人工确认是否内网有意为之
+```

--- a/examples/skills_code_review_agent/skills/code-review/rules/sensitive_info.md
+++ b/examples/skills_code_review_agent/skills/code-review/rules/sensitive_info.md
@@ -1,0 +1,54 @@
+# sensitive_info — 敏感信息规则
+
+> 覆盖明文 API key / token / password / 私钥 / 连接串。
+> 检测方式:已知前缀正则(精确)+ Shannon 熵值(启发式),与 `mask_secrets.py` 共享同一套正则。
+
+## finding 字段约定
+
+- `category`: `sensitive`
+- `source`: `rule`
+- 已知前缀命中 `confidence` 0.95,熵值命中 0.8
+
+## 规则
+
+```yaml
+- id: SEN001
+  pattern: 'AKIA[0-9A-Z]{16}'
+  severity_hint: critical
+  confidence: 0.95
+  type: pattern
+  description: AWS Access Key ID 明文
+- id: SEN002
+  pattern: 'sk-[a-zA-Z0-9]{20,}'
+  severity_hint: critical
+  confidence: 0.95
+  type: pattern
+  description: OpenAI API key 明文
+- id: SEN003
+  pattern: 'ghp_[a-zA-Z0-9]{36}'
+  severity_hint: critical
+  confidence: 0.95
+  type: pattern
+  description: GitHub personal access token 明文
+- id: SEN004
+  pattern: 'password\s*=\s*["''][^"'']+["'']'
+  severity_hint: critical
+  confidence: 0.85
+  type: pattern
+  description: 明文 password 赋值
+- id: SEN005
+  pattern: '-----BEGIN [A-Z ]*PRIVATE KEY-----'
+  severity_hint: critical
+  confidence: 0.95
+  type: pattern
+  description: 私钥头明文
+- id: SEN006
+  pattern: '(?:postgres|mysql|mongodb)://[^\s/]+:[^\s@/]+@'
+  severity_hint: critical
+  confidence: 0.9
+  type: pattern
+  description: 连接串含明文凭证
+```
+
+> 熵值检测(SEN_ENT):连续 ≥20 字符的高熵串(Shannon entropy > 4.5)且非纯英文单词,
+> 疑似密钥。由 `_check_sensitive` 内置实现,`confidence` 0.8,`severity_hint` critical。

--- a/examples/skills_code_review_agent/skills/code-review/scripts/cr_models.py
+++ b/examples/skills_code_review_agent/skills/code-review/scripts/cr_models.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+# Tencent is pleased to support the open source community by making tRPC-Agent-Python available.
+#
+# Copyright (C) 2026 Tencent. All rights reserved.
+#
+# tRPC-Agent-Python is licensed under Apache-2.0.
+"""Shared, zero-risk data contracts for the code-review Skill.
+
+``Finding`` and ``DedupeResult`` are deliberately defined here — *not* inside
+``dedupe.py`` — so that the agent can build an empty ``DedupeResult`` for a
+blocked stage (Filter deny / needs_human_review, or a skipped parse stage)
+WITHOUT importing ``dedupe.py`` (a filtered Skill script) at all. Importing a
+filtered script's module — even just to grab a dataclass — would defeat the
+pre-execution gate (see ARCHITECTURE.md §7). This module has no side effects
+and imports nothing risky, so it is always safe to import.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from dataclasses import field
+
+
+@dataclass
+class Finding:
+    """One structured finding — the 9-field contract (ARCHITECTURE.md §12)."""
+
+    severity: str  # critical|high|medium|low
+    category: str
+    file: str
+    line: int
+    title: str
+    evidence: str
+    recommendation: str
+    confidence: float
+    source: str  # rule|sandbox|llm|rule+sandbox|...
+
+
+@dataclass
+class DedupeResult:
+    """Triage output — three confidence buckets."""
+
+    findings: list[Finding] = field(default_factory=list)  # confidence >= 0.8
+    warnings: list[Finding] = field(default_factory=list)  # 0.6 <= conf < 0.8
+    needs_human_review: list[Finding] = field(default_factory=list)  # conf < 0.6
+
+    @property
+    def total(self) -> int:
+        return len(self.findings) + len(self.warnings) + len(self.needs_human_review)
+
+    def severity_counts(self) -> dict[str, int]:
+        """Count findings by severity across all three buckets."""
+        counts = {"critical": 0, "high": 0, "medium": 0, "low": 0}
+        for f in (*self.findings, *self.warnings, *self.needs_human_review):
+            counts[f.severity] = counts.get(f.severity, 0) + 1
+        return counts
+
+    def all_with_bucket(self) -> list[tuple[Finding, str]]:
+        """Yield (finding, bucket) for every finding — for storage into the
+        ``finding`` table where ``bucket`` distinguishes the three tiers."""
+        return (
+            [(f, "findings") for f in self.findings]
+            + [(f, "warnings") for f in self.warnings]
+            + [(f, "needs_human_review") for f in self.needs_human_review]
+        )

--- a/examples/skills_code_review_agent/skills/code-review/scripts/dedupe.py
+++ b/examples/skills_code_review_agent/skills/code-review/scripts/dedupe.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+# Tencent is pleased to support the open source community by making tRPC-Agent-Python available.
+#
+# Copyright (C) 2026 Tencent. All rights reserved.
+#
+# tRPC-Agent-Python is licensed under Apache-2.0.
+"""Dedupe + confidence triage (Phase 4, L5).
+
+Takes the raw diagnostics from P2 (rule matching) + P3 (sandbox) and:
+  1. groups by ``(file, line, category)`` — same file/line/category collapses;
+  2. within a group, keeps the highest-``confidence`` finding and merges
+     multi-source reports (``source`` → ``rule+sandbox``, ``severity`` → max);
+  3. triages by ``confidence`` into three buckets:
+     ``findings`` (≥0.8), ``warnings`` (0.6–0.8), ``needs_human_review`` (<0.6);
+  4. assembles the 9-field :class:`Finding`, with evidence masked + truncated
+     and an actionable default recommendation per category.
+
+Same line + different ``category`` is preserved (not merged) — two distinct
+issue types on one line stay as two findings.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from dataclasses import field
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from run_checks import RawFinding
+
+# NOTE: Finding/DedupeResult are defined in ``cr_models.py`` (zero-risk
+# top-level) so the agent can build an empty ``DedupeResult`` for a blocked
+# stage without importing *this* filtered Skill script. mask_secrets is still
+# imported lazily *inside* ``dedupe`` (not at module load) for the same reason.
+# We re-export them here so legacy ``from dedupe import Finding, DedupeResult``
+# imports (tests, etc.) keep working.
+from cr_models import DedupeResult, Finding  # noqa: E402
+
+# severity rank for "take the highest" on multi-source merge
+_SEVERITY_RANK = {"low": 0, "medium": 1, "high": 2, "critical": 3}
+_MAX_SEVERITY = "critical"
+
+# Actionable default recommendations per category (used when the rule didn't
+# supply one — RawFinding has no recommendation field).
+_DEFAULT_RECOMMENDATIONS: dict[str, str] = {
+    "security": "使用参数化查询/参数列表替代字符串拼接；密钥从环境变量或密钥管理服务读取",
+    "sensitive": "立即轮换该凭证并从代码中移除，改用密钥管理服务注入",
+    "async": "为协程调用补 await；异步资源用 async with 管理生命周期",
+    "resource": "将 open()/connect() 放入 with 语句确保异常路径也释放",
+    "db": "连接/游标用 with 管理；事务异常路径加 rollback，正常路径 commit",
+    "tests": "为新增公开函数补充对应 test_<fn> 测试用例",
+}
+
+# Max evidence length kept in the final finding (avoids over-long reports).
+_EVIDENCE_MAX_CHARS = 200
+
+
+def _highest_severity(severities: list[str]) -> str:
+    """Return the most severe from a list (critical > high > medium > low)."""
+    best = "low"
+    best_rank = -1
+    for s in severities:
+        r = _SEVERITY_RANK.get(s, 0)
+        if r > best_rank:
+            best, best_rank = s, r
+    return best
+
+
+def dedupe(raw_findings: "list[RawFinding]") -> DedupeResult:
+    """Dedupe + triage raw diagnostics into three confidence buckets.
+
+    Steps (ARCHITECTURE.md §9):
+      1. group by ``(file, line, category)``;
+      2. within a group keep the highest-confidence finding, merge sources
+         (``rule+sandbox``) and take the max severity;
+      3. mask + truncate evidence;
+      4. triage by confidence into findings / warnings / needs_human_review.
+    """
+    # 1. group by (file, line, category)
+    from mask_secrets import mask_secrets  # lazy: only when dedupe actually runs
+
+    groups: dict[tuple[str, int, str], list] = {}
+    for rf in raw_findings:
+        key = (rf.file, rf.line, rf.category)
+        groups.setdefault(key, []).append(rf)
+
+    # 2. merge each group → one Finding
+    merged: list[Finding] = []
+    for key, group in groups.items():
+        # highest-confidence finding is the "winner" (title/evidence/base)
+        best = max(group, key=lambda f: f.confidence)
+        # multi-source merge: union of sources, max severity
+        sources = sorted({f.source for f in group})
+        source = "+".join(sources) if len(sources) > 1 else sources[0] if sources else "rule"
+        severity = _highest_severity([f.severity_hint for f in group])
+
+        # 3. mask + truncate evidence (P3 sandbox already masked; local rule
+        # evidence may carry secrets — run mask_secrets unconditionally).
+        evidence, _ = mask_secrets(best.evidence or "")
+        if len(evidence) > _EVIDENCE_MAX_CHARS:
+            evidence = evidence[:_EVIDENCE_MAX_CHARS] + "…"
+
+        recommendation = _DEFAULT_RECOMMENDATIONS.get(
+            best.category, "检查并修复该问题"
+        )
+
+        merged.append(
+            Finding(
+                severity=severity,
+                category=best.category,
+                file=best.file,
+                line=best.line,
+                title=best.title,
+                evidence=evidence,
+                recommendation=recommendation,
+                confidence=best.confidence,
+                source=source,
+            )
+        )
+
+    # 4. triage by confidence
+    result = DedupeResult()
+    for f in merged:
+        if f.confidence >= 0.8:
+            result.findings.append(f)
+        elif f.confidence >= 0.6:
+            result.warnings.append(f)
+        else:
+            result.needs_human_review.append(f)
+
+    return result
+
+
+# --------------------------------------------------------------------------- #
+# CLI (stdin JSON list of RawFinding dicts → stdout JSON DedupeResult)
+# --------------------------------------------------------------------------- #
+def _raw_from_dict(d: dict):
+    """Reconstruct a RawFinding-like object from a JSON dict."""
+    from dataclasses import make_dataclass
+
+    RawLike = make_dataclass(
+        "RawLike",
+        ["category", "file", "line", "title", "evidence", "severity_hint",
+         "confidence", "source"],
+        defaults=["rule"],
+    )
+    return RawLike(
+        category=d["category"], file=d["file"], line=d["line"], title=d["title"],
+        evidence=d["evidence"], severity_hint=d["severity_hint"],
+        confidence=d["confidence"], source=d.get("source", "rule"),
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    import json
+    import sys
+
+    data = json.loads(sys.stdin.read())
+    raws = [_raw_from_dict(d) for d in data]
+    res = dedupe(raws)
+    out = {
+        "findings": [f.__dict__ for f in res.findings],
+        "warnings": [f.__dict__ for f in res.warnings],
+        "needs_human_review": [f.__dict__ for f in res.needs_human_review],
+    }
+    print(json.dumps(out, ensure_ascii=False, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/skills_code_review_agent/skills/code-review/scripts/mask_secrets.py
+++ b/examples/skills_code_review_agent/skills/code-review/scripts/mask_secrets.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+# Tencent is pleased to support the open source community by making tRPC-Agent-Python available.
+#
+# Copyright (C) 2026 Tencent. All rights reserved.
+#
+# tRPC-Agent-Python is licensed under Apache-2.0.
+"""Sensitive-information masking (Phase 2).
+
+Replaces known secret formats and high-entropy tokens in arbitrary text with
+``***REDACTED***``. Shared with the ``sensitive_info`` rule set so that
+detection and masking stay in sync.
+
+Regex set (known formats)
+-------------------------
+* ``AKIA[0-9A-Z]{16}``                 — AWS Access Key ID
+* ``sk-[a-zA-Z0-9]{20,}``              — OpenAI API key
+* ``ghp_[a-zA-Z0-9]{36}``              — GitHub personal access token
+* ``password\\s*=\\s*["']...["']``      — plaintext password assignment
+* ``-----BEGIN ... PRIVATE KEY-----``   — private key header
+* ``(postgres|mysql|mongodb)://u:p@``   — connection string with credentials
+
+Entropy detection
+-----------------
+Tokens of ≥20 base64-ish chars with Shannon entropy > 4.5 are treated as
+suspected secrets (catches un-prefixed random keys).
+
+Usage
+-----
+    from mask_secrets import mask_secrets
+    clean, n = mask_secrets(text)
+
+    # CLI:
+    python mask_secrets.py < input.txt          # masked text to stdout, count to stderr
+    python mask_secrets.py input.txt
+"""
+
+from __future__ import annotations
+
+import math
+import re
+import sys
+
+# Known secret formats. Order matters only for readability; each match is
+# replaced before the next runs, so overlapping patterns are fine.
+_KNOWN_PATTERNS: list[re.Pattern] = [
+    re.compile(r"AKIA[0-9A-Z]{16}"),
+    re.compile(r"sk-[a-zA-Z0-9]{20,}"),
+    re.compile(r"ghp_[a-zA-Z0-9]{36}"),
+    re.compile(r"""password\s*=\s*["'][^"']+["']"""),
+    re.compile(r"-----BEGIN [A-Z ]*PRIVATE KEY-----"),
+    re.compile(r"(?:postgres|mysql|mongodb)://[^\s/]+:[^\s@/]+@"),
+]
+
+# Candidate tokens for entropy analysis: long runs of base64/url-safe chars.
+_TOKEN_RE = re.compile(r"[A-Za-z0-9+/=_-]{20,}")
+
+_REDACTED = "***REDACTED***"
+
+# Entropy threshold per spec.
+_ENTROPY_THRESHOLD = 4.5
+
+
+def _shannon_entropy(s: str) -> float:
+    """Shannon entropy (bits/char) of a string — 0 for empty."""
+    if not s:
+        return 0.0
+    freq: dict[str, int] = {}
+    for ch in s:
+        freq[ch] = freq.get(ch, 0) + 1
+    n = len(s)
+    return -sum((f / n) * math.log2(f / n) for f in freq.values())
+
+
+def _mask_known(text: str) -> tuple[str, int]:
+    """Replace all known-format secrets. Returns (masked_text, hit_count)."""
+    count = 0
+    masked = text
+    for pat in _KNOWN_PATTERNS:
+        masked, n = pat.subn(_REDACTED, masked)
+        count += n
+    return masked, count
+
+
+def _mask_entropy(text: str) -> tuple[str, int]:
+    """Replace high-entropy tokens (≥20 chars, entropy > 4.5)."""
+    count = 0
+    out: list[str] = []
+    last = 0
+    for m in _TOKEN_RE.finditer(text):
+        tok = m.group(0)
+        if _shannon_entropy(tok) > _ENTROPY_THRESHOLD:
+            out.append(text[last:m.start()])
+            out.append(_REDACTED)
+            last = m.end()
+            count += 1
+    out.append(text[last:])
+    return "".join(out), count
+
+
+def mask_secrets(text: str) -> tuple[str, int]:
+    """Mask known secrets + high-entropy tokens.
+
+    Returns ``(masked_text, hit_count)`` where hit_count is the total number
+    of redactions (known formats + entropy hits). Known formats are masked
+    first so their long random tails don't double-count via entropy.
+    """
+    if not text:
+        return text, 0
+    masked, n1 = _mask_known(text)
+    masked, n2 = _mask_entropy(masked)
+    return masked, n1 + n2
+
+
+# --------------------------------------------------------------------------- #
+# CLI
+# --------------------------------------------------------------------------- #
+def _read_input(argv: list[str]) -> str:
+    if len(argv) > 1 and argv[1] != "-":
+        with open(argv[1], "r", encoding="utf-8") as fh:
+            return fh.read()
+    return sys.stdin.read()
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = list(sys.argv if argv is None else argv)
+    text = _read_input(argv)
+    masked, count = mask_secrets(text)
+    sys.stdout.write(masked)
+    sys.stderr.write(f"[mask_secrets] redacted {count} secret(s)\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/skills_code_review_agent/skills/code-review/scripts/parse_diff.py
+++ b/examples/skills_code_review_agent/skills/code-review/scripts/parse_diff.py
@@ -1,0 +1,284 @@
+#!/usr/bin/env python3
+# Tencent is pleased to support the open source community by making tRPC-Agent-Python available.
+#
+# Copyright (C) 2026 Tencent. All rights reserved.
+#
+# tRPC-Agent-Python is licensed under Apache-2.0.
+"""Unified-diff parser → ChangeSet (Phase 1, L1).
+
+Parses a standard unified diff (as produced by ``git diff`` / ``diff -u``)
+into a structured :class:`ChangeSet` of files → hunks → lines, preserving
+new-file line numbers so downstream rule engines can pin findings to exact
+locations.
+
+Line-number rule
+----------------
+``new_line_no`` starts at ``c`` from the hunk header ``@@ -a,b +c,d @@``
+and increments on every ``add`` / ``ctx`` line. ``del`` lines carry
+``new_line_no = None`` (they don't exist in the new file).
+
+Tolerates (skips without error): binary files, renames, mode changes,
+``\\ No newline at end of file`` markers. An empty diff yields an empty
+``ChangeSet``.
+
+Usage
+-----
+    from parse_diff import parse_diff, ChangeSet
+    cs = parse_diff(diff_text)
+
+    # CLI (stdin or file path):
+    python parse_diff.py < my.diff
+    python parse_diff.py my.diff          # prints JSON to stdout
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from dataclasses import asdict
+from dataclasses import dataclass
+from dataclasses import field
+from typing import Iterator
+
+# Hunk header: @@ -a,b +c,d @@  (counts are optional, e.g. @@ -1 +1 @@)
+_HUNK_RE = re.compile(r"^@@ -(\d+),?(\d*) \+(\d+),?(\d*) @@")
+
+# diff --git a/foo b/foo
+_GIT_DIFF_RE = re.compile(r"^diff --git a/(.+?) b/(.+)$")
+# --- a/foo  or  --- /dev/null
+_OLD_FILE_RE = re.compile(r"^--- (?:a/)?(.+)$")
+# +++ b/foo  or  +++ /dev/null
+_NEW_FILE_RE = re.compile(r"^\+\+\+ (?:b/)?(.+)$")
+
+
+@dataclass
+class DiffLine:
+    """One line inside a hunk.
+
+    ``new_line_no`` is the 1-based line number in the *new* file. It is set
+    for ``add`` / ``ctx`` lines and ``None`` for ``del`` lines (which only
+    exist in the old file).
+    """
+
+    type: str  # "add" | "del" | "ctx"
+    content: str
+    new_line_no: int | None = None
+
+
+@dataclass
+class Hunk:
+    """One ``@@ -a,b +c,d @@`` block."""
+
+    old_start: int
+    new_start: int
+    old_count: int
+    new_count: int
+    lines: list[DiffLine] = field(default_factory=list)
+
+
+@dataclass
+class ChangedFile:
+    """One file touched by the diff."""
+
+    path: str
+    status: str  # "added" | "modified" | "deleted"
+    hunks: list[Hunk] = field(default_factory=list)
+
+    @property
+    def added_lines(self) -> int:
+        return sum(1 for h in self.hunks for ln in h.lines if ln.type == "add")
+
+    @property
+    def deleted_lines(self) -> int:
+        return sum(1 for h in self.hunks for ln in h.lines if ln.type == "del")
+
+    @property
+    def line_count(self) -> int:
+        """Total diff lines across all hunks (add + del + ctx)."""
+        return sum(len(h.lines) for h in self.hunks)
+
+    @property
+    def hunk_count(self) -> int:
+        return len(self.hunks)
+
+
+@dataclass
+class ChangeSet:
+    """Structured representation of an entire diff."""
+
+    files: list[ChangedFile] = field(default_factory=list)
+
+    @property
+    def file_count(self) -> int:
+        return len(self.files)
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+    def to_json(self, indent: int | None = 2) -> str:
+        return json.dumps(self.to_dict(), ensure_ascii=False, indent=indent)
+
+
+def parse_diff(diff_text: str) -> ChangeSet:
+    """Parse a unified diff string into a :class:`ChangeSet`.
+
+    Robust to git diff variants: binary files, renames, mode changes are
+    skipped without raising. An empty / whitespace-only input returns an
+    empty ``ChangeSet``.
+    """
+    cs = ChangeSet()
+    if not diff_text or not diff_text.strip():
+        return cs
+
+    # Line iterator — one pass, no full copies. Keep trailing newline stripped
+    # so the diff-line sigils (+/-/space) are at column 0.
+    lines = diff_text.splitlines()
+    cur_file: ChangedFile | None = None
+    cur_hunk: Hunk | None = None
+    new_line_no = 0
+    # Track whether the current file has real content hunks vs. only meta
+    # lines (binary/rename/mode) — meta-only files are dropped at the end.
+    file_has_hunks = False
+
+    def _flush_hunk() -> None:
+        nonlocal cur_hunk
+        if cur_hunk is not None and cur_file is not None:
+            cur_file.hunks.append(cur_hunk)
+            cur_hunk = None
+
+    def _flush_file() -> None:
+        nonlocal cur_file
+        _flush_hunk()
+        if cur_file is not None and (file_has_hunks or cur_file.hunks):
+            cs.files.append(cur_file)
+        cur_file = None
+
+    for raw in lines:
+        # --- file boundary: diff --git a/x b/x ---
+        m = _GIT_DIFF_RE.match(raw)
+        if m:
+            _flush_file()
+            # Use the b/ path as the canonical new path; status decided later
+            # when we see --- / +++ lines.
+            cur_file = ChangedFile(path=m.group(2), status="modified")
+            file_has_hunks = False
+            continue
+
+        # --- old file line: --- a/x  /  --- /dev/null ---
+        if cur_file is not None and raw.startswith("--- "):
+            m = _OLD_FILE_RE.match(raw)
+            if m and m.group(1) == "/dev/null":
+                cur_file.status = "added"
+            continue
+
+        # --- new file line: +++ b/x  /  +++ /dev/null ---
+        if cur_file is not None and raw.startswith("+++ "):
+            m = _NEW_FILE_RE.match(raw)
+            if m:
+                if m.group(1) == "/dev/null":
+                    cur_file.status = "deleted"
+                else:
+                    # Prefer the explicit +++ b/path over the git header path.
+                    cur_file.path = m.group(1)
+            continue
+
+        # --- hunk header: @@ -a,b +c,d @@ ---
+        m = _HUNK_RE.match(raw)
+        if m and cur_file is not None:
+            _flush_hunk()
+            old_start = int(m.group(1))
+            new_start = int(m.group(3))
+            old_count = int(m.group(2)) if m.group(2) else 1
+            new_count = int(m.group(4)) if m.group(4) else 1
+            cur_hunk = Hunk(
+                old_start=old_start,
+                new_start=new_start,
+                old_count=old_count,
+                new_count=new_count,
+            )
+            new_line_no = new_start
+            file_has_hunks = True
+            continue
+
+        # --- inside a hunk ---
+        if cur_hunk is not None:
+            # add line
+            if raw.startswith("+"):
+                cur_hunk.lines.append(
+                    DiffLine("add", raw[1:], new_line_no)
+                )
+                new_line_no += 1
+            elif raw.startswith("-"):
+                cur_hunk.lines.append(DiffLine("del", raw[1:], None))
+            elif raw.startswith(" "):
+                cur_hunk.lines.append(
+                    DiffLine("ctx", raw[1:], new_line_no)
+                )
+                new_line_no += 1
+            elif raw.startswith("\\"):
+                # "\ No newline at end of file" — meta marker, skip.
+                continue
+            else:
+                # Unexpected line inside a hunk (e.g. truncated); stop hunk.
+                _flush_hunk()
+            continue
+
+        # --- meta lines outside any hunk (tolerate & skip) ---
+        # Binary files a/x b/x differ
+        # rename from / rename to / old mode / new mode / new file mode /
+        # deleted file mode / index abc..def 100644 / similarity index ...
+        if cur_file is not None and _is_meta_line(raw):
+            continue
+
+        # A "+++ b/foo" with no preceding "diff --git" (simplified diff) —
+        # start a file lazily so we still parse header-less diffs.
+        if cur_file is None and raw.startswith("+++ "):
+            cur_file = ChangedFile(path="unknown", status="modified")
+            file_has_hunks = False
+            m = _NEW_FILE_RE.match(raw)
+            if m and m.group(1) != "/dev/null":
+                cur_file.path = m.group(1)
+            continue
+
+    _flush_file()
+    return cs
+
+
+def _is_meta_line(raw: str) -> bool:
+    """True for git meta lines that carry no source hunks (skip gracefully)."""
+    return (
+        raw.startswith("Binary files")
+        or raw.startswith("rename from")
+        or raw.startswith("rename to")
+        or raw.startswith("old mode")
+        or raw.startswith("new mode")
+        or raw.startswith("new file mode")
+        or raw.startswith("deleted file mode")
+        or raw.startswith("similarity index")
+        or raw.startswith("dissimilarity index")
+        or raw.startswith("copy from")
+        or raw.startswith("copy to")
+        or raw.startswith("index ")
+    )
+
+
+# --------------------------------------------------------------------------- #
+# CLI
+# --------------------------------------------------------------------------- #
+def _read_input(argv: list[str]) -> str:
+    if len(argv) > 1 and argv[1] not in ("-",):
+        with open(argv[1], "r", encoding="utf-8") as fh:
+            return fh.read()
+    return sys.stdin.read()
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = list(sys.argv if argv is None else argv)
+    cs = parse_diff(_read_input(argv))
+    print(cs.to_json())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/skills_code_review_agent/skills/code-review/scripts/run_checks.py
+++ b/examples/skills_code_review_agent/skills/code-review/scripts/run_checks.py
@@ -1,0 +1,657 @@
+#!/usr/bin/env python3
+# Tencent is pleased to support the open source community by making tRPC-Agent-Python available.
+#
+# Copyright (C) 2026 Tencent. All rights reserved.
+#
+# tRPC-Agent-Python is licensed under Apache-2.0.
+"""Rule engine — ChangeSet → raw findings (Phase 2, L4).
+
+Loads the six rule documents (``rules/*.md`` YAML blocks) and matches them
+against the **add lines** of a :class:`ChangeSet`, emitting a list of
+:class:`RawFinding`. Output is deliberately un-deduped and un-bucketed —
+that is Phase 4's job. This module only produces raw diagnostics with a
+confidence hint so P4 can triage.
+
+Design
+------
+* Only ``add`` lines are analysed — deleted code raises no new issues.
+* Each rule carries ``id`` / ``pattern`` / ``severity_hint`` / ``confidence``
+  / ``type`` (``pattern`` | ``ast`` | ``diff``).
+* ``pattern`` rules: compiled regex matched per add line (fast, reliable).
+* ``ast`` rules: pattern match first, plus a best-effort ``ast`` parse of the
+  joined add lines for confirmation (skipped silently on syntax errors —
+  diff fragments are often incomplete).
+* ``diff`` rules (missing_tests): cross-file association analysis.
+* ``sensitive`` adds Shannon-entropy detection for un-prefixed high-entropy
+  tokens (shares logic with ``mask_secrets``).
+* Confidence: exact/known-format 0.9+, heuristic 0.6-0.75 (P4 routes low
+  confidence to ``warnings`` to control false positives).
+
+Usage
+-----
+    from run_checks import run_checks, load_rules
+    rules = load_rules(skill_dir, rule_paths)
+    findings = run_checks(changeset, {"_rules": rules})
+
+    # CLI (stdin JSON ChangeSet → stdout JSON findings):
+    python run_checks.py --skill-dir skills/code-review < changeset.json
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import re
+import sys
+import textwrap
+from dataclasses import asdict
+from dataclasses import dataclass
+from dataclasses import field
+from pathlib import Path
+from typing import Callable
+
+from mask_secrets import _TOKEN_RE
+from mask_secrets import _shannon_entropy
+from parse_diff import ChangeSet
+from parse_diff import parse_diff
+
+# --------------------------------------------------------------------------- #
+# RawFinding
+# --------------------------------------------------------------------------- #
+@dataclass
+class RawFinding:
+    """One raw diagnostic, pre-dedup / pre-bucket.
+
+    ``severity_hint`` and ``confidence`` are rule suggestions; the final
+    ``severity`` and ``bucket`` are decided in Phase 4.
+    """
+
+    category: str  # security|async|resource|tests|sensitive|db
+    file: str
+    line: int
+    title: str
+    evidence: str
+    severity_hint: str  # critical|high|medium|low
+    confidence: float  # 0.0-1.0
+    source: str = "rule"
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+# --------------------------------------------------------------------------- #
+# Rule document loading
+# --------------------------------------------------------------------------- #
+# rule file stem → finding category
+_CATEGORY_MAP = {
+    "security": "security",
+    "async_errors": "async",
+    "resource_leak": "resource",
+    "missing_tests": "tests",
+    "sensitive_info": "sensitive",
+    "db_lifecycle": "db",
+}
+
+_YAML_BLOCK_RE = re.compile(r"```yaml\n(.*?)```", re.DOTALL)
+
+
+def _category_from_path(rel_path: str) -> str:
+    stem = Path(rel_path).stem
+    return _CATEGORY_MAP.get(stem, stem)
+
+
+def _extract_yaml_block(doc: str) -> str:
+    """Return the first ```yaml ... ``` fenced block in a rule doc (or '')."""
+    m = _YAML_BLOCK_RE.search(doc)
+    return m.group(1) if m else ""
+
+
+def _coerce_scalar(val: str):
+    """Coerce a YAML scalar (single-quoted with '' escape, float, or raw)."""
+    if len(val) >= 2 and val[0] == "'" and val[-1] == "'":
+        return val[1:-1].replace("''", "'")
+    if len(val) >= 2 and val[0] == '"' and val[-1] == '"':
+        return val[1:-1]
+    try:
+        return float(val)
+    except ValueError:
+        pass
+    return val
+
+
+def _parse_rules_yaml(text: str) -> list[dict]:
+    """Parse a rule-doc YAML block (a list of rule dicts).
+
+    Focused parser for the rule-document shape: a top-level list whose items
+    are indented ``key: value`` pairs. Handles single-quoted strings with
+    ``''`` escapes so regex patterns containing quotes parse correctly.
+    """
+    rules: list[dict] = []
+    cur: dict | None = None
+    item_indent: int | None = None
+    for raw in text.splitlines():
+        if not raw.strip() or raw.strip().startswith("#"):
+            continue
+        stripped = raw.lstrip(" ")
+        indent = len(raw) - len(stripped)
+        if stripped.startswith("- "):
+            if cur is not None:
+                rules.append(cur)
+            cur = {}
+            item_indent = indent
+            cur.update(_parse_kv(stripped[2:].strip()))
+        elif cur is not None and item_indent is not None and indent > item_indent:
+            cur.update(_parse_kv(stripped))
+    if cur is not None:
+        rules.append(cur)
+    return rules
+
+
+def _parse_kv(s: str) -> dict:
+    if ":" not in s:
+        return {}
+    key, _, val = s.partition(":")
+    return {key.strip(): _coerce_scalar(val.strip())}
+
+
+def load_rules(skill_dir: str | Path, rule_paths: list[str]) -> dict[str, list[dict]]:
+    """Load all rule docs under ``skill_dir`` → {category: [rule_dict, ...]}.
+
+    Each rule dict has: id, pattern, severity_hint, confidence, type,
+    description.
+    """
+    skill_dir = Path(skill_dir)
+    by_cat: dict[str, list[dict]] = {}
+    for rel in rule_paths:
+        cat = _category_from_path(rel)
+        doc_path = skill_dir / rel
+        if not doc_path.exists():
+            continue
+        doc = doc_path.read_text(encoding="utf-8")
+        block = _extract_yaml_block(doc)
+        rules = _parse_rules_yaml(block) if block else []
+        by_cat.setdefault(cat, []).extend(rules)
+    return by_cat
+
+
+def _compile_rules(rules: list[dict]) -> list[tuple[dict, re.Pattern]]:
+    """Compile each rule's ``pattern`` to a regex; skip invalid patterns."""
+    out = []
+    for r in rules:
+        pat = r.get("pattern")
+        if not pat:
+            continue
+        try:
+            out.append((r, re.compile(pat)))
+        except re.error:
+            continue
+    return out
+
+
+# --------------------------------------------------------------------------- #
+# Shared helpers
+# --------------------------------------------------------------------------- #
+def _add_lines(file) -> list[tuple[int, str]]:
+    """Collect (new_line_no, content) for every add line in a ChangedFile."""
+    out = []
+    for hunk in file.hunks:
+        for ln in hunk.lines:
+            if ln.type == "add" and ln.new_line_no is not None:
+                out.append((ln.new_line_no, ln.content))
+    return out
+
+
+def _pattern_findings(
+    file_path: str,
+    add_lines: list[tuple[int, str]],
+    compiled: list[tuple[dict, re.Pattern]],
+    category: str,
+    *,
+    line_filter: Callable[[str, str, dict], bool] | None = None,
+) -> list[RawFinding]:
+    """Match compiled rules against add lines → RawFindings.
+
+    ``line_filter(content, match_text, rule)`` may return False to suppress a
+    match (used to drop ``with open(...)`` from the open()-leak rule, etc.).
+    """
+    findings: list[RawFinding] = []
+    for rule, pat in compiled:
+        for line_no, content in add_lines:
+            m = pat.search(content)
+            if not m:
+                continue
+            if line_filter and not line_filter(content, m.group(0), rule):
+                continue
+            rid = rule.get("id", category)
+            findings.append(
+                RawFinding(
+                    category=category,
+                    file=file_path,
+                    line=line_no,
+                    title=f"{rid}: {rule.get('description', '')}".strip(": ").strip(),
+                    evidence=content.strip(),
+                    severity_hint=str(rule.get("severity_hint", "medium")),
+                    confidence=float(rule.get("confidence", 0.6)),
+                    source="rule",
+                )
+            )
+    return findings
+
+
+# --------------------------------------------------------------------------- #
+# Checkers
+# --------------------------------------------------------------------------- #
+def _has_with_prefix(content: str) -> bool:
+    """True if the add line opens a `with` block (resource is managed)."""
+    s = content.lstrip()
+    return s.startswith("with ") or s.startswith("with\t") or " with " in content
+
+
+def _has_await(content: str) -> bool:
+    s = content.lstrip()
+    return s.startswith("await ") or "await " in content
+
+
+def check_security(file_path, add_lines, rules):
+    compiled = _compile_rules(rules)
+    return _pattern_findings(file_path, add_lines, compiled, "security")
+
+
+def check_sensitive(file_path, add_lines, rules):
+    findings = _pattern_findings(file_path, add_lines, _compile_rules(rules), "sensitive")
+    # Entropy detection for un-prefixed high-entropy tokens.
+    for line_no, content in add_lines:
+        # evidence of known-format hits on this line — used to suppress
+        # duplicate entropy findings for tokens already covered.
+        line_evidence = [
+            f.evidence for f in findings
+            if f.line == line_no and f.file == file_path
+        ]
+        for m in _TOKEN_RE.finditer(content):
+            tok = m.group(0)
+            if _shannon_entropy(tok) <= 4.5:
+                continue
+            # Skip if this token is already covered by a known-format finding.
+            if any(tok in ev for ev in line_evidence):
+                continue
+            findings.append(
+                RawFinding(
+                    category="sensitive",
+                    file=file_path,
+                    line=line_no,
+                    title="SEN_ENT: 高熵字符串疑似密钥 (entropy > 4.5)",
+                    evidence=content.strip(),
+                    severity_hint="critical",
+                    confidence=0.8,
+                    source="rule",
+                )
+            )
+            break  # one entropy finding per line is enough
+    return findings
+
+
+def check_async(file_path, add_lines, rules):
+    compiled = _compile_rules(rules)
+
+    def _filter(content, _match, rule):
+        # ASY001/ASY002: suppress if the call is already awaited.
+        if rule.get("id") in ("ASY001", "ASY002") and _has_await(content):
+            return False
+        return True
+
+    findings = _pattern_findings(file_path, add_lines, compiled, "async", line_filter=_filter)
+    findings.extend(_ast_async(file_path, add_lines))
+    return findings
+
+
+def check_resource(file_path, add_lines, rules):
+    compiled = _compile_rules(rules)
+
+    def _filter(content, _match, rule):
+        # RES001/RES002: suppress if the call sits inside a `with` line.
+        if rule.get("id") in ("RES001", "RES002") and _has_with_prefix(content):
+            return False
+        return True
+
+    findings = _pattern_findings(file_path, add_lines, compiled, "resource", line_filter=_filter)
+    findings.extend(_ast_resource(file_path, add_lines))
+    return findings
+
+
+def check_db(file_path, add_lines, rules):
+    compiled = _compile_rules(rules)
+
+    def _filter(content, _match, rule):
+        if rule.get("id") in ("DB001", "DB002") and _has_with_prefix(content):
+            return False
+        return True
+
+    findings = _pattern_findings(file_path, add_lines, compiled, "db", line_filter=_filter)
+    findings.extend(_ast_db(file_path, add_lines))
+    return findings
+
+
+def check_tests(changeset, rules):
+    """Cross-file: new public def/class with no matching test_* reference."""
+    findings: list[RawFinding] = []
+    # Collect new public names and their locations.
+    new_defs: list[tuple[str, int, str]] = []  # (name, line, file)
+    new_classes: list[tuple[str, int, str]] = []
+    test_refs: set[str] = set()
+    has_test_file = False
+    for f in changeset.files:
+        is_test = bool(re.search(r"(^|/)(test_|_test\.py$|tests?/)", f.path))
+        if is_test:
+            has_test_file = True
+        for line_no, content in _add_lines(f):
+            for m in re.finditer(r"def\s+([a-zA-Z][a-zA-Z0-9_]*)\s*\(", content):
+                name = m.group(1)
+                if is_test:
+                    test_refs.add(name)
+                elif not name.startswith("_"):
+                    new_defs.append((name, line_no, f.path))
+            for m in re.finditer(r"class\s+([A-Z][a-zA-Z0-9_]*)\s*(?:\(|:)", content):
+                name = m.group(1)
+                if is_test:
+                    test_refs.add(name)
+                elif not name.startswith("_"):
+                    new_classes.append((name, line_no, f.path))
+            # record test_<fn> / <fn>( references inside test files
+            if is_test:
+                for m in re.finditer(r"\b(test_)?([a-zA-Z][a-zA-Z0-9_]*)\s*\(", content):
+                    test_refs.add(m.group(2))
+
+    rule = rules[0] if rules else {}
+    rid = rule.get("id", "TST001")
+    conf = float(rule.get("confidence", 0.6))
+    for name, line_no, fpath in new_defs:
+        covered = f"test_{name}" in test_refs or name in test_refs
+        if not covered:
+            findings.append(
+                RawFinding(
+                    category="tests",
+                    file=fpath,
+                    line=line_no,
+                    title=f"{rid}: 新增公开函数 {name}() 无对应测试",
+                    evidence=f"def {name}(",
+                    severity_hint=str(rule.get("severity_hint", "low")),
+                    confidence=conf,
+                    source="rule",
+                )
+            )
+    for name, line_no, fpath in new_classes:
+        covered = f"Test{name}" in test_refs or name in test_refs
+        if not covered:
+            findings.append(
+                RawFinding(
+                    category="tests",
+                    file=fpath,
+                    line=line_no,
+                    title=f"{rid}: 新增公开类 {name} 无对应测试",
+                    evidence=f"class {name}",
+                    severity_hint=str(rule.get("severity_hint", "low")),
+                    confidence=conf,
+                    source="rule",
+                )
+            )
+    return findings
+
+
+# --------------------------------------------------------------------------- #
+# AST enhancements (best-effort)
+# --------------------------------------------------------------------------- #
+def _try_parse(add_lines):
+    """Join + dedent add lines, attempt ast.parse. Return tree or None."""
+    src = "\n".join(content for _, content in add_lines)
+    src = textwrap.dedent(src)
+    try:
+        return ast.parse(src)
+    except SyntaxError:
+        return None
+
+
+def _calls_not_in_with(tree, func_pred):
+    """Yield (lineno, func_name) for Call nodes whose func matches and that
+    are NOT inside a With block."""
+    in_with = set()
+
+    class _Walker(ast.NodeVisitor):
+        def __init__(self):
+            self.hits = []
+
+        def visit_With(self, node):
+            for child in ast.walk(node):
+                if child is not node:
+                    in_with.add(id(child))
+            self.generic_visit(node)
+
+        def visit_Call(self, node):
+            name = _call_name(node)
+            if name and func_pred(name) and id(node) not in in_with:
+                # node.lineno is 1-based within the joined source; map back via
+                # the order of add_lines. We keep lineno as-is for hinting.
+                self.hits.append((node.lineno, name))
+            self.generic_visit(node)
+
+    w = _Walker()
+    w.visit(tree)
+    return w.hits
+
+
+def _call_name(node) -> str | None:
+    """Best-effort function name from a Call node (Name or Attribute)."""
+    f = node.func
+    if isinstance(f, ast.Name):
+        return f.id
+    if isinstance(f, ast.Attribute):
+        return f.attr
+    return None
+
+
+def _ast_resource(file_path, add_lines):
+    tree = _try_parse(add_lines)
+    if tree is None:
+        return []
+    out = []
+    for _lineno, name in _calls_not_in_with(tree, lambda n: n in ("open", "connect")):
+        out.append(
+            RawFinding(
+                category="resource",
+                file=file_path,
+                line=add_lines[0][0] if add_lines else 0,
+                title=f"RES-AST: {name}() 调用未在 with 中 (AST 确认)",
+                evidence=f"{name}(",
+                severity_hint="high",
+                confidence=0.82,
+                source="rule",
+            )
+        )
+    return out
+
+
+def _ast_db(file_path, add_lines):
+    tree = _try_parse(add_lines)
+    if tree is None:
+        return []
+    out = []
+    for _lineno, name in _calls_not_in_with(tree, lambda n: n in ("connect", "cursor")):
+        out.append(
+            RawFinding(
+                category="db",
+                file=file_path,
+                line=add_lines[0][0] if add_lines else 0,
+                title=f"DB-AST: {name}() 调用未在 with 中 (AST 确认)",
+                evidence=f"{name}(",
+                severity_hint="high",
+                confidence=0.82,
+                source="rule",
+            )
+        )
+    return out
+
+
+def _ast_async(file_path, add_lines):
+    """Detect async-def names that are called without await in the add lines."""
+    tree = _try_parse(add_lines)
+    if tree is None:
+        return []
+    # Collect async def names.
+    async_names = {
+        n.name
+        for n in ast.walk(tree)
+        if isinstance(n, (ast.AsyncFunctionDef,)) and not n.name.startswith("_")
+    }
+    if not async_names:
+        return []
+    awaited = set()
+
+    class _Walker(ast.NodeVisitor):
+        def visit_Await(self, node):
+            for c in ast.walk(node.value):
+                if isinstance(c, ast.Call):
+                    nm = _call_name(c)
+                    if nm:
+                        awaited.add(nm)
+            self.generic_visit(node)
+
+        def visit_Call(self, node):
+            nm = _call_name(node)
+            # A bare call to an async name (not awaited) is suspicious.
+            if nm in async_names and nm not in awaited:
+                self.hits.append((node.lineno, nm))
+            self.generic_visit(node)
+
+    w = _Walker()
+    w.hits = []
+    w.visit(tree)
+    out = []
+    for _lineno, nm in w.hits:
+        out.append(
+            RawFinding(
+                category="async",
+                file=file_path,
+                line=add_lines[0][0] if add_lines else 0,
+                title=f"ASY-AST: async 函数 {nm}() 疑似未 await (AST 确认)",
+                evidence=f"{nm}(",
+                severity_hint="high",
+                confidence=0.8,
+                source="rule",
+            )
+        )
+    return out
+
+
+# --------------------------------------------------------------------------- #
+# run_checks
+# --------------------------------------------------------------------------- #
+_CHECKERS_PATTERN: dict[str, Callable] = {
+    "security": check_security,
+    "sensitive": check_sensitive,
+    "async": check_async,
+    "resource": check_resource,
+    "db": check_db,
+}
+
+
+def run_checks(changeset: ChangeSet, ruleset: dict) -> list[RawFinding]:
+    """Match all rules against a ChangeSet's add lines → RawFindings.
+
+    ``ruleset`` may be either:
+    * the dict returned by ``skill_load`` (must contain ``skill_dir`` and
+      ``rules``), or
+    * a dict with a pre-loaded ``"_rules"`` key (handy for tests).
+    """
+    if "_rules" in ruleset:
+        rules_by_cat = ruleset["_rules"]
+    else:
+        skill_dir = ruleset.get("skill_dir") or ruleset.get("_skill_dir")
+        rule_paths = ruleset.get("rules", [])
+        if not skill_dir or not rule_paths:
+            return []
+        rules_by_cat = load_rules(skill_dir, rule_paths)
+
+    findings: list[RawFinding] = []
+    for f in changeset.files:
+        add_lines = _add_lines(f)
+        if not add_lines:
+            continue
+        for cat, checker in _CHECKERS_PATTERN.items():
+            findings.extend(checker(f.path, add_lines, rules_by_cat.get(cat, [])))
+
+    # Cross-file tests check runs on the whole changeset.
+    findings.extend(check_tests(changeset, rules_by_cat.get("tests", [])))
+    return findings
+
+
+# --------------------------------------------------------------------------- #
+# CLI
+# --------------------------------------------------------------------------- #
+def _build_arg_parser():
+    import argparse
+
+    p = argparse.ArgumentParser(description="Run code-review rules on a ChangeSet.")
+    p.add_argument("--skill-dir", default=None, help="code-review skill directory (optional if rules come via stdin)")
+    p.add_argument(
+        "--diff-file",
+        help="optional: parse a diff file instead of reading ChangeSet JSON from stdin",
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_arg_parser().parse_args(argv)
+
+    if args.diff_file:
+        cs = parse_diff(Path(args.diff_file).read_text(encoding="utf-8"))
+        skill_dir = Path(args.skill_dir) if args.skill_dir else None
+        rule_paths = sorted(
+            p.relative_to(skill_dir).as_posix()
+            for p in (skill_dir / "rules").glob("*.md")
+        ) if skill_dir else []
+        rules_by_cat = load_rules(skill_dir, rule_paths) if skill_dir else {}
+    else:
+        data = json.loads(sys.stdin.read())
+        # Two stdin shapes:
+        #   {changeset: {...}, rules: {...}}  — rules pre-loaded (sandbox mode,
+        #     no rules/*.md files needed in the workspace)
+        #   {files: [...]}                     — bare ChangeSet (load rules from --skill-dir)
+        if isinstance(data, dict) and "changeset" in data and "rules" in data:
+            cs = _changeset_from_dict(data["changeset"])
+            rules_by_cat = data["rules"]
+        else:
+            cs = _changeset_from_dict(data)
+            skill_dir = Path(args.skill_dir) if args.skill_dir else None
+            rule_paths = sorted(
+                p.relative_to(skill_dir).as_posix()
+                for p in (skill_dir / "rules").glob("*.md")
+            ) if skill_dir else []
+            rules_by_cat = load_rules(skill_dir, rule_paths) if skill_dir else {}
+
+    findings = run_checks(cs, {"_rules": rules_by_cat})
+    print(json.dumps([f.to_dict() for f in findings], ensure_ascii=False, indent=2))
+    return 0
+
+
+def _changeset_from_dict(data: dict) -> ChangeSet:
+    """Reconstruct a ChangeSet from its JSON dict (for CLI stdin)."""
+    cs = ChangeSet()
+    for fd in data.get("files", []):
+        from parse_diff import ChangedFile, Hunk, DiffLine
+
+        cf = ChangedFile(path=fd["path"], status=fd["status"])
+        for hd in fd.get("hunks", []):
+            h = Hunk(
+                old_start=hd["old_start"],
+                new_start=hd["new_start"],
+                old_count=hd["old_count"],
+                new_count=hd["new_count"],
+            )
+            for ld in hd.get("lines", []):
+                h.lines.append(DiffLine(**ld))
+            cf.hunks.append(h)
+        cs.files.append(cf)
+    return cs
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/skills_code_review_agent/tests/fixtures/01_clean.diff
+++ b/examples/skills_code_review_agent/tests/fixtures/01_clean.diff
@@ -1,0 +1,10 @@
+diff --git a/app/utils.py b/app/utils.py
+--- a/app/utils.py
++++ b/app/utils.py
+@@ -1,4 +1,4 @@
+ def add(a, b):
+-    return a + b
++    return a + b  # keep behavior, tidy comment
+ 
+ def mul(a, b):
+     return a * b

--- a/examples/skills_code_review_agent/tests/fixtures/02_security.diff
+++ b/examples/skills_code_review_agent/tests/fixtures/02_security.diff
@@ -1,0 +1,11 @@
+diff --git a/app/db.py b/app/db.py
+--- a/app/db.py
++++ b/app/db.py
+@@ -10,4 +10,7 @@ class DB:
+     def get_user(self, conn, uid):
+         cur = self.cursor()
+-        cur.execute("SELECT * FROM users WHERE id=%s", (uid,))
++        # 安全反面示例：SQL 注入（字符串拼接）
++        cur.execute("SELECT * FROM users WHERE id=" + str(uid))
++        SECRET_KEY = "0123456789abcdef"
+         return cur.fetchone()

--- a/examples/skills_code_review_agent/tests/fixtures/03_async_leak.diff
+++ b/examples/skills_code_review_agent/tests/fixtures/03_async_leak.diff
@@ -1,0 +1,13 @@
+diff --git a/app/fetcher.py b/app/fetcher.py
+--- a/app/fetcher.py
++++ b/app/fetcher.py
+@@ -1,6 +1,8 @@
+ async def fetch(url):
+     resp = await httpx.get(url)
+     return resp.json()
+ 
+ def run_pipeline():
+-    return fetch_all()
++    task = asyncio.create_task(fetch("http://example.com"))
++    session = aiohttp.ClientSession()
++    return task

--- a/examples/skills_code_review_agent/tests/fixtures/04_db_lifecycle.diff
+++ b/examples/skills_code_review_agent/tests/fixtures/04_db_lifecycle.diff
@@ -1,0 +1,11 @@
+diff --git a/app/db.py b/app/db.py
+--- a/app/db.py
++++ b/app/db.py
+@@ -1,3 +1,6 @@
+ def get_rows(query):
+     engine = create_engine(URL)
+-    return engine.execute(query).fetchall()
++    conn = engine.connect()
++    cur = conn.cursor()
++    conn.begin()
++    return cur.execute(query).fetchall()

--- a/examples/skills_code_review_agent/tests/fixtures/05_missing_tests.diff
+++ b/examples/skills_code_review_agent/tests/fixtures/05_missing_tests.diff
@@ -1,0 +1,6 @@
+diff --git a/app/service.py b/app/service.py
+--- /dev/null
++++ b/app/service.py
+@@ -0,0 +1,2 @@
++def calculate_discount(price, rate):
++    return price * (1 - rate)

--- a/examples/skills_code_review_agent/tests/fixtures/06_duplicate.diff
+++ b/examples/skills_code_review_agent/tests/fixtures/06_duplicate.diff
@@ -1,0 +1,8 @@
+diff --git a/app/tasks.py b/app/tasks.py
+--- a/app/tasks.py
++++ b/app/tasks.py
+@@ -1,2 +1,3 @@
+ def run_pipeline():
+-    return schedule()
++    task = asyncio.create_task(aiohttp.ClientSession())
++    return task

--- a/examples/skills_code_review_agent/tests/fixtures/07_sandbox_fail.diff
+++ b/examples/skills_code_review_agent/tests/fixtures/07_sandbox_fail.diff
@@ -1,0 +1,9 @@
+diff --git a/app/handler.py b/app/handler.py
+--- a/app/handler.py
++++ b/app/handler.py
+@@ -1,2 +1,4 @@
+ def handle(req):
+-    return process(req)
++    conn = engine.connect()
++    cur = conn.cursor()
++    return process(req)

--- a/examples/skills_code_review_agent/tests/fixtures/08_sensitive_info.diff
+++ b/examples/skills_code_review_agent/tests/fixtures/08_sensitive_info.diff
@@ -1,0 +1,13 @@
+diff --git a/app/config.py b/app/config.py
+--- a/app/config.py
++++ b/app/config.py
+@@ -1,2 +1,10 @@
++# 敏感信息脱敏样本
++AWS_KEY = "AKIAIOSFODNN7EXAMPLE"
++OPENAI_KEY = "sk-1234567890abcdef1234567890ab"
++GH_TOKEN = "ghp_aBcDeFgHiJkLmNoPqRsTuVwXyZ1234567890"
++db_password = "SuperSecret123!"
++PRIV_KEY = """-----BEGIN RSA PRIVATE KEY-----
++MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA
++-----END RSA PRIVATE KEY-----"""
++DB_URL = "postgres://admin:pa55w0rd@localhost:5432/app"

--- a/examples/skills_code_review_agent/tests/fixtures/09_sandbox_runtime_failure.diff
+++ b/examples/skills_code_review_agent/tests/fixtures/09_sandbox_runtime_failure.diff
@@ -1,0 +1,10 @@
+diff --git a/app/runtime_failure_handler.py b/app/runtime_failure_handler.py
+--- a/app/runtime_failure_handler.py
++++ b/app/runtime_failure_handler.py
+@@ -1,2 +1,5 @@
+ def handle_runtime_failure_case(req):
+-    return process(req)
++    conn = engine.connect()
++    cur = conn.cursor()
++    result = process(req)
++    return result

--- a/examples/skills_code_review_agent/tests/fixtures/skills/failing/code-review/SKILL.md
+++ b/examples/skills_code_review_agent/tests/fixtures/skills/failing/code-review/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: code-review
+description: Test-only code-review Skill whose checker exits nonzero.
+version: 0.0.1
+entry: scripts/run_checks.py
+rules:
+  - rules/db_lifecycle.md
+sandbox:
+  default_runtime: container
+  fallback: local
+  timeout_s: 5
+  max_output_bytes: 8192
+  env_whitelist: [PATH, HOME, LANG]
+---
+
+# failing code-review Skill
+
+This fixture Skill is intentionally minimal. Its `run_checks.py` exits with a
+nonzero status so tests can exercise the real sandbox-failure path without
+monkeypatching the runtime.

--- a/examples/skills_code_review_agent/tests/fixtures/skills/failing/code-review/rules/db_lifecycle.md
+++ b/examples/skills_code_review_agent/tests/fixtures/skills/failing/code-review/rules/db_lifecycle.md
@@ -1,0 +1,16 @@
+# db_lifecycle test rule
+
+```yaml
+- id: DB001
+  pattern: '(?:engine|conn|connection|db)\.connect\s*\('
+  severity_hint: high
+  confidence: 0.7
+  type: ast
+  description: Database connection should be closed with a context manager or explicit close.
+- id: DB002
+  pattern: '\.cursor\s*\('
+  severity_hint: medium
+  confidence: 0.65
+  type: ast
+  description: Cursor should be closed with a context manager or explicit close.
+```

--- a/examples/skills_code_review_agent/tests/fixtures/skills/failing/code-review/scripts/run_checks.py
+++ b/examples/skills_code_review_agent/tests/fixtures/skills/failing/code-review/scripts/run_checks.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+"""Test fixture checker that fails during real sandbox execution."""
+
+import sys
+
+
+def main() -> int:
+    sys.stderr.write("intentional fixture sandbox failure\n")
+    return 7
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/skills_code_review_agent/tests/test_cr_agent.py
+++ b/examples/skills_code_review_agent/tests/test_cr_agent.py
@@ -1,0 +1,730 @@
+# Tencent is pleased to support the open source community by making tRPC-Agent-Python available.
+#
+# Copyright (C) 2026 Tencent. All rights reserved.
+#
+# tRPC-Agent-Python is licensed under Apache-2.0.
+"""Phase 6 (Test & acceptance) — end-to-end acceptance tests.
+
+Runs the full Code Review Agent pipeline over the public diff fixtures and
+asserts the eight acceptance criteria from phase-6-test-acceptance.md:
+
+  1. all public fixtures run and produce a report
+  2. high-risk detection (security/async/db) + no false positive on clean
+  3. complete DB record queryable by task_id
+  4. sandbox failure degrades gracefully (task still done)
+  5. sensitive-info masking rate >= 95% (no plaintext secrets)
+  6. dry-run full pipeline <= 2 minutes
+  7. Filter deny/review never enters the sandbox
+  8. report has all eight sections
+
+Run:
+    C:/Users/douzhenyu/.workbuddy/binaries/python/envs/cr_agent/Scripts/python.exe \\
+        examples/skills_code_review_agent/tests/test_cr_agent.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import shutil
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+_EXAMPLE_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_EXAMPLE_ROOT))
+
+import agent  # noqa: E402
+from agent.db import SQLiteStore  # noqa: E402
+from agent.filters import FilterDecision, FilterGovernance  # noqa: E402
+
+_FIXTURES = _EXAMPLE_ROOT / "tests" / "fixtures"
+_SKILL_DIR = _EXAMPLE_ROOT / "skills" / "code-review"
+_FAILING_SKILL_DIR = _FIXTURES / "skills" / "failing" / "code-review"
+
+# Plaintext secret tokens planted in fixture 08 — must NEVER appear in a report.
+_SECRET_PLAINTEXT = [
+    "AKIAIOSFODNN7EXAMPLE",
+    "sk-1234567890abcdef1234567890ab",
+    "ghp_aBcDeFgHiJkLmNoPqRsTuVwXyZ1234567890",
+    "SuperSecret123!",
+    "pa55w0rd",
+]
+
+_REPORT_KEYS = {
+    "task_id", "1_findings", "2_severity_stats", "3_needs_human_review",
+    "4_filter_blocks", "5_monitor", "6_sandbox_runs", "7_recommendations",
+    "8_warnings",
+}
+_MD_SECTIONS = [
+    "## 1. Findings", "## 2. 严重级别统计", "## 3. 人工复核项",
+    "## 4. Filter 拦截摘要", "## 5. 监控指标", "## 6. 沙箱执行摘要",
+    "## 7. 可执行修复建议", "## 8. Warnings",
+]
+
+
+def _args(**kw) -> SimpleNamespace:
+    base = dict(
+        skill_dir=str(_SKILL_DIR), diff_file=None, repo_path=None, fixture=None,
+        db_path="", mode="dry-run", output_dir="", print_changeset=False,
+        telemetry=False, dry_run=False,
+    )
+    base.update(kw)
+    return SimpleNamespace(**base)
+
+
+async def _run_pipeline(fixture_name: str | None = None, **kw) -> tuple[str, str]:
+    """Run the pipeline on a fixture .diff file (or raw kwargs) → (db, out).
+
+    ``fixture_name`` is the fixture file stem (e.g. ``"01_clean"``); it is fed
+    via ``--diff-file`` (the built-in ``--fixture`` only knows clean/security).
+    """
+    db = tempfile.mktemp(suffix=".db", prefix="cr_p6_")
+    out = tempfile.mkdtemp(prefix="cr_p6_out_")
+    diff_file = str(_FIXTURES / f"{fixture_name}.diff") if fixture_name else None
+    ns = _args(db_path=db, output_dir=out, diff_file=diff_file, **kw)
+    await agent._async_main(ns)
+    return db, out
+
+
+def _first_task_id(db_path: str) -> str:
+    import sqlite3
+    conn = sqlite3.connect(db_path)
+    tid = conn.execute("SELECT id FROM review_task ORDER BY created_at LIMIT 1").fetchone()[0]
+    conn.close()
+    return tid
+
+
+def _load_report(out: str) -> dict:
+    return json.loads(Path(out, "review_report.json").read_text(encoding="utf-8"))
+
+
+def _all_findings(report: dict) -> list[dict]:
+    return [*report["1_findings"], *report["8_warnings"], *report["3_needs_human_review"]]
+
+
+def _cleanup(db: str, out: str) -> None:
+    if os.path.exists(db):
+        try:
+            os.unlink(db)
+        except PermissionError:
+            pass
+    shutil.rmtree(out, ignore_errors=True)
+
+
+def _patch_governance(verdict_for_suffix: dict) -> object:
+    """Patch ``FilterGovernance.decide`` so scripts whose path ends with a given
+    suffix receive the mapped verdict; everything else is allowed.
+
+    Returns the original ``decide`` so the caller can restore it. Use this to
+    force a specific Skill script (parse_diff / run_checks / dedupe /
+    mask_secrets) into deny / needs_human_review and prove the orchestrator
+    stops that phase *before* executing the script.
+    """
+    def _decide(self, script_path, script_content, budget=None):
+        for suffix, verdict in verdict_for_suffix.items():
+            if script_path.endswith(suffix):
+                return FilterDecision(
+                    verdict=verdict, reason="test", target=script_path,
+                    detail=f"simulated {verdict} for acceptance test")
+        return FilterDecision(verdict="allow", reason="ok", target=script_path, detail="")
+
+    original = FilterGovernance.decide
+    FilterGovernance.decide = _decide  # type: ignore[assignment]
+    return original
+
+
+def _restore_governance(original) -> None:
+    if original is None:
+        return
+    try:
+        FilterGovernance.decide = original  # type: ignore[assignment]
+    except Exception:
+        pass
+
+
+class TestPerFixture(unittest.IsolatedAsyncioTestCase):
+    """Acceptance #1 + #2 — each fixture runs, high-risk detected, clean has 0."""
+
+    async def test_clean_diff(self):
+        db, out = await _run_pipeline("01_clean")
+        report = _load_report(out)
+        self.assertEqual(report["1_findings"], [], "clean diff must have 0 findings (no false positive)")
+        self.assertEqual(_all_findings(report), [])
+        _cleanup(db, out)
+
+    async def test_security_detection(self):
+        db, out = await _run_pipeline("02_security")
+        report = _load_report(out)
+        sec = [f for f in report["1_findings"] if f["category"] == "security"]
+        self.assertTrue(sec, "security fixture must surface a security finding")
+        self.assertTrue(
+            any(f["severity"] == "critical" for f in sec),
+            "security critical (SQLi) must be detected",
+        )
+        _cleanup(db, out)
+
+    async def test_async_leak(self):
+        db, out = await _run_pipeline("03_async_leak")
+        report = _load_report(out)
+        async_hi = [
+            f for f in _all_findings(report)
+            if f["category"] == "async" and f["severity"] == "high"
+        ]
+        self.assertTrue(async_hi, "async high-severity leak must be detected")
+        _cleanup(db, out)
+
+    async def test_db_lifecycle(self):
+        db, out = await _run_pipeline("04_db_lifecycle")
+        report = _load_report(out)
+        db_hi = [
+            f for f in _all_findings(report)
+            if f["category"] == "db" and f["severity"] == "high"
+        ]
+        self.assertTrue(db_hi, "db high-severity lifecycle issue must be detected")
+        _cleanup(db, out)
+
+    async def test_missing_tests(self):
+        db, out = await _run_pipeline("05_missing_tests")
+        report = _load_report(out)
+        tests = [f for f in _all_findings(report) if f["category"] == "tests"]
+        self.assertTrue(tests, "new public function without a test must be flagged")
+        self.assertEqual(tests[0]["severity"], "low")
+        _cleanup(db, out)
+
+    async def test_dedup(self):
+        db, out = await _run_pipeline("06_duplicate")
+        report = _load_report(out)
+        async_findings = [f for f in _all_findings(report) if f["category"] == "async"]
+        # Two raw diagnostics on the same (file, line, category) collapse to one.
+        self.assertEqual(len(async_findings), 1, "duplicate diagnostics must merge to one")
+        _cleanup(db, out)
+
+
+class TestSandboxFailure(unittest.IsolatedAsyncioTestCase):
+    """Acceptance #4 — sandbox failure degrades; task still completes.
+
+    The failure is injected at the runtime-factory level (not by patching a
+    single backend), so it fires regardless of which sandbox backend the agent
+    actually selects — local, container, or cube. This fixes the previous test
+    that only patched ``LocalRuntime.run`` and was silently bypassed whenever
+    docker was available (the agent then used ``ContainerRuntime`` instead).
+    """
+
+    async def test_sandbox_fail(self):
+        from agent.sandbox import build_runtime_with_fallback, select_runtime
+
+        class BoomRuntime:
+            """A sandbox backend whose execution always fails."""
+
+            def ensure_available(self) -> bool:
+                return True
+
+            async def run(self, script_path, input, policy=None):
+                raise RuntimeError("sandbox timeout / crash")
+
+        def _boom_factory(*a, **k):
+            return (BoomRuntime(), "boom")
+
+        with mock.patch(
+            "agent.sandbox.build_runtime_with_fallback", _boom_factory
+        ), mock.patch(
+            "agent.sandbox.select_runtime", lambda *a, **k: BoomRuntime()
+        ):
+            db, out = await _run_pipeline("07_sandbox_fail", mode="real")
+
+        store = SQLiteStore(db)
+        try:
+            rec = await store.get_task(_first_task_id(db))
+            # (a) graceful degradation — the task still completes.
+            self.assertEqual(rec["task"]["status"], "done")
+            # (b) findings are still produced via the FakeRunner fallback.
+            self.assertGreater(
+                len(rec["findings"]), 0, "degraded run should still yield findings"
+            )
+            # (c) the failed sandbox execution is recorded in the DB
+            #     (ties P1-1: every sandbox run must be persisted).
+            self.assertEqual(
+                len(rec["sandbox_runs"]), 1,
+                "the failed sandbox run must be recorded in the DB",
+            )
+            self.assertEqual(rec["sandbox_runs"][0]["status"], "failed")
+        finally:
+            await store.close()
+        _cleanup(db, out)
+
+    async def test_real_failure_fixture_records_failed_sandbox_run(self):
+        """Fixture 09 fails by executing a checker that exits nonzero."""
+
+        db, out = await _run_pipeline(
+            "09_sandbox_runtime_failure",
+            mode="real",
+            skill_dir=str(_FAILING_SKILL_DIR),
+        )
+
+        store = SQLiteStore(db)
+        try:
+            rec = await store.get_task(_first_task_id(db))
+            self.assertEqual(rec["task"]["status"], "done")
+            self.assertEqual(len(rec["sandbox_runs"]), 1)
+            run = rec["sandbox_runs"][0]
+            self.assertEqual(run["status"], "failed")
+            self.assertNotEqual(run["exit_code"], 0)
+            self.assertGreater(len(rec["findings"]), 0)
+
+            report = _load_report(out)
+            self.assertEqual(report["6_sandbox_runs"][0]["status"], "failed")
+            self.assertNotEqual(report["6_sandbox_runs"][0]["exit_code"], 0)
+        finally:
+            await store.close()
+        _cleanup(db, out)
+
+
+class TestLocalRuntimeEnvWhitelist(unittest.IsolatedAsyncioTestCase):
+    """P1-2 — LocalRuntime must enforce the env-variable whitelist."""
+
+    async def test_non_whitelisted_env_not_leaked(self):
+        from agent.sandbox import LocalRuntime, SandboxPolicy
+
+        probe_dir = tempfile.mkdtemp(prefix="cr_envprobe_")
+        probe = Path(probe_dir) / "probe.py"
+        probe.write_text(
+            "import os\nprint(os.environ.get('CR_P3_VISIBLE'))\n", encoding="utf-8"
+        )
+        os.environ["CR_P3_VISIBLE"] = "leaked"
+        try:
+            rt = LocalRuntime()
+            res = await rt.run(
+                str(probe),
+                {"_rules": {}},
+                SandboxPolicy(env_whitelist=["PATH", "HOME", "LANG"]),
+            )
+        finally:
+            os.environ.pop("CR_P3_VISIBLE", None)
+            shutil.rmtree(probe_dir, ignore_errors=True)
+
+        # The script must actually have executed (not silently failed).
+        self.assertEqual(
+            res.status, "ok", f"sandbox script should run; stderr={res.stderr!r}"
+        )
+        # CR_P3_VISIBLE is NOT in the whitelist, so it must not be visible.
+        self.assertNotIn(
+            "leaked", res.stdout,
+            "non-whitelisted env var leaked into the sandbox",
+        )
+
+    async def test_whitelisted_env_is_visible(self):
+        from agent.sandbox import LocalRuntime, SandboxPolicy
+
+        probe_dir = tempfile.mkdtemp(prefix="cr_envprobe_")
+        probe = Path(probe_dir) / "probe.py"
+        probe.write_text(
+            "import os\nprint(os.environ.get('CR_P3_ALLOWED'))\n", encoding="utf-8"
+        )
+        os.environ["CR_P3_ALLOWED"] = "visible"
+        try:
+            rt = LocalRuntime()
+            res = await rt.run(
+                str(probe),
+                {"_rules": {}},
+                SandboxPolicy(env_whitelist=["PATH", "HOME", "LANG", "CR_P3_ALLOWED"]),
+            )
+        finally:
+            os.environ.pop("CR_P3_ALLOWED", None)
+            shutil.rmtree(probe_dir, ignore_errors=True)
+
+        self.assertEqual(res.status, "ok", f"stderr={res.stderr!r}")
+        self.assertIn("visible", res.stdout, "whitelisted env var must be visible")
+
+
+class TestSensitiveMasking(unittest.IsolatedAsyncioTestCase):
+    """Acceptance #5 — masking rate >= 95%, no plaintext secrets in output."""
+
+    async def test_sensitive_masking(self):
+        db, out = await _run_pipeline("08_sensitive_info")
+        report = _load_report(out)
+        # 1) sensitive findings are detected.
+        sensitive = [f for f in report["1_findings"] if f["category"] == "sensitive"]
+        self.assertGreaterEqual(len(sensitive), 5, "multiple secret formats must be detected")
+
+        # 2) no plaintext secret anywhere in the JSON or MD report.
+        blob = json.dumps(report, ensure_ascii=False)
+        blob += "\n" + Path(out, "review_report.md").read_text(encoding="utf-8")
+        for secret in _SECRET_PLAINTEXT:
+            self.assertNotIn(secret, blob, f"plaintext secret leaked: {secret}")
+
+        # 3) redaction actually happened.
+        self.assertIn("***REDACTED***", blob, "expected at least one redaction marker")
+
+        # 4) DB-stored evidence is also masked.
+        store = SQLiteStore(db)
+        try:
+            rec = await store.get_task(_first_task_id(db))
+            db_blob = json.dumps(rec["findings"], ensure_ascii=False)
+            for secret in _SECRET_PLAINTEXT:
+                self.assertNotIn(secret, db_blob, f"plaintext secret in DB: {secret}")
+        finally:
+            await store.close()
+        _cleanup(db, out)
+
+
+class TestReportAndDb(unittest.IsolatedAsyncioTestCase):
+    """Acceptance #3, #8 — complete DB record + eight report sections."""
+
+    async def test_report_eight_sections(self):
+        db, out = await _run_pipeline("02_security")
+        report = _load_report(out)
+        self.assertTrue(_REPORT_KEYS.issubset(report.keys()), "report missing sections")
+        md = Path(out, "review_report.md").read_text(encoding="utf-8")
+        for sec in _MD_SECTIONS:
+            self.assertIn(sec, md, f"md missing section header: {sec}")
+        _cleanup(db, out)
+
+    async def test_db_query_by_task_id(self):
+        db, out = await _run_pipeline("02_security")
+        store = SQLiteStore(db)
+        try:
+            tid = _first_task_id(db)
+            rec = await store.get_task(tid)
+            for key in ("task", "input_diffs", "sandbox_runs", "findings",
+                        "filter_blocks", "monitor_summary", "report"):
+                self.assertIn(key, rec, f"get_task missing {key}")
+            self.assertEqual(rec["task"]["id"], tid)
+            self.assertEqual(rec["task"]["status"], "done")
+            self.assertGreater(len(rec["input_diffs"]), 0)
+        finally:
+            await store.close()
+        _cleanup(db, out)
+
+
+class TestFilterGating(unittest.IsolatedAsyncioTestCase):
+    """Acceptance #7 — Filter deny/review never *executes* the checker.
+
+    The previous test only proved ``LocalRuntime.run`` is not called. It did
+    NOT prove the in-process ``FakeRunner`` fallback (which imports and runs
+    ``run_checks.py`` *outside* the sandbox) was skipped. A denied script is a
+    denied script regardless of backend, so we patch BOTH execution paths to
+    raise, and assert zero raw findings flow through — covering dry-run and
+    real mode, for both ``deny`` and ``needs_human_review`` verdicts.
+    """
+
+    def _force_verdict(self, verdict):
+        def _decide(self, script_path, script_content, budget=None):
+            if script_path.endswith("run_checks.py"):
+                return FilterDecision(
+                    verdict=verdict, reason="test", target=script_path,
+                    detail=f"simulated {verdict} for acceptance test",
+                )
+            return FilterDecision(verdict="allow", reason="ok", target=script_path, detail="")
+
+        original = FilterGovernance.decide
+        FilterGovernance.decide = _decide  # type: ignore[assignment]
+        return original
+
+    async def _run_blocked(self, verdict, mode):
+        from agent.agent import FakeRunner
+        from agent.sandbox import LocalRuntime
+
+        original_gov = self._force_verdict(verdict)
+
+        # If EITHER execution path fires on a denied/reviewed checker, fail loud.
+        async def _sandbox_must_not_run(self_, script_path, input, policy):
+            raise AssertionError("sandbox must NOT run a denied/reviewed checker")
+        orig_local = LocalRuntime.run
+        LocalRuntime.run = _sandbox_must_not_run  # type: ignore[assignment]
+
+        orig_fake = FakeRunner.run
+        async def _fake_must_not_run(self_, changeset, ruleset):
+            raise AssertionError("FakeRunner must NOT execute a denied/reviewed checker")
+        FakeRunner.run = _fake_must_not_run  # type: ignore[assignment]
+
+        db = out = None
+        try:
+            db, out = await _run_pipeline("02_security", mode=mode)
+            store = SQLiteStore(db)
+            try:
+                rec = await store.get_task(_first_task_id(db))
+                self.assertEqual(rec["task"]["status"], "done")
+                # (a) a filter_block must be recorded for the blocked checker.
+                blocks = rec["filter_blocks"]
+                self.assertTrue(blocks, "blocked checker must record a filter_block")
+                self.assertTrue(
+                    any(b["decision"] == verdict for b in blocks),
+                    f"filter_block decision must be {verdict}",
+                )
+                # (b) NO raw findings may flow through — the checker never ran.
+                self.assertEqual(
+                    len(rec["findings"]), 0,
+                    "a blocked checker must produce zero findings",
+                )
+                # (c) the (non-)execution is recorded as blocked in the DB.
+                runs = rec["sandbox_runs"]
+                self.assertEqual(len(runs), 1, "one sandbox decision must be recorded")
+                self.assertEqual(runs[0]["runtime"], "blocked")
+                self.assertEqual(runs[0]["status"], verdict)
+            finally:
+                await store.close()
+        finally:
+            # Restore every patch independently — a failure in one must not
+            # leave a global monkey-patch in place for the next test (which
+            # would cause hard-to-diagnose cross-test contamination).
+            for _restore in (
+                lambda: setattr(FilterGovernance, "decide", original_gov),
+                lambda: setattr(LocalRuntime, "run", orig_local),
+                lambda: setattr(FakeRunner, "run", orig_fake),
+            ):
+                try:
+                    _restore()
+                except Exception:
+                    pass
+            if db or out:
+                _cleanup(db, out)
+
+    async def test_deny_blocks_real(self):
+        await self._run_blocked("deny", "real")
+
+    async def test_deny_blocks_dry_run(self):
+        await self._run_blocked("deny", "dry-run")
+
+    async def test_review_blocks_real(self):
+        await self._run_blocked("needs_human_review", "real")
+
+    async def test_review_blocks_dry_run(self):
+        await self._run_blocked("needs_human_review", "dry-run")
+
+
+class TestUnifiedGate(unittest.IsolatedAsyncioTestCase):
+    """Unified Filter gate — Acceptance #7 extended to EVERY Skill script.
+
+    run_checks.py was already gated. These tests prove the gate also holds for
+    parse_diff (L1), dedupe (L5) and mask_secrets (helper used by dedupe + LLM
+    triage): when the Filter returns deny / needs_human_review for one of them,
+    the orchestrator stops that phase *before* the script executes — in-process
+    no less than in the sandbox. We prove non-execution by monkey-patching the
+    script's entry point to raise: if the gate is broken the patch fires and the
+    test errors; if the gate holds, the patch is never invoked.
+    """
+
+    async def _assert_blocked_execution(
+        self, *, suffix, verdict, fixture, mode, llm_enabled=False,
+        expect_no_sandbox_run=False,
+    ):
+        """Run a pipeline with ``suffix`` forced to ``verdict`` and assert the
+        matching script never executed, a filter_block was recorded, and zero
+        findings flowed through.
+
+        The whole body is wrapped in try/finally with the ``try`` at the very
+        top, so the FilterGovernance patch is ALWAYS restored even if an early
+        line raises — otherwise a leaked ``decide`` would contaminate the next
+        test (e.g. deny parse_diff and zero out its findings).
+        """
+        import dedupe as dedupe_mod
+        from agent.agent import FakeRunner
+        from agent.llm import LlmTriage
+        from agent.sandbox import LocalRuntime
+
+        # Pre-initialize so the finally can restore unconditionally (a patch
+        # that was never installed simply restores to None-safe state).
+        original_gov = None
+        orig_parse = orig_local = orig_fake = orig_dedupe = orig_triage = None
+
+        # Set up every patch inside the try so the finally (which restores all
+        # of them) is guaranteed to run even on an early failure.
+        try:
+            original_gov = _patch_governance({suffix: verdict})
+
+            orig_parse = agent.agent.parse_diff
+            def _parse_must_not_run(*a, **k):
+                raise AssertionError(f"parse_diff must NOT execute when filtered ({verdict})")
+
+            orig_local = LocalRuntime.run
+            async def _sandbox_must_not_run(self_, script_path, input, policy):
+                raise AssertionError("sandbox must NOT run when a script is filtered")
+
+            orig_fake = FakeRunner.run
+            async def _fake_must_not_run(self_, changeset, ruleset):
+                raise AssertionError("FakeRunner must NOT execute a filtered script")
+
+            orig_dedupe = dedupe_mod.dedupe
+            def _dedupe_must_not_run(*a, **k):
+                raise AssertionError("dedupe must NOT execute when filtered")
+            orig_triage = LlmTriage.run
+            async def _triage_must_not_run(self_, *a, **k):
+                raise AssertionError("LLM triage (masked diff) must NOT run when filtered")
+
+            # Install the raising stub ONLY on the script under test. The other
+            # declared scripts are allowed in that scenario and MUST run, so
+            # patching them to raise would be a test bug (not a product bug).
+            # (run_checks.py executors are jointly exercised by TestFilterGating.)
+            if suffix == "parse_diff.py":
+                agent.agent.parse_diff = _parse_must_not_run  # type: ignore[assignment]
+            if suffix in ("dedupe.py", "mask_secrets.py"):
+                dedupe_mod.dedupe = _dedupe_must_not_run  # type: ignore[assignment]
+            if suffix == "mask_secrets.py":
+                LlmTriage.run = _triage_must_not_run  # type: ignore[assignment]
+
+            # Point the LLM config at an empty .env so the product .env (which
+            # now carries a real DeepSeek key) cannot leak in and flip is_enabled.
+            llm_env = tempfile.NamedTemporaryFile(
+                suffix=".env", prefix="cr_empty_", delete=False).name
+            Path(llm_env).write_text("", encoding="utf-8")
+
+            db = out = None
+            try:
+                db, out = await _run_pipeline(
+                    fixture, mode=mode, enable_llm=llm_enabled, llm_env=llm_env)
+                store = SQLiteStore(db)
+                try:
+                    rec = await store.get_task(_first_task_id(db))
+                    self.assertEqual(rec["task"]["status"], "done")
+                    blocks = rec["filter_blocks"]
+                    self.assertTrue(blocks, "filtered script must record a filter_block")
+                    self.assertTrue(
+                        any(b["decision"] == verdict and b["target"].endswith(suffix)
+                            for b in blocks),
+                        f"filter_block must be {verdict} for *{suffix}",
+                    )
+                    self.assertEqual(
+                        len(rec["findings"]), 0,
+                        f"a filtered *{suffix} must produce zero findings",
+                    )
+                    if expect_no_sandbox_run:
+                        self.assertEqual(
+                            len(rec["sandbox_runs"]), 0,
+                            "no sandbox decision may be recorded when parse is blocked",
+                        )
+                finally:
+                    await store.close()
+            finally:
+                if os.path.exists(llm_env):
+                    os.unlink(llm_env)
+        finally:
+            # Restore every patch independently — a failure restoring one must
+            # not leave another global monkey-patch in place for the next test.
+            _restore_governance(original_gov)
+            for _mod, _name, _orig in (
+                (agent.agent, "parse_diff", orig_parse),
+                (LocalRuntime, "run", orig_local),
+                (FakeRunner, "run", orig_fake),
+                (dedupe_mod, "dedupe", orig_dedupe),
+                (LlmTriage, "run", orig_triage),
+            ):
+                if _orig is None:
+                    continue
+                try:
+                    setattr(_mod, _name, _orig)
+                except Exception:
+                    pass
+            if db or out:
+                _cleanup(db, out)
+
+    async def test_parse_diff_deny_stops_everything(self):
+        # parse_diff is the L1 foundation; a deny must stop the whole chain
+        # (no sandbox, no dedupe) and never execute the script.
+        await self._assert_blocked_execution(
+            suffix="parse_diff.py", verdict="deny", fixture="02_security",
+            mode="real", expect_no_sandbox_run=True)
+
+    async def test_dedupe_deny_skips_dedupe(self):
+        # run_checks is allowed (so raw findings exist), but dedupe is denied →
+        # dedupe() must NOT run and zero findings flow through.
+        await self._assert_blocked_execution(
+            suffix="dedupe.py", verdict="deny", fixture="02_security", mode="real")
+
+    async def test_mask_secrets_deny_skips_dedupe_and_triage(self):
+        # mask_secrets gates both the dedupe helper and the LLM triage; a deny
+        # must skip dedupe AND skip sending the (unmasked) diff to the model.
+        await self._assert_blocked_execution(
+            suffix="mask_secrets.py", verdict="deny", fixture="02_security",
+            mode="real", llm_enabled=True)
+
+
+class TestGateNoModuleImport(unittest.IsolatedAsyncioTestCase):
+    """Proof that a denied Skill script is NEVER even *imported* — its module
+    top-level code and any ``load_rules``-style call must not execute. Function
+    patches (TestFilterGating / TestUnifiedGate) cannot catch module-level
+    import, so we evict the module from ``sys.modules`` first and assert it is
+    NOT re-imported during a denied run.
+
+    NOTE: ``mask_secrets`` is intentionally excluded — ``agent/sandbox/
+    runtime.py`` imports it at module top for always-on output redaction (a
+    mandatory safety boundary, not a pipeline execution), so its absence can't
+    be asserted. The dedupe/LLM-triage *usage* of mask_secrets is still gated
+    (lazy import inside ``dedupe()`` / ``LlmTriage.run``, only on allow).
+    """
+
+    async def _assert_module_not_imported(self, *, suffix, verdict, fixture, mode):
+        import sys
+
+        from agent.sandbox import LocalRuntime
+
+        mod_name = {
+            "run_checks.py": "run_checks",
+            "dedupe.py": "dedupe",
+        }[suffix]
+
+        original_gov = None
+        saved_module = None
+        llm_env = None
+        db = out = None
+        try:
+            original_gov = _patch_governance({suffix: verdict})
+            # Evict the module so a fresh import during the run is detectable.
+            saved_module = sys.modules.pop(mod_name, None)
+
+            llm_env = tempfile.NamedTemporaryFile(
+                suffix=".env", prefix="cr_empty_", delete=False).name
+            Path(llm_env).write_text("", encoding="utf-8")
+
+            db, out = await _run_pipeline(
+                fixture, mode=mode, enable_llm=False, llm_env=llm_env)
+            # The denied script must NOT have been imported into this process —
+            # no module top-level, no load_rules, no execution of any kind.
+            self.assertNotIn(
+                mod_name, sys.modules,
+                f"{mod_name} must NOT be imported when the Filter denies it")
+        finally:
+            _restore_governance(original_gov)
+            if saved_module is not None:
+                sys.modules[mod_name] = saved_module
+            if llm_env and os.path.exists(llm_env):
+                os.unlink(llm_env)
+            if db or out:
+                _cleanup(db, out)
+
+    async def test_run_checks_deny_not_imported(self):
+        # run_checks.py is denied → the checker module is never imported, yet
+        # the blocked decision is still recorded (DB integrity preserved).
+        await self._assert_module_not_imported(
+            suffix="run_checks.py", verdict="deny", fixture="02_security", mode="real")
+
+    async def test_dedupe_deny_not_imported(self):
+        # dedupe.py is denied → dedupe() never runs AND the module is never
+        # imported. The empty DedupeResult comes from the benign cr_models.
+        await self._assert_module_not_imported(
+            suffix="dedupe.py", verdict="deny", fixture="02_security", mode="real")
+
+
+class TestDryRunPerformance(unittest.IsolatedAsyncioTestCase):
+    """Acceptance #6 — full dry-run pipeline completes within 2 minutes."""
+
+    async def test_dry_run_under_2min(self):
+        db = tempfile.mktemp(suffix=".db", prefix="cr_p6_perf_")
+        out = tempfile.mkdtemp(prefix="cr_p6_perf_out_")
+        ns = _args(
+            db_path=db, output_dir=out,
+            diff_file=str(_FIXTURES / "02_security.diff"), mode="dry-run")
+        start = time.perf_counter()
+        await agent._async_main(ns)
+        elapsed = time.perf_counter() - start
+        self.assertLess(elapsed, 120.0, f"dry-run took {elapsed:.1f}s (> 120s)")
+        _cleanup(db, out)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/examples/skills_code_review_agent/tests/test_phase0_foundation.py
+++ b/examples/skills_code_review_agent/tests/test_phase0_foundation.py
@@ -1,0 +1,336 @@
+# Tencent is pleased to support the open source community by making tRPC-Agent-Python available.
+#
+# Copyright (C) 2026 Tencent. All rights reserved.
+#
+# tRPC-Agent-Python is licensed under Apache-2.0.
+"""Phase 0 (Foundation) acceptance tests — SDK-backed async edition.
+
+Replaces the original hand-rolled sqlite3 tests. The store now runs on the
+SDK's :class:`SqlStorage` + SQLAlchemy ORM (``db.models.CRBase``), so all
+operations are async. Run with the CR Agent venv that has SDK deps:
+
+    C:/Users/douzhenyu/.workbuddy/binaries/python/envs/cr_agent/Scripts/python.exe \\
+        examples/skills_code_review_agent/tests/test_phase0_foundation.py
+
+Covers the Phase-0 DoD:
+  1. init_db builds the DB and is idempotent.
+  2. create_task / update_task_status.
+  3. All seven add_*/set_* writers persist.
+  4. get_task returns the fully joined record.
+  5. SQLiteStore satisfies the ReviewStore protocol (backend-swappable).
+  + foreign-key enforcement + bulk finding insert.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from sqlalchemy import inspect as sa_inspect
+from sqlalchemy.exc import IntegrityError
+
+_EXAMPLE_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_EXAMPLE_ROOT))
+
+from agent.db import ReviewStore  # noqa: E402
+from agent.db import SQLiteStore  # noqa: E402
+from agent.db.init_db import init_db  # noqa: E402
+from agent.db.models import CRBase  # noqa: E402
+
+_EXPECTED_TABLES = {
+    "review_task", "input_diff", "sandbox_run", "finding",
+    "filter_block", "monitor_summary", "review_report",
+}
+
+
+def _new_store() -> SQLiteStore:
+    """A store backed by a fresh on-disk temp DB (isolated per test)."""
+    fd, path = tempfile.mkstemp(suffix=".db", prefix="cr_phase0_")
+    os.close(fd)
+    return SQLiteStore(path)
+
+
+class TestInitDb(unittest.IsolatedAsyncioTestCase):
+    """DoD #1 — init_db builds the DB and is idempotent."""
+
+    async def _table_names(self, store) -> set:
+        eng = store.storage._db_engine
+        async with eng.connect() as conn:
+            return await conn.run_sync(lambda c: set(sa_inspect(c).get_table_names()))
+
+    async def _finding_indexes(self, store) -> set:
+        eng = store.storage._db_engine
+        async with eng.connect() as conn:
+            return await conn.run_sync(
+                lambda c: {i["name"] for i in sa_inspect(c).get_indexes("finding")}
+            )
+
+    async def test_init_creates_all_seven_tables_and_dedupe_index(self):
+        fd, path = tempfile.mkstemp(suffix=".db")
+        os.close(fd)
+        store = None
+        try:
+            await init_db(path, verbose=False)
+            store = SQLiteStore(path)
+            await store._ensure_engine()
+            tables = await self._table_names(store)
+            self.assertTrue(_EXPECTED_TABLES.issubset(tables))
+            idx = await self._finding_indexes(store)
+            self.assertIn("idx_finding_dedup", idx)
+        finally:
+            if store is not None:
+                await store.close()
+            if os.path.exists(path):
+                try:
+                    os.unlink(path)
+                except PermissionError:
+                    pass  # Windows file lock on rare races; GC will release.
+
+    async def test_init_is_idempotent(self):
+        fd, path = tempfile.mkstemp(suffix=".db")
+        os.close(fd)
+        store = None
+        try:
+            await init_db(path, verbose=False)
+            await init_db(path, verbose=False)  # second run must succeed
+            store = SQLiteStore(path)
+            await store._ensure_engine()
+            tables = await self._table_names(store)
+            self.assertTrue(_EXPECTED_TABLES.issubset(tables))
+        finally:
+            if store is not None:
+                await store.close()
+            if os.path.exists(path):
+                try:
+                    os.unlink(path)
+                except PermissionError:
+                    pass
+
+
+class TestTaskLifecycle(unittest.IsolatedAsyncioTestCase):
+    """DoD #2 — create_task / update_task_status."""
+
+    async def test_create_task_returns_id_and_pending(self):
+        store = _new_store()
+        try:
+            tid = await store.create_task("diff", "a.diff", "dry-run")
+            self.assertIsInstance(tid, str)
+            task = (await store.get_task(tid))["task"]
+            self.assertEqual(task["status"], "pending")
+            self.assertEqual(task["input_type"], "diff")
+            self.assertEqual(task["mode"], "dry-run")
+        finally:
+            await store.close()
+
+    async def test_update_task_status_transitions(self):
+        store = _new_store()
+        try:
+            tid = await store.create_task("repo", ".", "real")
+            await store.update_task_status(tid, "running")
+            self.assertEqual((await store.get_task(tid))["task"]["status"], "running")
+            await store.update_task_status(tid, "done", total_duration_ms=1234)
+            task = (await store.get_task(tid))["task"]
+            self.assertEqual(task["status"], "done")
+            self.assertEqual(task["total_duration_ms"], 1234)
+        finally:
+            await store.close()
+
+
+class TestChildWrites(unittest.IsolatedAsyncioTestCase):
+    """DoD #3 — all seven add_*/set_* writers persist rows."""
+
+    async def test_add_input_diff(self):
+        store = _new_store()
+        try:
+            tid = await store.create_task("diff", "a.diff", "dry-run")
+            did = await store.add_input_diff(tid, "src/a.py", "deadbeef", 3, 42, "3 hunks")
+            self.assertTrue(did)
+            diffs = (await store.get_task(tid))["input_diffs"]
+            self.assertEqual(len(diffs), 1)
+            self.assertEqual(diffs[0]["file_path"], "src/a.py")
+            self.assertEqual(diffs[0]["hunk_count"], 3)
+        finally:
+            await store.close()
+
+    async def test_add_sandbox_run(self):
+        store = _new_store()
+        try:
+            tid = await store.create_task("diff", "a.diff", "dry-run")
+            rid = await store.add_sandbox_run(
+                tid, "container", "run_checks.py", "ok", 1200, 0, 2048, 0, 3)
+            runs = (await store.get_task(tid))["sandbox_runs"]
+            self.assertEqual(len(runs), 1)
+            self.assertEqual(runs[0]["runtime"], "container")
+            self.assertEqual(runs[0]["masked_count"], 3)
+        finally:
+            await store.close()
+
+    async def test_add_finding_single(self):
+        store = _new_store()
+        try:
+            tid = await store.create_task("diff", "a.diff", "dry-run")
+            fid = await store.add_finding(
+                tid, "critical", "security", "src/a.py", 10, "SQL injection",
+                "cursor.execute(q % x)", "Use parameterized query", 0.95, "rule", "findings")
+            f = (await store.get_task(tid))["findings"][0]
+            self.assertEqual(f["severity"], "critical")
+            self.assertEqual(f["confidence"], 0.95)
+            self.assertEqual(f["bucket"], "findings")
+        finally:
+            await store.close()
+
+    async def test_add_finding_bulk(self):
+        store = _new_store()
+        try:
+            tid = await store.create_task("diff", "a.diff", "dry-run")
+            payload = [
+                {"severity": "high", "category": "async", "file": "b.py", "line": i,
+                 "title": f"unawaited {i}", "evidence": "foo()", "recommendation": "await it",
+                 "confidence": 0.82, "source": "rule", "bucket": "findings"}
+                for i in range(50)
+            ]
+            ids = await store.add_findings(tid, payload)
+            self.assertEqual(len(ids), 50)
+            self.assertEqual(len(set(ids)), 50)
+            self.assertEqual(len((await store.get_task(tid))["findings"]), 50)
+        finally:
+            await store.close()
+
+    async def test_add_filter_block(self):
+        store = _new_store()
+        try:
+            tid = await store.create_task("diff", "a.diff", "dry-run")
+            await store.add_filter_block(tid, "high-risk", "evil.py", "deny", "rm -rf /")
+            blocks = (await store.get_task(tid))["filter_blocks"]
+            self.assertEqual(blocks[0]["decision"], "deny")
+        finally:
+            await store.close()
+
+    async def test_set_monitor_summary(self):
+        store = _new_store()
+        try:
+            tid = await store.create_task("diff", "a.diff", "dry-run")
+            await store.set_monitor_summary(tid, {
+                "finding_count": 7, "sev_critical": 1, "sev_high": 2,
+                "exception_types": {"timeout": 2, "oom": 1},
+            })
+            ms = (await store.get_task(tid))["monitor_summary"]
+            self.assertEqual(ms["finding_count"], 7)
+            self.assertEqual(ms["sev_critical"], 1)
+            self.assertEqual(json.loads(ms["exception_types"]), {"timeout": 2, "oom": 1})
+        finally:
+            await store.close()
+
+    async def test_set_monitor_summary_upsert(self):
+        store = _new_store()
+        try:
+            tid = await store.create_task("diff", "a.diff", "dry-run")
+            await store.set_monitor_summary(tid, {"finding_count": 3})
+            await store.set_monitor_summary(tid, {"finding_count": 9})
+            # 1:1 — second call replaces, not duplicates.
+            ms = (await store.get_task(tid))["monitor_summary"]
+            self.assertEqual(ms["finding_count"], 9)
+        finally:
+            await store.close()
+
+    async def test_set_report_and_upsert(self):
+        store = _new_store()
+        try:
+            tid = await store.create_task("diff", "a.diff", "dry-run")
+            rid1 = await store.set_report(tid, "a.json", "a.md", "v1")
+            rid2 = await store.set_report(tid, "b.json", "b.md", "v2")
+            self.assertEqual(rid1, rid2)
+            rep = (await store.get_task(tid))["report"]
+            self.assertEqual(rep["report_json_path"], "b.json")
+            self.assertEqual(rep["summary"], "v2")
+        finally:
+            await store.close()
+
+
+class TestGetTaskJoin(unittest.IsolatedAsyncioTestCase):
+    """DoD #4 — get_task returns the fully joined record."""
+
+    async def test_full_join_record_shape(self):
+        store = _new_store()
+        try:
+            tid = await store.create_task("diff", "fixture/03.diff", "real")
+            await store.update_task_status(tid, "done", total_duration_ms=9000)
+            await store.add_input_diff(tid, "x.py", "abc", 1, 5, "1 hunk")
+            await store.add_input_diff(tid, "y.py", "def", 2, 8, "2 hunks")
+            await store.add_sandbox_run(tid, "cube", "run_checks.py", "ok", 100, 0, 512, 0, 0)
+            await store.add_finding(tid, "high", "resource", "x.py", 4, "leak", "open()",
+                                    "close()", 0.9, "sandbox", "findings")
+            await store.add_finding(tid, "low", "tests", "x.py", 1, "no test", "new fn",
+                                    "add test", 0.4, "rule", "needs_human_review")
+            await store.add_filter_block(tid, "network", "evil.com", "needs_human_review", "oob")
+            await store.set_monitor_summary(tid, {"finding_count": 2, "sev_high": 1})
+            await store.set_report(tid, "r.json", "r.md", "ok")
+
+            rec = await store.get_task(tid)
+            self.assertEqual(rec["task"]["status"], "done")
+            self.assertEqual(len(rec["input_diffs"]), 2)
+            self.assertEqual(len(rec["sandbox_runs"]), 1)
+            self.assertEqual(len(rec["findings"]), 2)
+            self.assertEqual(len(rec["filter_blocks"]), 1)
+            self.assertEqual(rec["monitor_summary"]["sev_high"], 1)
+            self.assertEqual(rec["report"]["summary"], "ok")
+        finally:
+            await store.close()
+
+    async def test_get_task_missing_raises(self):
+        store = _new_store()
+        try:
+            with self.assertRaises(KeyError):
+                await store.get_task("does-not-exist")
+        finally:
+            await store.close()
+
+
+class TestForeignKeyEnforcement(unittest.IsolatedAsyncioTestCase):
+    """Risk note — foreign_keys pragma must be ON and enforced."""
+
+    async def test_orphan_finding_blocked(self):
+        store = _new_store()
+        try:
+            with self.assertRaises(IntegrityError):
+                await store.add_finding(
+                    "nonexistent-task", "low", "tests", "f.py", 1,
+                    "x", "y", "z", 0.5, "rule", "warnings")
+        finally:
+            await store.close()
+
+
+class TestProtocolConformance(unittest.IsolatedAsyncioTestCase):
+    """DoD #5 — SQLiteStore satisfies the ReviewStore protocol."""
+
+    def test_sqlite_store_is_review_store(self):
+        self.assertIsInstance(SQLiteStore(":memory:"), ReviewStore)
+
+    def test_protocol_methods_present(self):
+        for name in ("create_task", "update_task_status", "add_input_diff",
+                     "add_sandbox_run", "add_finding", "add_filter_block",
+                     "set_monitor_summary", "set_report", "get_task"):
+            self.assertTrue(hasattr(SQLiteStore, name), f"missing {name}")
+
+    def test_fake_store_satisfies_protocol(self):
+        class FakeStore:
+            async def create_task(self, input_type, input_ref, mode): return "fake"
+            async def update_task_status(self, task_id, status, total_duration_ms=None): pass
+            async def add_input_diff(self, task_id, file_path, sha256, hunk_count, line_count, summary): return "fake"
+            async def add_sandbox_run(self, task_id, runtime, script, status, duration_ms, exit_code, output_bytes, timed_out, masked_count): return "fake"
+            async def add_finding(self, task_id, severity, category, file, line, title, evidence, recommendation, confidence, source, bucket): return "fake"
+            async def add_filter_block(self, task_id, reason, target, decision, detail): return "fake"
+            async def set_monitor_summary(self, task_id, summary): pass
+            async def set_report(self, task_id, json_path, md_path, summary): return "fake"
+            async def get_task(self, task_id): return {"task": {"id": task_id}}
+
+        self.assertIsInstance(FakeStore(), ReviewStore)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/examples/skills_code_review_agent/tests/test_phase1_input_skill.py
+++ b/examples/skills_code_review_agent/tests/test_phase1_input_skill.py
@@ -1,0 +1,450 @@
+# Tencent is pleased to support the open source community by making tRPC-Agent-Python available.
+#
+# Copyright (C) 2026 Tencent. All rights reserved.
+#
+# tRPC-Agent-Python is licensed under Apache-2.0.
+"""Phase 1 (Input & Skill loading) acceptance tests.
+
+Covers every line of the Phase-1 Definition of Done:
+  1. parse_diff parses a standard unified diff (files / hunks / line numbers).
+  2. add lines carry correct new_line_no.
+  3. skill_load reads SKILL.md frontmatter → rules + scripts + sandbox_config.
+  4. ChangeSet persists to the input_diff table.
+  5. All three input modes work: --diff-file / --repo-path / fixture.
+
+Run:
+    python examples/skills_code_review_agent/tests/test_phase1_input_skill.py
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import sqlite3
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+_EXAMPLE_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_EXAMPLE_ROOT))
+
+# parse_diff lives under the skill scripts dir; agent.py wires it onto
+# sys.path on import, but we add it directly so tests can import it too.
+_SCRIPTS_DIR = _EXAMPLE_ROOT / "skills" / "code-review" / "scripts"
+sys.path.insert(0, str(_SCRIPTS_DIR))
+
+import agent  # noqa: E402
+from agent.db import SQLiteStore  # noqa: E402
+from parse_diff import ChangeSet  # noqa: E402
+from parse_diff import parse_diff  # noqa: E402
+
+_SKILL_DIR = _EXAMPLE_ROOT / "skills" / "code-review"
+
+# A canonical diff with known line numbers, used to assert new_line_no.
+_SAMPLE_DIFF = """\
+diff --git a/foo.py b/foo.py
+--- a/foo.py
++++ b/foo.py
+@@ -10,3 +10,4 @@
+ context line
+-old line
++new line
++added line
+diff --git a/bar.py b/bar.py
+--- /dev/null
++++ b/bar.py
+@@ -0,0 +1,2 @@
++def hello():
++    return "hi"
+"""
+
+# diff with binary + rename + mode-change meta lines to test tolerance.
+_META_DIFF = """\
+diff --git a/binary.dat b/binary.dat
+index 1234567..89abcde 100644
+Binary files a/binary.dat and b/binary.dat differ
+diff --git a/old.py b/new.py
+similarity index 90%
+rename from old.py
+rename to new.py
+diff --git a/mode.sh b/mode.sh
+old mode 100644
+new mode 100755
+diff --git a/real.py b/real.py
+--- a/real.py
++++ b/real.py
+@@ -1,2 +1,2 @@
+-x
++y
+ z
+"""
+
+
+def _git_available() -> bool:
+    return shutil.which("git") is not None
+
+
+class TestParseDiff(unittest.TestCase):
+    """DoD #1 — parse_diff extracts files / hunks / line numbers."""
+
+    def test_parses_two_files(self):
+        cs = parse_diff(_SAMPLE_DIFF)
+        self.assertIsInstance(cs, ChangeSet)
+        self.assertEqual(cs.file_count, 2)
+        paths = [f.path for f in cs.files]
+        self.assertEqual(paths, ["foo.py", "bar.py"])
+
+    def test_status_inference(self):
+        cs = parse_diff(_SAMPLE_DIFF)
+        self.assertEqual(cs.files[0].status, "modified")  # --- a/ +++ b/
+        self.assertEqual(cs.files[1].status, "added")     # --- /dev/null
+
+    def test_hunk_header_fields(self):
+        cs = parse_diff(_SAMPLE_DIFF)
+        h = cs.files[0].hunks[0]
+        self.assertEqual((h.old_start, h.old_count), (10, 3))
+        self.assertEqual((h.new_start, h.new_count), (10, 4))
+
+    def test_line_types(self):
+        cs = parse_diff(_SAMPLE_DIFF)
+        h = cs.files[0].hunks[0]
+        types = [ln.type for ln in h.lines]
+        self.assertEqual(types, ["ctx", "del", "add", "add"])
+
+    def test_content_stripped_of_sigil(self):
+        cs = parse_diff(_SAMPLE_DIFF)
+        h = cs.files[0].hunks[0]
+        self.assertEqual(h.lines[0].content, "context line")
+        self.assertEqual(h.lines[1].content, "old line")
+        self.assertEqual(h.lines[2].content, "new line")
+
+    def test_hunk_without_counts(self):
+        """@@ -1 +1 @@ (no comma counts) must parse with count=1."""
+        diff = "--- a/x\n+++ b/x\n@@ -1 +1 @@\n-a\n+b\n"
+        cs = parse_diff(diff)
+        h = cs.files[0].hunks[0]
+        self.assertEqual(h.old_count, 1)
+        self.assertEqual(h.new_count, 1)
+
+    def test_empty_diff_returns_empty_changeset(self):
+        self.assertEqual(parse_diff("").file_count, 0)
+        self.assertEqual(parse_diff("   \n  ").file_count, 0)
+
+    def test_meta_lines_tolerated(self):
+        """Binary / rename / mode-change meta must be skipped, not crash."""
+        cs = parse_diff(_META_DIFF)
+        # Only real.py has an actual hunk; the others are meta-only.
+        paths = [f.path for f in cs.files]
+        self.assertIn("real.py", paths)
+        self.assertEqual(len(cs.files), 1)
+        self.assertEqual(cs.files[0].hunks[0].lines[0].content, "x")
+
+    def test_no_newline_marker_skipped(self):
+        diff = (
+            "--- a/x\n+++ b/x\n@@ -1 +1 @@\n-old\n\\ No newline at end of file\n"
+            "+new\n\\ No newline at end of file\n"
+        )
+        cs = parse_diff(diff)
+        h = cs.files[0].hunks[0]
+        # Two real lines (del + add); the two \ markers are dropped.
+        self.assertEqual(len(h.lines), 2)
+        self.assertEqual([ln.type for ln in h.lines], ["del", "add"])
+
+    def test_changed_file_helpers(self):
+        cs = parse_diff(_SAMPLE_DIFF)
+        f = cs.files[0]
+        self.assertEqual(f.hunk_count, 1)
+        self.assertEqual(f.added_lines, 2)
+        self.assertEqual(f.deleted_lines, 1)
+        self.assertEqual(f.line_count, 4)  # ctx+del+add+add
+
+
+class TestParseDiffLineNumbers(unittest.TestCase):
+    """DoD #2 — add lines carry correct new_line_no."""
+
+    def test_new_line_no_increments_on_add_and_ctx(self):
+        cs = parse_diff(_SAMPLE_DIFF)
+        h = cs.files[0].hunks[0]  # @@ -10,3 +10,4 @@
+        # ctx -> 10, del -> None, add -> 11, add -> 12
+        self.assertEqual(h.lines[0].new_line_no, 10)   # ctx
+        self.assertIsNone(h.lines[1].new_line_no)      # del
+        self.assertEqual(h.lines[2].new_line_no, 11)   # add
+        self.assertEqual(h.lines[3].new_line_no, 12)   # add
+
+    def test_added_file_starts_at_new_start(self):
+        cs = parse_diff(_SAMPLE_DIFF)
+        h = cs.files[1].hunks[0]  # @@ -0,0 +1,2 @@
+        self.assertEqual(h.new_start, 1)
+        self.assertEqual(h.lines[0].new_line_no, 1)  # first add line
+        self.assertEqual(h.lines[1].new_line_no, 2)
+
+    def test_del_lines_carry_none(self):
+        diff = "--- a/x\n+++ b/x\n@@ -5,2 +5,1 @@\n ctx\n-removed\n-also\n"
+        cs = parse_diff(diff)
+        h = cs.files[0].hunks[0]
+        self.assertIsNone(h.lines[1].new_line_no)
+        self.assertIsNone(h.lines[2].new_line_no)
+        # ctx line keeps its number; del lines don't advance it.
+        self.assertEqual(h.lines[0].new_line_no, 5)
+
+    def test_multiple_hunks_line_numbers_independent(self):
+        diff = (
+            "--- a/x\n+++ b/x\n"
+            "@@ -10,2 +10,2 @@\n c\n-a\n+b\n"
+            "@@ -50,2 +50,2 @@\n d\n-e\n+f\n"
+        )
+        cs = parse_diff(diff)
+        hunks = cs.files[0].hunks
+        self.assertEqual(len(hunks), 2)
+        # hunk0: ctx(10), del(None), add(11)  →  +b at line 11
+        self.assertEqual(hunks[0].lines[0].new_line_no, 10)   # ctx c
+        self.assertIsNone(hunks[0].lines[1].new_line_no)      # del a
+        self.assertEqual(hunks[0].lines[2].new_line_no, 11)   # add b
+        # hunk1: ctx(50), del(None), add(51)  →  +f at line 51
+        self.assertEqual(hunks[1].lines[0].new_line_no, 50)   # ctx d
+        self.assertIsNone(hunks[1].lines[1].new_line_no)      # del e
+        self.assertEqual(hunks[1].lines[2].new_line_no, 51)   # add f
+
+
+class TestSkillLoad(unittest.TestCase):
+    """DoD #3 — skill_load reads frontmatter → rules + scripts + sandbox_config."""
+
+    def test_returns_name_and_lists(self):
+        skill = agent.skill_load(_SKILL_DIR)
+        self.assertEqual(skill["name"], "code-review")
+        self.assertIsInstance(skill["rules"], list)
+        self.assertIsInstance(skill["scripts"], list)
+        self.assertGreater(len(skill["rules"]), 0)
+        self.assertGreater(len(skill["scripts"]), 0)
+
+    def test_rules_are_relative_paths_to_md(self):
+        skill = agent.skill_load(_SKILL_DIR)
+        for r in skill["rules"]:
+            self.assertTrue(r.startswith("rules/"))
+            self.assertTrue(r.endswith(".md"))
+        # The six canonical rule files are present.
+        expected = {
+            "rules/security.md",
+            "rules/async_errors.md",
+            "rules/resource_leak.md",
+            "rules/missing_tests.md",
+            "rules/sensitive_info.md",
+            "rules/db_lifecycle.md",
+        }
+        self.assertEqual(set(skill["rules"]), expected)
+
+    def test_scripts_are_relative_py_paths(self):
+        skill = agent.skill_load(_SKILL_DIR)
+        self.assertIn("scripts/parse_diff.py", skill["scripts"])
+        for s in skill["scripts"]:
+            self.assertTrue(s.startswith("scripts/"))
+            self.assertTrue(s.endswith(".py"))
+
+    def test_sandbox_config_fields_and_types(self):
+        cfg = agent.skill_load(_SKILL_DIR)["sandbox_config"]
+        self.assertEqual(cfg["default_runtime"], "container")
+        self.assertEqual(cfg["fallback"], "local")
+        self.assertEqual(cfg["timeout_s"], 30)
+        self.assertIsInstance(cfg["timeout_s"], int)
+        self.assertEqual(cfg["max_output_bytes"], 1048576)
+        self.assertIsInstance(cfg["max_output_bytes"], int)
+        self.assertEqual(cfg["env_whitelist"], ["PATH", "HOME", "LANG"])
+        self.assertIsInstance(cfg["env_whitelist"], list)
+
+    def test_skill_load_missing_skill_md_raises(self):
+        with self.assertRaises(FileNotFoundError):
+            agent.skill_load(_EXAMPLE_ROOT)  # no SKILL.md here
+
+
+class TestChangeSetPersist(unittest.IsolatedAsyncioTestCase):
+    """DoD #4 — ChangeSet persists to the input_diff table (async store)."""
+
+    async def test_persist_writes_one_row_per_file(self):
+        store = SQLiteStore(":memory:")
+        try:
+            tid = await store.create_task("diff", "sample.diff", "dry-run")
+            cs = parse_diff(_SAMPLE_DIFF)
+            written = await agent.persist_changeset(store, tid, cs)
+            self.assertEqual(written, 2)
+
+            diffs = (await store.get_task(tid))["input_diffs"]
+            self.assertEqual(len(diffs), 2)
+            by_path = {d["file_path"]: d for d in diffs}
+
+            foo = by_path["foo.py"]
+            self.assertEqual(foo["hunk_count"], 1)
+            self.assertEqual(foo["line_count"], 4)  # ctx+del+add+add
+            self.assertIn("2+", foo["summary"])  # 2 add lines
+            self.assertIn("1-", foo["summary"])  # 1 del line
+            self.assertRegex(foo["sha256"], r"^[0-9a-f]{64}$")
+
+            bar = by_path["bar.py"]
+            self.assertEqual(bar["hunk_count"], 1)
+            self.assertEqual(bar["line_count"], 2)  # 2 add lines
+            self.assertRegex(bar["sha256"], r"^[0-9a-f]{64}$")
+
+            # sha256 differs per file.
+            self.assertNotEqual(foo["sha256"], bar["sha256"])
+        finally:
+            await store.close()
+
+    async def test_persist_empty_changeset_writes_nothing(self):
+        store = SQLiteStore(":memory:")
+        try:
+            tid = await store.create_task("diff", "empty.diff", "dry-run")
+            written = await agent.persist_changeset(store, tid, parse_diff(""))
+            self.assertEqual(written, 0)
+            self.assertEqual(len((await store.get_task(tid))["input_diffs"]), 0)
+        finally:
+            await store.close()
+
+    async def test_persist_rolls_into_get_task_join(self):
+        """Phase-0 get_task must surface the Phase-1 input_diff rows."""
+        store = SQLiteStore(":memory:")
+        try:
+            tid = await store.create_task("fixture", "security", "dry-run")
+            cs = parse_diff(agent.FIXTURES["security"])
+            await agent.persist_changeset(store, tid, cs)
+            rec = await store.get_task(tid)
+            self.assertEqual(rec["task"]["id"], tid)
+            self.assertEqual(len(rec["input_diffs"]), 2)
+        finally:
+            await store.close()
+
+
+class TestInputModes(unittest.TestCase):
+    """DoD #5 — --diff-file / --repo-path / fixture all work."""
+
+    def test_diff_file_mode(self):
+        fd, path = tempfile.mkstemp(suffix=".diff")
+        os.close(fd)
+        try:
+            Path(path).write_text(_SAMPLE_DIFF, encoding="utf-8")
+            text, itype, ref = agent.load_diff(diff_file=path)
+            self.assertEqual(itype, "diff")
+            self.assertEqual(ref, path)
+            self.assertEqual(parse_diff(text).file_count, 2)
+        finally:
+            os.unlink(path)
+
+    def test_fixture_mode_security(self):
+        text, itype, ref = agent.load_diff(fixture="security")
+        self.assertEqual(itype, "fixture")
+        self.assertEqual(ref, "security")
+        cs = parse_diff(text)
+        self.assertEqual(cs.file_count, 2)
+        paths = [f.path for f in cs.files]
+        self.assertIn("app/db.py", paths)
+        self.assertIn("app/secret.py", paths)
+
+    def test_fixture_mode_clean(self):
+        text, itype, ref = agent.load_diff(fixture="clean")
+        self.assertEqual(itype, "fixture")
+        self.assertEqual(parse_diff(text).file_count, 1)
+
+    def test_fixture_unknown_raises(self):
+        with self.assertRaises(KeyError):
+            agent.load_diff(fixture="nope")
+
+    def test_no_input_raises(self):
+        with self.assertRaises(ValueError):
+            agent.load_diff()
+
+    @unittest.skipUnless(_git_available(), "git not installed")
+    def test_repo_path_mode_git_diff_head(self):
+        """Create a temp git repo, commit, modify, and read `git diff HEAD`."""
+        repo = tempfile.mkdtemp(prefix="cr_p1_repo_")
+        try:
+            env = dict(os.environ)
+            # Minimal git identity so commit doesn't fail.
+            subprocess.run(
+                ["git", "init", "-q"], cwd=repo, check=True,
+                env=env,
+            )
+            subprocess.run(
+                ["git", "config", "user.email", "t@t"], cwd=repo, check=True,
+            )
+            subprocess.run(
+                ["git", "config", "user.name", "t"], cwd=repo, check=True,
+            )
+            # Initial commit.
+            Path(repo, "a.py").write_text("a = 1\n", encoding="utf-8")
+            subprocess.run(["git", "add", "."], cwd=repo, check=True)
+            subprocess.run(
+                ["git", "commit", "-q", "-m", "init"], cwd=repo, check=True,
+                env=env,
+            )
+            # Modify a.py (unstaged) → git diff HEAD should see it.
+            Path(repo, "a.py").write_text("a = 2\nb = 3\n", encoding="utf-8")
+
+            text, itype, ref = agent.load_diff(repo_path=repo)
+            self.assertEqual(itype, "repo")
+            self.assertEqual(ref, repo)
+            cs = parse_diff(text)
+            self.assertEqual(cs.file_count, 1)
+            self.assertEqual(cs.files[0].path, "a.py")
+            # Modified: added b=3, changed a=1→a=2.
+            self.assertEqual(cs.files[0].status, "modified")
+        finally:
+            shutil.rmtree(repo, ignore_errors=True)
+
+
+class TestCLIIntegration(unittest.TestCase):
+    """End-to-end: `agent.py --fixture ...` runs the full Phase-1 chain."""
+
+    def test_cli_fixture_security(self):
+        db_path = tempfile.mktemp(suffix=".db", prefix="cr_p1_cli_")
+        out_dir = tempfile.mkdtemp(prefix="cr_p1_out_")
+        try:
+            rc = agent.main(
+                ["--fixture", "security", "--db-path", db_path, "--output-dir", out_dir]
+            )
+            self.assertEqual(rc, 0)
+            # Verify persistence directly. P5 full pipeline → status "done".
+            conn = sqlite3.connect(db_path)
+            conn.row_factory = sqlite3.Row
+            task = conn.execute("SELECT * FROM review_task").fetchone()
+            self.assertEqual(task["status"], "done")
+            self.assertEqual(task["input_type"], "fixture")
+            self.assertEqual(task["input_ref"], "security")
+            n = conn.execute("SELECT COUNT(*) FROM input_diff").fetchone()[0]
+            conn.close()
+            self.assertEqual(n, 2)
+        finally:
+            if os.path.exists(db_path):
+                try:
+                    os.unlink(db_path)
+                except PermissionError:
+                    pass
+            shutil.rmtree(out_dir, ignore_errors=True)
+
+    def test_cli_diff_file_mode(self):
+        fd, diff_path = tempfile.mkstemp(suffix=".diff")
+        os.close(fd)
+        db_path = tempfile.mktemp(suffix=".db")
+        out_dir = tempfile.mkdtemp(prefix="cr_p1_out_")
+        try:
+            Path(diff_path).write_text(_SAMPLE_DIFF, encoding="utf-8")
+            rc = agent.main(
+                ["--diff-file", diff_path, "--db-path", db_path, "--output-dir", out_dir]
+            )
+            self.assertEqual(rc, 0)
+            conn = sqlite3.connect(db_path)
+            n = conn.execute("SELECT COUNT(*) FROM input_diff").fetchone()[0]
+            conn.close()
+            self.assertEqual(n, 2)
+        finally:
+            if os.path.exists(diff_path):
+                os.unlink(diff_path)
+            if os.path.exists(db_path):
+                try:
+                    os.unlink(db_path)
+                except PermissionError:
+                    pass
+            shutil.rmtree(out_dir, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/examples/skills_code_review_agent/tests/test_phase2_rules_engine.py
+++ b/examples/skills_code_review_agent/tests/test_phase2_rules_engine.py
@@ -1,0 +1,400 @@
+# Tencent is pleased to support the open source community by making tRPC-Agent-Python available.
+#
+# Copyright (C) 2026 Tencent. All rights reserved.
+#
+# tRPC-Agent-Python is licensed under Apache-2.0.
+"""Phase 2 (Rules engine) acceptance tests.
+
+Covers every line of the Phase-2 Definition of Done:
+  1. Six rule docs present, each with ≥3 concrete rules.
+  2. run_checks detects each rule category on a sample diff.
+  3. RawFinding has all fields with sensible confidence.
+  4. mask_secrets redacts common secret formats with correct count.
+  5. A clean diff yields an empty finding list (no false positives).
+
+Run:
+    python examples/skills_code_review_agent/tests/test_phase2_rules_engine.py
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+_EXAMPLE_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_EXAMPLE_ROOT))
+
+_SCRIPTS_DIR = _EXAMPLE_ROOT / "skills" / "code-review" / "scripts"
+sys.path.insert(0, str(_SCRIPTS_DIR))
+
+import agent  # noqa: E402
+from mask_secrets import mask_secrets  # noqa: E402
+from parse_diff import parse_diff  # noqa: E402
+from run_checks import RawFinding  # noqa: E402
+from run_checks import load_rules  # noqa: E402
+from run_checks import run_checks  # noqa: E402
+
+_SKILL_DIR = _EXAMPLE_ROOT / "skills" / "code-review"
+
+
+def _ruleset() -> dict:
+    """A ruleset wired to the real skill dir (exercises load_rules on disk)."""
+    return agent.skill_load(_SKILL_DIR)
+
+
+def _run(diff_text: str) -> list[RawFinding]:
+    cs = parse_diff(diff_text)
+    return run_checks(cs, _ruleset())
+
+
+def _diff(path: str, add_lines: list[str], extra_files: list[tuple[str, list[str]]] | None = None) -> str:
+    """Build a minimal diff adding the given lines to ``path`` (and optional
+    extra files). Each add line is prefixed with '+' automatically."""
+    parts = [f"diff --git a/{path} b/{path}", f"--- a/{path}", f"+++ b/{path}",
+             "@@ -0,0 +1,{0} @@".format(len(add_lines) if add_lines else 1)]
+    for ln in add_lines:
+        parts.append("+" + ln)
+    for fpath, flines in (extra_files or []):
+        parts.append(f"diff --git a/{fpath} b/{fpath}")
+        parts.append(f"--- a/{fpath}")
+        parts.append(f"+++ b/{fpath}")
+        parts.append("@@ -0,0 +1,{0} @@".format(len(flines) if flines else 1))
+        for ln in flines:
+            parts.append("+" + ln)
+    return "\n".join(parts) + "\n"
+
+
+class TestRuleDocs(unittest.TestCase):
+    """DoD #1 — six rule docs, each with ≥3 concrete rules."""
+
+    def test_six_categories_loaded(self):
+        rs = _ruleset()
+        rules = load_rules(rs["skill_dir"], rs["rules"])
+        self.assertEqual(
+            set(rules.keys()),
+            {"security", "sensitive", "async", "resource", "db", "tests"},
+        )
+
+    def test_each_category_has_at_least_three_rules(self):
+        rs = _ruleset()
+        rules = load_rules(rs["skill_dir"], rs["rules"])
+        for cat, rlist in rules.items():
+            self.assertGreaterEqual(
+                len(rlist), 3, f"category {cat} has only {len(rlist)} rules"
+            )
+
+    def test_rule_fields_complete(self):
+        rs = _ruleset()
+        rules = load_rules(rs["skill_dir"], rs["rules"])
+        for cat, rlist in rules.items():
+            for r in rlist:
+                for field in ("id", "pattern", "severity_hint", "confidence", "description"):
+                    self.assertIn(field, r, f"{cat} rule missing {field}: {r}")
+                self.assertIn(r.get("type"), ("pattern", "ast", "diff", None))
+
+    def test_skill_load_returns_skill_dir(self):
+        """P2 added skill_dir so run_checks can locate rule docs."""
+        rs = agent.skill_load(_SKILL_DIR)
+        self.assertIn("skill_dir", rs)
+        self.assertTrue(Path(rs["skill_dir"]).is_absolute())
+        self.assertTrue((Path(rs["skill_dir"]) / "SKILL.md").exists())
+
+
+class TestRunChecksSecurity(unittest.TestCase):
+    """DoD #2 — run_checks detects security issues."""
+
+    def test_sql_injection_detected(self):
+        findings = _run(_diff("s.py", [
+            'def get(uid):',
+            '    cur = conn.execute("SELECT * FROM u WHERE id=" + str(uid))',
+        ]))
+        sec = [f for f in findings if f.category == "security"]
+        self.assertTrue(any("SEC001" in f.title for f in sec), sec)
+        self.assertEqual(sec[0].severity_hint, "critical")
+        self.assertGreaterEqual(sec[0].confidence, 0.9)
+
+    def test_command_injection_detected(self):
+        findings = _run(_diff("s.py", [
+            '    os.system("ls " + name)',
+        ]))
+        self.assertTrue(any("SEC002" in f.title for f in findings))
+
+    def test_pickle_deserialization_detected(self):
+        findings = _run(_diff("s.py", [
+            '    data = pickle.loads(user_bytes)',
+        ]))
+        self.assertTrue(any("SEC004" in f.title for f in findings))
+
+    def test_hardcoded_key_detected(self):
+        findings = _run(_diff("s.py", [
+            'API_KEY = "sk-1234567890abcdef1234567890"',
+        ]))
+        sec = [f for f in findings if f.category == "security"]
+        self.assertTrue(any("SEC003" in f.title for f in sec))
+
+
+class TestRunChecksSensitive(unittest.TestCase):
+    """DoD #2 — run_checks detects sensitive info (patterns + entropy)."""
+
+    def test_known_formats_detected(self):
+        findings = _run(_diff("c.py", [
+            'a = "AKIAIOSFODNN7EXAMPLE"',
+            'b = "sk-1234567890abcdef1234567890abcdef"',
+            'c = "ghp_aBcDeFgHiJkLmNoPqRsTuVwXyZ1234567890"',
+            'password = "hunter2"',
+        ]))
+        sen = [f for f in findings if f.category == "sensitive"]
+        ids = " ".join(f.title for f in sen)
+        self.assertIn("SEN001", ids)  # AWS
+        self.assertIn("SEN002", ids)  # OpenAI
+        self.assertIn("SEN003", ids)  # GitHub
+        self.assertIn("SEN004", ids)  # password
+        for f in sen:
+            self.assertGreaterEqual(f.confidence, 0.85)
+
+    def test_entropy_detected_for_unprefixed_token(self):
+        # A high-entropy base64 string with no known prefix → SEN_ENT.
+        findings = _run(_diff("c.py", [
+            'key = "Zm9vYmFyYmF6cXV4NTEyMzRhYmNkZWZnaGlqa2xtbg=="',
+        ]))
+        ent = [f for f in findings if f.category == "sensitive" and "SEN_ENT" in f.title]
+        self.assertEqual(len(ent), 1)
+        self.assertEqual(ent[0].severity_hint, "critical")
+
+    def test_known_format_suppresses_duplicate_entropy(self):
+        # ghp_ token is high-entropy but already caught by SEN003 — no SEN_ENT.
+        findings = _run(_diff("c.py", [
+            'TOKEN = "ghp_aBcDeFgHiJkLmNoPqRsTuVwXyZ1234567890"',
+        ]))
+        sen = [f for f in findings if f.category == "sensitive"]
+        self.assertTrue(any("SEN003" in f.title for f in sen))
+        self.assertFalse(any("SEN_ENT" in f.title for f in sen), sen)
+
+
+class TestRunChecksAsync(unittest.TestCase):
+    """DoD #2 — run_checks detects async errors."""
+
+    def test_gather_without_await_detected(self):
+        findings = _run(_diff("a.py", [
+            '    task = asyncio.gather(coro1, coro2)',
+        ]))
+        asy = [f for f in findings if f.category == "async"]
+        self.assertTrue(any("ASY001" in f.title for f in asy))
+
+    def test_client_session_without_async_with_detected(self):
+        findings = _run(_diff("a.py", [
+            '    session = aiohttp.ClientSession()',
+        ]))
+        asy = [f for f in findings if f.category == "async"]
+        self.assertTrue(any("ASY002" in f.title for f in asy))
+
+    def test_awaited_call_not_flagged(self):
+        findings = _run(_diff("a.py", [
+            '    await asyncio.gather(coro1, coro2)',
+        ]))
+        asy = [f for f in findings if f.category == "async" and "ASY001" in f.title]
+        self.assertEqual(asy, [])
+
+
+class TestRunChecksResource(unittest.TestCase):
+    """DoD #2 — run_checks detects resource leaks (with `with` filtering)."""
+
+    def test_open_without_with_detected(self):
+        findings = _run(_diff("r.py", [
+            '    f = open("x.txt")',
+        ]))
+        res = [f for f in findings if f.category == "resource"]
+        self.assertTrue(any("RES001" in f.title for f in res))
+
+    def test_open_with_with_not_flagged(self):
+        findings = _run(_diff("r.py", [
+            '    with open("x.txt") as f:',
+            '        pass',
+        ]))
+        res = [f for f in findings if f.category == "resource" and "RES001" in f.title]
+        self.assertEqual(res, [])
+
+    def test_connect_without_with_detected(self):
+        findings = _run(_diff("r.py", [
+            '    conn = pool.connect()',
+        ]))
+        res = [f for f in findings if f.category == "resource"]
+        self.assertTrue(any("RES002" in f.title for f in res))
+
+
+class TestRunChecksDb(unittest.TestCase):
+    """DoD #2 — run_checks detects DB lifecycle issues."""
+
+    def test_connect_without_with_detected(self):
+        findings = _run(_diff("d.py", [
+            '    conn = engine.connect()',
+        ]))
+        db = [f for f in findings if f.category == "db"]
+        self.assertTrue(any("DB001" in f.title for f in db))
+
+    def test_cursor_without_close_detected(self):
+        findings = _run(_diff("d.py", [
+            '    cur = conn.cursor()',
+        ]))
+        db = [f for f in findings if f.category == "db"]
+        self.assertTrue(any("DB002" in f.title for f in db))
+
+    def test_begin_transaction_detected(self):
+        findings = _run(_diff("d.py", [
+            '    txn = conn.begin()',
+        ]))
+        db = [f for f in findings if f.category == "db"]
+        self.assertTrue(any("DB003" in f.title for f in db))
+
+
+class TestRunChecksTests(unittest.TestCase):
+    """DoD #2 — run_checks detects missing tests (cross-file)."""
+
+    def test_new_public_function_without_test_detected(self):
+        findings = _run(_diff("app.py", [
+            'def public_fn(arg):',
+            '    return arg',
+        ]))
+        tests = [f for f in findings if f.category == "tests"]
+        self.assertTrue(any("public_fn" in f.title for f in tests))
+
+    def test_new_function_with_test_not_flagged(self):
+        findings = _run(_diff("app.py", [
+            'def public_fn(arg):',
+            '    return arg',
+        ], extra_files=[("test_app.py", ['def test_public_fn():', '    assert public_fn(1) == 1'])]))
+        tests = [f for f in findings if f.category == "tests" and "public_fn" in f.title]
+        self.assertEqual(tests, [])
+
+    def test_private_function_not_flagged(self):
+        findings = _run(_diff("app.py", [
+            'def _private():',
+            '    pass',
+        ]))
+        tests = [f for f in findings if f.category == "tests"]
+        self.assertEqual(tests, [])
+
+
+class TestRawFindingFields(unittest.TestCase):
+    """DoD #3 — RawFinding fields complete, confidence sensible."""
+
+    def test_fields_complete(self):
+        findings = _run(_diff("s.py", [
+            '    cur = conn.execute("SELECT * FROM u WHERE id=" + x)',
+        ]))
+        self.assertTrue(findings)
+        for f in findings:
+            self.assertIsInstance(f.category, str)
+            self.assertIsInstance(f.file, str)
+            self.assertIsInstance(f.line, int)
+            self.assertIsInstance(f.title, str)
+            self.assertIsInstance(f.evidence, str)
+            self.assertIsInstance(f.severity_hint, str)
+            self.assertIsInstance(f.confidence, float)
+            self.assertEqual(f.source, "rule")
+            self.assertIn(f.category, ("security", "sensitive", "async", "resource", "db", "tests"))
+            self.assertIn(f.severity_hint, ("critical", "high", "medium", "low"))
+            self.assertGreater(f.confidence, 0.0)
+            self.assertLessEqual(f.confidence, 1.0)
+
+    def test_confidence_range_by_strength(self):
+        # Exact known format → ≥0.9; heuristic AST/pattern → ≤0.75.
+        known = _run(_diff("c.py", ['a = "AKIAIOSFODNN7EXAMPLE"']))
+        known_conf = [f.confidence for f in known if "SEN001" in f.title]
+        self.assertTrue(known_conf and known_conf[0] >= 0.9)
+
+        heur = _run(_diff("a.py", ['    task = asyncio.gather(coro)']))
+        heur_conf = [f.confidence for f in heur if "ASY001" in f.title]
+        self.assertTrue(heur_conf and heur_conf[0] <= 0.75)
+
+    def test_to_dict_roundtrip(self):
+        f = RawFinding("security", "a.py", 1, "t", "e", "high", 0.9)
+        d = f.to_dict()
+        self.assertEqual(d["category"], "security")
+        self.assertEqual(d["confidence"], 0.9)
+
+
+class TestMaskSecrets(unittest.TestCase):
+    """DoD #4 — mask_secrets redacts common formats with correct count."""
+
+    def test_aws_key(self):
+        m, n = mask_secrets("key AKIAIOSFODNN7EXAMPLE here")
+        self.assertIn("***REDACTED***", m)
+        self.assertEqual(n, 1)
+
+    def test_openai_key(self):
+        m, n = mask_secrets("sk-1234567890abcdef1234567890abcdef")
+        self.assertEqual(n, 1)
+        self.assertEqual(m, "***REDACTED***")
+
+    def test_github_token(self):
+        m, n = mask_secrets("ghp_aBcDeFgHiJkLmNoPqRsTuVwXyZ1234567890")
+        self.assertEqual(n, 1)
+
+    def test_password_assignment(self):
+        m, n = mask_secrets('password = "hunter2"')
+        self.assertEqual(n, 1)
+        self.assertIn("***REDACTED***", m)
+
+    def test_private_key(self):
+        m, n = mask_secrets("-----BEGIN RSA PRIVATE KEY-----\nblah")
+        self.assertEqual(n, 1)
+
+    def test_connection_string(self):
+        m, n = mask_secrets("postgres://user:secretpw@host/db")
+        self.assertEqual(n, 1)
+
+    def test_multiple_secrets_count(self):
+        text = "AKIAIOSFODNN7EXAMPLE and sk-1234567890abcdef1234567890abcdef"
+        m, n = mask_secrets(text)
+        self.assertEqual(n, 2)
+        self.assertEqual(m.count("***REDACTED***"), 2)
+
+    def test_no_secrets(self):
+        m, n = mask_secrets("just normal text without secrets")
+        self.assertEqual(n, 0)
+        self.assertEqual(m, "just normal text without secrets")
+
+    def test_empty(self):
+        self.assertEqual(mask_secrets(""), ("", 0))
+
+    def test_entropy_redaction(self):
+        # High-entropy base64 with no known prefix → redacted by entropy.
+        m, n = mask_secrets("key=Zm9vYmFyYmF6cXV4NTEyMzRhYmNkZWZnaGlqa2xtbg==")
+        self.assertGreaterEqual(n, 1)
+        self.assertIn("***REDACTED***", m)
+
+
+class TestCleanDiff(unittest.TestCase):
+    """DoD #5 — a clean diff produces an empty finding list."""
+
+    def test_clean_fixture_no_findings(self):
+        findings = _run(agent.FIXTURES["clean"])
+        self.assertEqual(findings, [])
+
+    def test_trivial_clean_diff(self):
+        findings = _run(_diff("ok.py", [
+            '    return a + b',
+            '',
+        ]))
+        self.assertEqual(findings, [])
+
+    def test_empty_changeset(self):
+        self.assertEqual(run_checks(parse_diff(""), _ruleset()), [])
+
+
+class TestRunChecksUsesSkillDir(unittest.TestCase):
+    """run_checks resolves rules via skill_load's skill_dir (integration)."""
+
+    def test_run_via_skill_load_ruleset(self):
+        rs = agent.skill_load(_SKILL_DIR)  # carries skill_dir + rules
+        cs = parse_diff(_diff("s.py", [
+            '    cur = conn.execute("SELECT * FROM u WHERE id=" + x)',
+        ]))
+        findings = run_checks(cs, rs)
+        self.assertTrue(any(f.category == "security" for f in findings))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/examples/skills_code_review_agent/tests/test_phase3_container_sandbox.py
+++ b/examples/skills_code_review_agent/tests/test_phase3_container_sandbox.py
@@ -1,0 +1,106 @@
+# Tencent is pleased to support the open source community by making tRPC-Agent-Python available.
+#
+# Copyright (C) 2026 Tencent. All rights reserved.
+#
+# tRPC-Agent-Python is licensed under Apache-2.0.
+"""Container (independent sandbox) integration tests — Phase 3, G1 closure.
+
+These tests prove the PRD's production sandbox contract: in ``real`` mode the
+code-review checks execute inside an **isolated docker container**
+(``network_mode=none``, no inherited host env), not a local process. They are
+gated on docker availability and SKIP (not fail) in environments without a
+docker daemon, so the default suite stays green in CI.
+
+Run with docker present to actually exercise the independent sandbox.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sqlite3
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+EXAMPLE_ROOT = Path(__file__).resolve().parent.parent
+for _p in (EXAMPLE_ROOT, EXAMPLE_ROOT / "skills" / "code-review" / "scripts"):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+from agent.agent import FIXTURES, parse_diff, skill_load  # noqa: E402
+from agent.sandbox import ContainerRuntime, SandboxPolicy  # noqa: E402
+from run_checks import load_rules  # noqa: E402
+
+
+def _docker_available() -> bool:
+    """Best-effort probe: is a docker daemon reachable in this environment?"""
+    try:
+        import docker  # noqa: F401
+
+        client = docker.from_env()
+        return bool(client.ping())
+    except Exception:
+        return False
+
+
+@unittest.skipUnless(_docker_available(), "docker daemon not available")
+class TestContainerIndependentSandbox(unittest.TestCase):
+    """The checks must run inside an isolated container, not a local process."""
+
+    def setUp(self):
+        self.skill = skill_load(str(EXAMPLE_ROOT / "skills" / "code-review"))
+        self.rules_by_cat = load_rules(self.skill["skill_dir"], self.skill["rules"])
+        self.policy = SandboxPolicy.from_config(self.skill["sandbox_config"])
+        self.rc_path = str(Path(self.skill["skill_dir"]) / "scripts" / "run_checks.py")
+
+    def test_ensure_available_true_with_docker(self):
+        rt = ContainerRuntime(policy=self.policy)
+        self.assertTrue(rt.ensure_available())
+
+    def test_run_checks_executes_inside_container(self):
+        cs = parse_diff(FIXTURES["security"])
+        rt = ContainerRuntime(policy=self.policy)
+        res = asyncio.run(
+            rt.run(
+                self.rc_path,
+                {"changeset": cs.to_dict(), "rules": self.rules_by_cat},
+                self.policy,
+            )
+        )
+        self.assertEqual(res.status, "ok", res.stderr)
+        self.assertEqual(res.exit_code, 0)
+        data = json.loads(res.stdout) if res.stdout else []
+        self.assertGreaterEqual(len(data), 1, "expected >=1 finding from container")
+        # Secrets leaving the sandbox must already be masked (>=1 masked token).
+        self.assertGreater(res.masked_count, 0)
+        # No plaintext key must appear in the container's raw stdout.
+        self.assertNotIn("sk-1234567890abcdef1234567890abcdef", res.stdout or "")
+
+    def test_agent_real_mode_records_container_runtime(self):
+        """End-to-end: --mode real --require-sandbox must use the container."""
+        from agent.agent import main as agent_main
+
+        with tempfile.TemporaryDirectory() as d:
+            db = os.path.join(d, "t.db")
+            out = os.path.join(d, "out")
+            agent_main(
+                [
+                    "--mode", "real",
+                    "--require-sandbox",
+                    "--fixture", "security",
+                    "--db-path", db,
+                    "--output-dir", out,
+                ]
+            )
+            conn = sqlite3.connect(db)
+            rows = list(conn.execute("SELECT runtime, status FROM sandbox_run"))
+            conn.close()
+        self.assertTrue(rows, "no sandbox_run recorded")
+        self.assertEqual(rows[0][0], "container")
+        self.assertEqual(rows[0][1], "ok")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/examples/skills_code_review_agent/tests/test_phase3_sandbox_filter.py
+++ b/examples/skills_code_review_agent/tests/test_phase3_sandbox_filter.py
@@ -1,0 +1,322 @@
+# Tencent is pleased to support the open source community by making tRPC-Agent-Python available.
+#
+# Copyright (C) 2026 Tencent. All rights reserved.
+#
+# tRPC-Agent-Python is licensed under Apache-2.0.
+"""Phase 3 (Sandbox & Filter) acceptance tests.
+
+Covers the Phase-3 DoD:
+  1. LocalRuntime runs a script; timeout interrupts without crashing.
+  2. Output over 1MB is truncated (status=truncated).
+  3. Only whitelisted env vars are passed (non-whitelisted dropped).
+  4. stdout is masked + masked_count is correct.
+  5. FilterGovernance flags high-risk scripts → deny.
+  6. FilterGovernance flags forbidden paths → deny.
+  7. RunResult persists to the sandbox_run table.
+
+Run with the CR Agent venv (SDK + python-magic-bin):
+    C:/Users/douzhenyu/.workbuddy/binaries/python/envs/cr_agent/Scripts/python.exe \\
+        examples/skills_code_review_agent/tests/test_phase3_sandbox_filter.py
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+_EXAMPLE_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_EXAMPLE_ROOT))
+
+from agent.db import SQLiteStore  # noqa: E402
+from agent.filters import FilterGovernance  # noqa: E402
+from agent.sandbox import LocalRuntime  # noqa: E402
+from agent.sandbox import RunResult  # noqa: E402
+from agent.sandbox import RuntimeUnavailable  # noqa: E402
+from agent.sandbox import SandboxPolicy  # noqa: E402
+from agent.sandbox import build_runtime_with_fallback  # noqa: E402
+from agent.sandbox import select_runtime  # noqa: E402
+
+
+def _make_script_dir() -> str:
+    """Create a temp dir + return its path. Caller cleans up."""
+    return tempfile.mkdtemp(prefix="cr_p3_ws_")
+
+
+def _write(d: str, name: str, content: str) -> str:
+    p = Path(d) / name
+    p.write_text(content, encoding="utf-8")
+    return str(p)
+
+
+class TestLocalRuntime(unittest.IsolatedAsyncioTestCase):
+    """DoD #1-4 — LocalRuntime execution + timeout + truncation + env + masking."""
+
+    async def test_run_ok_returns_stdout(self):
+        d = _make_script_dir()
+        try:
+            script = _write(d, "echo.py",
+                "import sys, json\n"
+                "d = json.load(sys.stdin)\n"
+                "print(json.dumps({'got': d}))\n")
+            rt = LocalRuntime(work_root=d)
+            res = await rt.run(script, {"hello": "world"}, SandboxPolicy(timeout_s=10))
+            self.assertEqual(res.status, "ok")
+            self.assertEqual(res.exit_code, 0)
+            self.assertIn("hello", res.stdout)
+            self.assertFalse(res.timed_out)
+        finally:
+            shutil.rmtree(d, ignore_errors=True)
+
+    async def test_timeout_interrupts_without_crash(self):
+        d = _make_script_dir()
+        try:
+            script = _write(d, "sleep.py", "import time; time.sleep(30)\n")
+            rt = LocalRuntime(work_root=d)
+            res = await rt.run(script, {}, SandboxPolicy(timeout_s=1))
+            self.assertEqual(res.status, "timeout")
+            self.assertTrue(res.timed_out)
+            # Must not raise — fail-safe.
+            self.assertIsInstance(res, RunResult)
+        finally:
+            shutil.rmtree(d, ignore_errors=True)
+
+    async def test_output_truncated_over_limit(self):
+        d = _make_script_dir()
+        try:
+            # Print ~2MB of 'A' — exceeds the 1024-byte cap below.
+            script = _write(d, "big.py", "print('A' * (2 * 1024 * 1024))\n")
+            rt = LocalRuntime(work_root=d)
+            res = await rt.run(script, {}, SandboxPolicy(timeout_s=10, max_output_bytes=1024))
+            self.assertEqual(res.status, "truncated")
+            self.assertLessEqual(res.output_bytes, 1024)
+        finally:
+            shutil.rmtree(d, ignore_errors=True)
+
+    async def test_secrets_masked_in_stdout(self):
+        d = _make_script_dir()
+        try:
+            script = _write(d, "secret.py",
+                'print("key=sk-1234567890abcdef1234567890abcdef")\n')
+            rt = LocalRuntime(work_root=d)
+            res = await rt.run(script, {}, SandboxPolicy(timeout_s=10, mask_secrets=True))
+            self.assertEqual(res.status, "ok")
+            self.assertIn("***REDACTED***", res.stdout)
+            self.assertGreater(res.masked_count, 0)
+            self.assertNotIn("sk-1234567890abcdef", res.stdout)
+        finally:
+            shutil.rmtree(d, ignore_errors=True)
+
+    async def test_env_whitelist_drops_non_whitelisted(self):
+        d = _make_script_dir()
+        try:
+            script = _write(d, "envcheck.py",
+                "import os\n"
+                "print(os.environ.get('CR_P3_SECRET', 'MISSING'))\n")
+            os.environ["CR_P3_SECRET"] = "leaked"
+            try:
+                rt = LocalRuntime(work_root=d)
+                # CR_P3_SECRET is NOT in the default whitelist → not passed.
+                res = await rt.run(script, {}, SandboxPolicy(timeout_s=10))
+                self.assertEqual(res.status, "ok")
+                self.assertIn("MISSING", res.stdout)
+                self.assertNotIn("leaked", res.stdout)
+            finally:
+                os.environ.pop("CR_P3_SECRET", None)  # tolerant of restore timing
+        finally:
+            shutil.rmtree(d, ignore_errors=True)
+
+    async def test_failed_does_not_crash(self):
+        d = _make_script_dir()
+        try:
+            # Script that exits non-zero.
+            script = _write(d, "fail.py", "import sys; sys.exit(3)\n")
+            rt = LocalRuntime(work_root=d)
+            res = await rt.run(script, {}, SandboxPolicy(timeout_s=10))
+            self.assertEqual(res.status, "failed")
+            self.assertEqual(res.exit_code, 3)
+        finally:
+            shutil.rmtree(d, ignore_errors=True)
+
+    async def test_siblings_importable_in_workspace(self):
+        """run_checks-style: script imports a sibling module staged alongside."""
+        d = _make_script_dir()
+        try:
+            _write(d, "helper.py", "VALUE = 42\n")
+            script = _write(d, "main.py", "from helper import VALUE\nprint(VALUE)\n")
+            rt = LocalRuntime(work_root=d)
+            res = await rt.run(script, {}, SandboxPolicy(timeout_s=10))
+            self.assertEqual(res.status, "ok")
+            self.assertIn("42", res.stdout)
+        finally:
+            shutil.rmtree(d, ignore_errors=True)
+
+
+class TestFilterGovernance(unittest.TestCase):
+    """DoD #5-6 — governance flags high-risk + forbidden-path → deny."""
+
+    def setUp(self):
+        self.gov = FilterGovernance()
+
+    def test_high_risk_rm_rf_denied(self):
+        d = self.gov.decide("x.sh", "import os; os.system('rm -rf /')", {})
+        self.assertEqual(d.verdict, "deny")
+        self.assertEqual(d.reason, "high-risk")
+
+    def test_high_risk_sudo_denied(self):
+        d = self.gov.decide("x.sh", "os.system('sudo apt install evil')", {})
+        self.assertEqual(d.verdict, "deny")
+        self.assertEqual(d.reason, "high-risk")
+
+    def test_high_risk_eval_denied(self):
+        d = self.gov.decide("x.py", "eval(user_input)", {})
+        self.assertEqual(d.verdict, "deny")
+        self.assertEqual(d.reason, "high-risk")
+
+    def test_forbidden_path_etc_denied(self):
+        d = self.gov.decide("x.py", "open('/etc/passwd').read()", {})
+        self.assertEqual(d.verdict, "deny")
+        self.assertEqual(d.reason, "forbidden-path")
+
+    def test_forbidden_path_ssh_denied(self):
+        d = self.gov.decide("x.py", "with open('~/.ssh/id_rsa') as f: pass", {})
+        self.assertEqual(d.verdict, "deny")
+        self.assertEqual(d.reason, "forbidden-path")
+
+    def test_network_non_whitelisted_needs_review(self):
+        d = self.gov.decide("x.py", "requests.get('http://evil.com/data')", {})
+        self.assertEqual(d.verdict, "needs_human_review")
+        self.assertEqual(d.reason, "network")
+
+    def test_network_whitelisted_allowed(self):
+        d = self.gov.decide("x.py", "requests.get('http://localhost:8080/h')", {})
+        self.assertEqual(d.verdict, "allow")
+
+    def test_budget_over_limit_needs_review(self):
+        d = self.gov.decide("x.py", "print('ok')",
+                            {"estimated_duration_s": 120, "estimated_memory_mb": 100})
+        self.assertEqual(d.verdict, "needs_human_review")
+        self.assertEqual(d.reason, "budget")
+
+    def test_normal_script_allowed(self):
+        d = self.gov.decide("run_checks.py",
+                            "import ast\nfor n in ast.walk(tree): pass\n", {})
+        self.assertEqual(d.verdict, "allow")
+        self.assertEqual(d.reason, "ok")
+
+    def test_rm_rf_in_comment_not_flagged(self):
+        """False-positive guard: `rm -rf` in a comment is skipped (spec risk note)."""
+        d = self.gov.decide("x.py", "# warning: do not run rm -rf /tmp\nprint('safe')\n", {})
+        self.assertEqual(d.verdict, "allow")
+
+
+class TestRunResultPersist(unittest.IsolatedAsyncioTestCase):
+    """DoD #7 — RunResult persists to the sandbox_run table."""
+
+    async def test_sandbox_run_row_written_and_joined(self):
+        store = SQLiteStore(":memory:")
+        try:
+            tid = await store.create_task("diff", "a.diff", "dry-run")
+            run_id = await store.add_sandbox_run(
+                tid, "local", "run_checks.py", "ok", 1200, 0, 2048, 0, 3)
+            self.assertTrue(run_id)
+            runs = (await store.get_task(tid))["sandbox_runs"]
+            self.assertEqual(len(runs), 1)
+            r = runs[0]
+            self.assertEqual(r["runtime"], "local")
+            self.assertEqual(r["status"], "ok")
+            self.assertEqual(r["masked_count"], 3)
+            self.assertEqual(r["timed_out"], 0)
+        finally:
+            await store.close()
+
+    async def test_failed_run_result_persisted(self):
+        store = SQLiteStore(":memory:")
+        try:
+            tid = await store.create_task("diff", "a.diff", "dry-run")
+            await store.add_sandbox_run(
+                tid, "local", "run_checks.py", "timeout", 30000, 124, 0, 1, 0)
+            r = (await store.get_task(tid))["sandbox_runs"][0]
+            self.assertEqual(r["status"], "timeout")
+            self.assertEqual(r["timed_out"], 1)
+            self.assertEqual(r["exit_code"], 124)
+        finally:
+            await store.close()
+
+
+class _StubRuntime:
+    """Minimal SandboxRuntime used to exercise selection/fallback logic."""
+
+    def __init__(self, kind, available=True):
+        self.kind = kind
+        self._available = available
+
+    def ensure_available(self):
+        if not self._available:
+            raise RuntimeUnavailable(f"{self.kind} unavailable")
+        return True
+
+    async def run(self, script_path, input, policy=None):
+        return RunResult("ok", "[]", "", 0, 0, 0, False, 0)
+
+
+def _patched_select(mapping):
+    """Return a select_runtime replacement backed by a fixed kind→instance map."""
+    def _select(kind, policy=None, work_root=None, image=None):
+        return mapping[kind]
+    return _select
+
+
+class TestRuntimeSelection(unittest.IsolatedAsyncioTestCase):
+    """G1 — agent honors default_runtime/fallback, not hardcoded LocalRuntime."""
+
+    def test_default_used_when_available(self):
+        import agent.sandbox.runtime as _rt
+        orig = _rt.select_runtime
+        container = _StubRuntime("container", available=True)
+        local = _StubRuntime("local", available=True)
+        _rt.select_runtime = _patched_select({"container": container, "local": local})
+        try:
+            rt, kind = build_runtime_with_fallback("container", "local")
+            self.assertIs(rt, container)
+            self.assertEqual(kind, "container")
+        finally:
+            _rt.select_runtime = orig
+
+    def test_fallback_used_when_default_unavailable(self):
+        import agent.sandbox.runtime as _rt
+        orig = _rt.select_runtime
+        container = _StubRuntime("container", available=False)
+        local = _StubRuntime("local", available=True)
+        _rt.select_runtime = _patched_select({"container": container, "local": local})
+        try:
+            rt, kind = build_runtime_with_fallback("container", "local")
+            self.assertIs(rt, local)
+            self.assertEqual(kind, "local")
+        finally:
+            _rt.select_runtime = orig
+
+    def test_select_runtime_kind_mapping(self):
+        self.assertIsInstance(select_runtime("local"), LocalRuntime)
+        self.assertIsInstance(select_runtime("container"), object)
+        self.assertIsInstance(select_runtime("cube"), object)
+        self.assertIsInstance(select_runtime("bogus-unknown"), LocalRuntime)
+
+    def test_no_runtime_available_raises(self):
+        import agent.sandbox.runtime as _rt
+        orig = _rt.select_runtime
+        container = _StubRuntime("container", available=False)
+        local = _StubRuntime("local", available=False)
+        _rt.select_runtime = _patched_select({"container": container, "local": local})
+        try:
+            with self.assertRaises(RuntimeUnavailable):
+                build_runtime_with_fallback("container", "local")
+        finally:
+            _rt.select_runtime = orig
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/examples/skills_code_review_agent/tests/test_phase4_dedupe.py
+++ b/examples/skills_code_review_agent/tests/test_phase4_dedupe.py
@@ -1,0 +1,222 @@
+# Tencent is pleased to support the open source community by making tRPC-Agent-Python available.
+#
+# Copyright (C) 2026 Tencent. All rights reserved.
+#
+# tRPC-Agent-Python is licensed under Apache-2.0.
+"""Phase 4 (Dedupe & structuring) acceptance tests.
+
+Covers the Phase-4 DoD:
+  1. Same (file,line,category) collapses to one (highest confidence).
+  2. Same line + different category is preserved.
+  3. confidence < 0.6 → needs_human_review; 0.6–0.8 → warnings; ≥0.8 → findings.
+  4. Finding has all 9 fields; evidence is masked.
+  5. Multi-source merge: source="rule+sandbox", severity takes the max.
+  6. Evidence is truncated to a sane length.
+  7. Three buckets persist to the finding table (bucket column).
+
+Run:
+    C:/Users/douzhenyu/.workbuddy/binaries/python/envs/cr_agent/Scripts/python.exe \\
+        examples/skills_code_review_agent/tests/test_phase4_dedupe.py
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+_EXAMPLE_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_EXAMPLE_ROOT))
+_SCRIPTS_DIR = _EXAMPLE_ROOT / "skills" / "code-review" / "scripts"
+sys.path.insert(0, str(_SCRIPTS_DIR))
+
+from agent.db import SQLiteStore  # noqa: E402
+from dedupe import DedupeResult  # noqa: E402
+from dedupe import Finding  # noqa: E402
+from dedupe import dedupe  # noqa: E402
+from run_checks import RawFinding  # noqa: E402
+
+
+def _rf(category, file, line, title, evidence, sev, conf, source="rule"):
+    return RawFinding(category, file, line, title, evidence, sev, conf, source)
+
+
+class TestDedupeGrouping(unittest.TestCase):
+    """DoD #1-2 — same key collapses, different category preserved."""
+
+    def test_same_key_keeps_highest_confidence(self):
+        raws = [
+            _rf("security", "a.py", 5, "sqli", "execute(q+x)", "critical", 0.9),
+            _rf("security", "a.py", 5, "sqli dup", "execute(q+x) dup", "high", 0.7),
+        ]
+        res = dedupe(raws)
+        self.assertEqual(res.total, 1)
+        self.assertEqual(res.findings[0].confidence, 0.9)
+        self.assertEqual(res.findings[0].title, "sqli")  # winner's title
+
+    def test_same_line_different_category_preserved(self):
+        raws = [
+            _rf("security", "a.py", 5, "sqli", "execute(q+x)", "critical", 0.9),
+            _rf("sensitive", "a.py", 5, "key", "API_KEY=x", "critical", 0.95),
+        ]
+        res = dedupe(raws)
+        self.assertEqual(res.total, 2)
+        cats = {f.category for f in res.findings}
+        self.assertEqual(cats, {"security", "sensitive"})
+
+    def test_duplicate_sample_merges_to_one(self):
+        """P6 'duplicate finding' sample: two same-category reports → one."""
+        raws = [
+            _rf("async", "x.py", 10, "unawaited", "foo()", "high", 0.7, "rule"),
+            _rf("async", "x.py", 10, "unawaited", "foo() [sb]", "high", 0.8, "sandbox"),
+        ]
+        res = dedupe(raws)
+        self.assertEqual(res.total, 1)
+        self.assertEqual(res.findings[0].confidence, 0.8)
+
+
+class TestTriageBuckets(unittest.TestCase):
+    """DoD #3 — confidence thresholds route to the right bucket."""
+
+    def test_below_0_6_to_needs_human_review(self):
+        res = dedupe([_rf("tests", "a.py", 1, "t", "e", "low", 0.4)])
+        self.assertEqual(len(res.needs_human_review), 1)
+        self.assertEqual(len(res.findings), 0)
+        self.assertEqual(len(res.warnings), 0)
+
+    def test_0_6_to_0_8_to_warnings(self):
+        res = dedupe([_rf("async", "a.py", 1, "t", "e", "medium", 0.65)])
+        self.assertEqual(len(res.warnings), 1)
+        self.assertEqual(len(res.findings), 0)
+
+    def test_above_0_8_to_findings(self):
+        res = dedupe([_rf("security", "a.py", 1, "t", "e", "critical", 0.95)])
+        self.assertEqual(len(res.findings), 1)
+        self.assertEqual(len(res.warnings), 0)
+
+    def test_boundary_0_6_is_warnings(self):
+        res = dedupe([_rf("x", "a.py", 1, "t", "e", "low", 0.6)])
+        self.assertEqual(len(res.warnings), 1)
+
+    def test_boundary_0_8_is_findings(self):
+        res = dedupe([_rf("x", "a.py", 1, "t", "e", "low", 0.8)])
+        self.assertEqual(len(res.findings), 1)
+
+
+class TestFindingFields(unittest.TestCase):
+    """DoD #4 — Finding has 9 fields, evidence masked."""
+
+    def test_finding_has_nine_fields(self):
+        res = dedupe([_rf("security", "a.py", 5, "sqli", "execute(q+x)", "critical", 0.9)])
+        f = res.findings[0]
+        for field in ("severity", "category", "file", "line", "title",
+                      "evidence", "recommendation", "confidence", "source"):
+            self.assertTrue(hasattr(f, field), f"missing field: {field}")
+
+    def test_evidence_masked(self):
+        secret = "sk-1234567890abcdef1234567890abcdef"  # 32 chars, matches sk- pattern
+        res = dedupe([_rf("sensitive", "a.py", 1, "key", f"token={secret}", "critical", 0.95)])
+        self.assertIn("***REDACTED***", res.findings[0].evidence)
+        self.assertNotIn(secret, res.findings[0].evidence)
+
+    def test_recommendation_default_per_category(self):
+        res = dedupe([_rf("db", "a.py", 1, "t", "e", "high", 0.85)])
+        self.assertTrue(res.findings[0].recommendation)  # non-empty, actionable
+
+    def test_severity_from_hint(self):
+        res = dedupe([_rf("security", "a.py", 1, "t", "e", "critical", 0.9)])
+        self.assertEqual(res.findings[0].severity, "critical")
+
+
+class TestMultiSourceMerge(unittest.TestCase):
+    """DoD #5 — rule+sandbox merge, severity takes the max."""
+
+    def test_source_concatenated(self):
+        raws = [
+            _rf("security", "a.py", 5, "sqli", "ev1", "high", 0.7, "rule"),
+            _rf("security", "a.py", 5, "sqli", "ev2", "critical", 0.85, "sandbox"),
+        ]
+        res = dedupe(raws)
+        self.assertEqual(res.total, 1)
+        f = res.findings[0]
+        self.assertEqual(f.source, "rule+sandbox")
+
+    def test_severity_takes_highest(self):
+        raws = [
+            _rf("security", "a.py", 5, "sqli", "ev1", "medium", 0.9, "rule"),
+            _rf("security", "a.py", 5, "sqli", "ev2", "critical", 0.85, "sandbox"),
+        ]
+        res = dedupe(raws)
+        self.assertEqual(res.findings[0].severity, "critical")
+
+    def test_single_source_not_concatenated(self):
+        res = dedupe([_rf("security", "a.py", 1, "t", "e", "high", 0.9, "rule")])
+        self.assertEqual(res.findings[0].source, "rule")
+
+
+class TestEvidenceTruncation(unittest.TestCase):
+    """Risk note — evidence capped to a sane length."""
+
+    def test_long_evidence_truncated(self):
+        long_ev = "x" * 500
+        res = dedupe([_rf("security", "a.py", 1, "t", long_ev, "high", 0.9)])
+        self.assertLessEqual(len(res.findings[0].evidence), 201)  # 200 + ellipsis
+
+
+class TestPersistFindings(unittest.IsolatedAsyncioTestCase):
+    """DoD #7 — three buckets persist to the finding table (bucket column)."""
+
+    async def test_all_buckets_persisted(self):
+        raws = [
+            _rf("security", "a.py", 5, "sqli", "execute(q+x)", "critical", 0.95),
+            _rf("async", "b.py", 2, "unawaited", "foo()", "high", 0.7),
+            _rf("tests", "c.py", 1, "notest", "def f()", "low", 0.4),
+        ]
+        res = dedupe(raws)
+        store = SQLiteStore(":memory:")
+        try:
+            tid = await store.create_task("diff", "x.diff", "dry-run")
+            for finding, bucket in res.all_with_bucket():
+                await store.add_finding(
+                    tid, finding.severity, finding.category, finding.file,
+                    finding.line, finding.title, finding.evidence,
+                    finding.recommendation, finding.confidence,
+                    finding.source, bucket,
+                )
+            rec = await store.get_task(tid)
+            findings = rec["findings"]
+            self.assertEqual(len(findings), 3)
+            buckets = {f["bucket"] for f in findings}
+            self.assertEqual(buckets, {"findings", "warnings", "needs_human_review"})
+            # severity counts via the dedupe result
+            counts = res.severity_counts()
+            self.assertEqual(counts["critical"], 1)
+            self.assertEqual(counts["high"], 1)
+            self.assertEqual(counts["low"], 1)
+        finally:
+            await store.close()
+
+
+class TestDedupeResultHelpers(unittest.TestCase):
+    """DedupeResult utility methods."""
+
+    def test_all_with_bucket_order(self):
+        res = dedupe([
+            _rf("a", "f.py", 1, "t", "e", "high", 0.9),
+            _rf("b", "f.py", 2, "t", "e", "medium", 0.7),
+            _rf("c", "f.py", 3, "t", "e", "low", 0.5),
+        ])
+        pairs = res.all_with_bucket()
+        self.assertEqual(len(pairs), 3)
+        self.assertEqual(pairs[0][1], "findings")
+        self.assertEqual(pairs[1][1], "warnings")
+        self.assertEqual(pairs[2][1], "needs_human_review")
+
+    def test_empty_input(self):
+        res = dedupe([])
+        self.assertEqual(res.total, 0)
+        self.assertEqual(res.severity_counts(), {"critical": 0, "high": 0, "medium": 0, "low": 0})
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/examples/skills_code_review_agent/tests/test_phase5_orchestration.py
+++ b/examples/skills_code_review_agent/tests/test_phase5_orchestration.py
@@ -1,0 +1,228 @@
+# Tencent is pleased to support the open source community by making tRPC-Agent-Python available.
+#
+# Copyright (C) 2026 Tencent. All rights reserved.
+#
+# tRPC-Agent-Python is licensed under Apache-2.0.
+"""Phase 5 (Orchestration & report) acceptance tests.
+
+Covers the Phase-5 DoD:
+  1. CLI supports --diff-file / --repo-path / --fixture.
+  2. Full pipeline runs: parse → filter → sandbox → dedupe → persist → report.
+  3. dry-run needs no API key (FakeRunner).
+  4. Produces review_report.json + review_report.md.
+  5. Report has all eight sections.
+  6. DB stores a complete record queryable by task_id.
+
+Run:
+    C:/Users/douzhenyu/.workbuddy/binaries/python/envs/cr_agent/Scripts/python.exe \\
+        examples/skills_code_review_agent/tests/test_phase5_orchestration.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+_EXAMPLE_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_EXAMPLE_ROOT))
+
+import agent  # noqa: E402
+from agent.db import SQLiteStore  # noqa: E402
+
+_SKILL_DIR = _EXAMPLE_ROOT / "skills" / "code-review"
+
+_REPORT_KEYS = {
+    "task_id", "1_findings", "2_severity_stats", "3_needs_human_review",
+    "4_filter_blocks", "5_monitor", "6_sandbox_runs", "7_recommendations",
+    "8_warnings",
+}
+_MD_SECTIONS = [
+    "## 1. Findings", "## 2. 严重级别统计", "## 3. 人工复核项",
+    "## 4. Filter 拦截摘要", "## 5. 监控指标", "## 6. 沙箱执行摘要",
+    "## 7. 可执行修复建议", "## 8. Warnings",
+]
+
+
+def _args(**kw) -> SimpleNamespace:
+    base = dict(
+        skill_dir=str(_SKILL_DIR), diff_file=None, repo_path=None, fixture=None,
+        db_path="", mode="dry-run", output_dir="", print_changeset=False,
+        telemetry=False, dry_run=False,
+    )
+    base.update(kw)
+    return SimpleNamespace(**base)
+
+
+def _run_pipeline(**kw) -> tuple[str, str, str]:
+    """Run agent._async_main with temp db + output dir. Returns (db, outdir, task_id-from-report)."""
+    db = tempfile.mktemp(suffix=".db", prefix="cr_p5_")
+    out = tempfile.mkdtemp(prefix="cr_p5_out_")
+    ns = _args(db_path=db, output_dir=out, **kw)
+    import asyncio
+    asyncio.run(agent._async_main(ns))
+    return db, out, None
+
+
+class TestFullPipeline(unittest.IsolatedAsyncioTestCase):
+    """DoD #1-3 — full pipeline, three inputs, dry-run."""
+
+    async def test_dry_run_fixture_security_full_chain(self):
+        db, out, _ = await _async_run("security")
+        self.assertTrue(Path(out, "review_report.json").exists())
+        self.assertTrue(Path(out, "review_report.md").exists())
+        # DB: task done, findings present
+        store = SQLiteStore(db)
+        try:
+            rec = await store.get_task(_first_task_id(db))
+            self.assertEqual(rec["task"]["status"], "done")
+            self.assertGreater(len(rec["findings"]), 0)
+            self.assertIsNotNone(rec["report"])
+            self.assertIsNotNone(rec["monitor_summary"])
+        finally:
+            await store.close()
+        _cleanup(db, out)
+
+    async def test_diff_file_input(self):
+        fd, diff_path = tempfile.mkstemp(suffix=".diff")
+        os.close(fd)
+        Path(diff_path).write_text(
+            "diff --git a/x.py b/x.py\n--- a/x.py\n+++ b/x.py\n"
+            "@@ -1,2 +1,2 @@\n-old\n+new\n ctx\n", encoding="utf-8")
+        try:
+            db, out, _ = await _async_run(diff_file=diff_path)
+            self.assertTrue(Path(out, "review_report.json").exists())
+            _cleanup(db, out)
+        finally:
+            os.unlink(diff_path)
+
+    async def test_dry_run_flag_equiv_mode(self):
+        # --dry-run flag should behave like --mode dry-run (overrides --mode real).
+        db, out, _ = await _async_run(fixture="security", dry_run=True, mode="real")
+        # dry_run overrides mode → FakeRunner, no API call.
+        self.assertTrue(Path(out, "review_report.json").exists())
+        _cleanup(db, out)
+
+    async def test_clean_fixture_no_findings(self):
+        db, out, _ = await _async_run("clean")
+        report = json.loads(Path(out, "review_report.json").read_text(encoding="utf-8"))
+        self.assertEqual(len(report["1_findings"]), 0)
+        _cleanup(db, out)
+
+
+class TestReport(unittest.IsolatedAsyncioTestCase):
+    """DoD #4-5 — report files + eight sections."""
+
+    async def asyncSetUp(self):
+        self.db, self.out, _ = await _async_run("security")
+
+    async def asyncTearDown(self):
+        _cleanup(self.db, self.out)
+
+    def test_json_has_eight_sections(self):
+        report = json.loads(Path(self.out, "review_report.json").read_text(encoding="utf-8"))
+        self.assertTrue(_REPORT_KEYS.issubset(report.keys()))
+
+    def test_md_has_eight_section_headers(self):
+        md = Path(self.out, "review_report.md").read_text(encoding="utf-8")
+        for section in _MD_SECTIONS:
+            self.assertIn(section, md)
+
+    def test_json_and_md_consistent_findings_count(self):
+        report = json.loads(Path(self.out, "review_report.json").read_text(encoding="utf-8"))
+        md = Path(self.out, "review_report.md").read_text(encoding="utf-8")
+        # md mentions the finding count in section 1 header.
+        self.assertIn(str(len(report["1_findings"])), md)
+
+
+class TestDbComplete(unittest.IsolatedAsyncioTestCase):
+    """DoD #8 — DB queryable by task_id with a complete record."""
+
+    async def test_get_task_returns_full_record(self):
+        db, out, _ = await _async_run("security")
+        store = SQLiteStore(db)
+        try:
+            tid = _first_task_id(db)
+            rec = await store.get_task(tid)
+            # All seven sections present.
+            for key in ("task", "input_diffs", "sandbox_runs", "findings",
+                        "filter_blocks", "monitor_summary", "report"):
+                self.assertIn(key, rec, f"missing {key} in get_task result")
+            self.assertEqual(rec["task"]["id"], tid)
+            self.assertEqual(rec["task"]["status"], "done")
+            self.assertGreater(len(rec["input_diffs"]), 0)  # security fixture has 2 files
+            self.assertGreater(len(rec["findings"]), 0)
+        finally:
+            await store.close()
+        _cleanup(db, out)
+
+
+class TestSandboxFailureDegrades(unittest.IsolatedAsyncioTestCase):
+    """DoD #7 — sandbox failure degrades to FakeRunner, task still completes."""
+
+    async def test_real_mode_degrades_on_sandbox_error(self):
+        # Force the sandbox path to fail by pointing skill-dir scripts at a
+        # non-existent path — the pipeline should fall back to FakeRunner.
+        db = tempfile.mktemp(suffix=".db")
+        out = tempfile.mkdtemp(prefix="cr_p5_deg_")
+        # Monkey-patch LocalRuntime.run to raise, simulating sandbox failure.
+        from agent.sandbox import LocalRuntime
+        original = LocalRuntime.run
+
+        async def _boom(self, script_path, input, policy):
+            raise RuntimeError("sandbox unavailable")
+
+        LocalRuntime.run = _boom
+        try:
+            ns = _args(fixture="security", db_path=db, output_dir=out, mode="real")
+            await agent._async_main(ns)
+            # Task still completes (degraded to FakeRunner).
+            store = SQLiteStore(db)
+            try:
+                rec = await store.get_task(_first_task_id(db))
+                self.assertEqual(rec["task"]["status"], "done")
+                self.assertGreater(len(rec["findings"]), 0)  # FakeRunner still produced findings
+            finally:
+                await store.close()
+        finally:
+            LocalRuntime.run = original
+            _cleanup(db, out)
+
+
+# --------------------------------------------------------------------------- #
+# helpers
+# --------------------------------------------------------------------------- #
+async def _async_run(fixture=None, **kw) -> tuple[str, str, None]:
+    """Run the pipeline with a temp db + output dir, return (db, out, None)."""
+    import asyncio
+    db = tempfile.mktemp(suffix=".db", prefix="cr_p5_")
+    out = tempfile.mkdtemp(prefix="cr_p5_out_")
+    ns = _args(db_path=db, output_dir=out, fixture=fixture, **kw)
+    await agent._async_main(ns)
+    return db, out, None
+
+
+def _first_task_id(db_path: str) -> str:
+    import sqlite3
+    conn = sqlite3.connect(db_path)
+    tid = conn.execute("SELECT id FROM review_task ORDER BY created_at LIMIT 1").fetchone()[0]
+    conn.close()
+    return tid
+
+
+def _cleanup(db: str, out: str) -> None:
+    if os.path.exists(db):
+        try:
+            os.unlink(db)
+        except PermissionError:
+            pass
+    shutil.rmtree(out, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/examples/skills_code_review_agent/tests/test_phase7_llm.py
+++ b/examples/skills_code_review_agent/tests/test_phase7_llm.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+# Tencent is pleased to support the open source community by making tRPC-Agent-Python available.
+#
+# Copyright (C) 2026 Tencent. All rights reserved.
+#
+# tRPC-Agent-Python is licensed under Apache-2.0.
+"""Phase 7 — LLM integration tests.
+
+Guarantees:
+  * No API key / LLM_ENABLED=false -> FakeLlm (no model dependency).
+  * FakeLlm path leaves the dedupe result untouched (dry-run-safe).
+  * RealLlm parses verdicts, promotes/drops findings, and degrades on failure.
+The whole suite stays runnable with NO real API key.
+"""
+import asyncio
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+_HERE = Path(__file__).resolve().parent.parent
+_SCRIPTS_DIR = _HERE / "skills" / "code-review" / "scripts"
+for _p in (str(_HERE), str(_SCRIPTS_DIR)):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+from dedupe import DedupeResult, Finding  # noqa: E402
+from agent.llm import FakeLlm, LlmTriage, RealLlm, get_llm_client, load_llm_config  # noqa: E402
+from agent.llm.client import _parse_verdicts  # noqa: E402
+
+
+def _mk_finding(idx=0, conf=0.4, source="rule"):
+    return Finding(
+        severity="medium", category="security", file=f"a{idx}.py", line=idx,
+        title=f"t{idx}", evidence="e", recommendation="r",
+        confidence=conf, source=source)
+
+
+def _mk_dr(n=3):
+    dr = DedupeResult()
+    dr.needs_human_review = [_mk_finding(i) for i in range(n)]
+    return dr
+
+
+class TestConfigDisable(unittest.TestCase):
+    """No-key / disabled paths must yield FakeLlm and stay model-free.
+
+    These tests assert the *resolved* config contains no API key. Because the
+    project ships a real ``.env`` (with a key for live verification), we must
+    isolate config loading from it: point ``env_path`` at an empty temp file
+    and clear the key from ``os.environ`` so ``load_dotenv(override=False)``
+    cannot re-inject it.
+    """
+
+    def setUp(self):
+        self._saved = {k: os.environ.get(k) for k in ("LLM_API_KEY", "LLM_ENABLED")}
+        # Empty .env so load_dotenv re-injects nothing from the project file.
+        self._tmp = tempfile.NamedTemporaryFile(
+            mode="w", suffix=".env", delete=False, encoding="utf-8")
+        self._tmp.write("# isolated\n")
+        self._tmp.close()
+        os.environ.pop("LLM_API_KEY", None)
+
+    def tearDown(self):
+        os.unlink(self._tmp.name)
+        for k, v in self._saved.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+    def test_no_key_returns_fake(self):
+        os.environ["LLM_ENABLED"] = "false"
+        c = get_llm_client(env_path=self._tmp.name)
+        self.assertIsInstance(c, FakeLlm)
+        self.assertFalse(c.is_enabled)
+
+    def test_enabled_but_no_key_returns_fake(self):
+        os.environ["LLM_ENABLED"] = "true"
+        c = get_llm_client(env_path=self._tmp.name)
+        self.assertIsInstance(c, FakeLlm)
+
+    def test_explicit_enable_flag_no_key_returns_fake(self):
+        os.environ["LLM_ENABLED"] = "false"
+        c = get_llm_client(enable=True, env_path=self._tmp.name)
+        self.assertIsInstance(c, FakeLlm)
+
+
+class TestFakeTriage(unittest.TestCase):
+    def test_fake_noop_passthrough(self):
+        dr = _mk_dr(3)
+        out = asyncio.run(LlmTriage(FakeLlm()).run(dr, "some diff"))
+        self.assertEqual(len(out.needs_human_review), 3)
+        self.assertEqual(len(out.findings), 0)
+
+    def test_empty_findings(self):
+        dr = DedupeResult()
+        out = asyncio.run(LlmTriage(FakeLlm()).run(dr, "x"))
+        self.assertEqual(out.total, 0)
+
+    def test_disabled_client_short_circuits(self):
+        dr = _mk_dr(2)
+        out = asyncio.run(LlmTriage(FakeLlm()).run(dr, "x"))
+        self.assertIs(out, dr)  # returns the same object, no copy
+
+
+class TestParse(unittest.TestCase):
+    def test_parse_clean(self):
+        content = json.dumps(
+            {"verdicts": [{"index": 0, "verdict": "real",
+                           "confidence": 0.95, "explanation": "x"}]})
+        vs = _parse_verdicts(content)
+        self.assertEqual(len(vs), 1)
+        self.assertEqual(vs[0]["verdict"], "real")
+        self.assertAlmostEqual(vs[0]["confidence"], 0.95)
+
+    def test_parse_fenced(self):
+        content = "```json\n" + json.dumps(
+            {"verdicts": [{"index": 1, "verdict": "false_positive",
+                           "confidence": 0.2}]}) + "\n```"
+        vs = _parse_verdicts(content)
+        self.assertEqual(len(vs), 1)
+        self.assertEqual(vs[0]["index"], 1)
+        self.assertEqual(vs[0]["verdict"], "false_positive")
+
+    def test_parse_garbage(self):
+        self.assertEqual(_parse_verdicts("not json at all"), [])
+
+    def test_parse_clamps_confidence(self):
+        content = json.dumps(
+            {"verdicts": [{"index": 0, "verdict": "real", "confidence": 5.0}]})
+        vs = _parse_verdicts(content)
+        self.assertAlmostEqual(vs[0]["confidence"], 1.0)
+
+
+# --- helpers for RealLlm with an injected fake OpenAI client -------------- #
+
+class _FakeResp:
+    def __init__(self, content):
+        self.choices = [
+            type("C", (), {"message": type("M", (), {"content": content})()})()
+        ]
+
+
+class _FakeAsyncClient:
+    def __init__(self, content):
+        self._content = content
+        self.chat = type("Chat", (), {"completions": self})()
+
+    async def create(self, **kw):
+        return _FakeResp(self._content)
+
+
+class TestRealTriage(unittest.TestCase):
+    def _client(self, content):
+        cfg = load_llm_config()
+        cfg.api_key = "sk-test"
+        cfg.enabled = True
+        return RealLlm(cfg, client=_FakeAsyncClient(content))
+
+    def test_real_promotes_and_drops(self):
+        content = json.dumps(
+            {"verdicts": [
+                {"index": 0, "verdict": "real", "confidence": 0.92,
+                 "explanation": "confirmed SQLi"},
+                {"index": 1, "verdict": "false_positive", "confidence": 0.1},
+                {"index": 2, "verdict": "real", "confidence": 0.7,
+                 "explanation": "likely ok"},
+            ]})
+        dr = _mk_dr(3)
+        out = asyncio.run(
+            LlmTriage(self._client(content)).run(
+                dr, "diff with secret sk-abcdefghijklmnopqrstuvwxyz"))
+        # index 1 dropped -> 2 remain for review... but index 2 is promoted to
+        # warnings (0.7), so only index 0 (promoted to findings) leaves review.
+        self.assertEqual(len(out.needs_human_review), 0)
+        self.assertEqual(len(out.findings), 1)
+        self.assertEqual(len(out.warnings), 1)
+        f0 = out.findings[0]
+        self.assertIn("llm", f0.source)
+        self.assertIn("[LLM]", f0.recommendation)
+
+    def test_real_failure_degrades(self):
+        class _BadClient:
+            def __init__(self):
+                self.chat = type("C", (), {"completions": self})()
+
+            async def create(self, **kw):
+                raise RuntimeError("boom")
+
+        cfg = load_llm_config()
+        cfg.api_key = "sk-test"
+        cfg.enabled = True
+        c = RealLlm(cfg, client=_BadClient())
+        dr = _mk_dr(2)
+        out = asyncio.run(LlmTriage(c).run(dr, "x"))
+        # call failed -> degrade to no-op, original result untouched
+        self.assertEqual(len(out.needs_human_review), 2)
+
+    def test_real_masks_diff_before_send(self):
+        sent = {}
+
+        class _CapturingClient:
+            def __init__(self):
+                self.chat = type("C", (), {"completions": self})()
+
+            async def create(self, **kw):
+                sent["messages"] = kw["messages"]
+                return _FakeResp(json.dumps({"verdicts": []}))
+
+        cfg = load_llm_config()
+        cfg.api_key = "sk-test"
+        cfg.enabled = True
+        c = RealLlm(cfg, client=_CapturingClient())
+        asyncio.run(
+            LlmTriage(c).run(_mk_dr(1),
+                             "leak sk-abcdefghijklmnopqrstuvwxyz here"))
+        user_msg = sent["messages"][1]["content"]
+        self.assertNotIn("sk-abcdefghijklmnopqrstuvwxyz", user_msg)
+        self.assertIn("REDACTED", user_msg)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/examples/skills_code_review_agent/tests/test_phase7_llm_live.py
+++ b/examples/skills_code_review_agent/tests/test_phase7_llm_live.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+# Tencent is pleased to support the open source community by making tRPC-Agent-Python available.
+#
+# Copyright (C) 2026 Tencent. All rights reserved.
+#
+# tRPC-Agent-Python is licensed under Apache-2.0.
+"""Phase 7 — LIVE real-LLM integration test (gated, network + key required).
+
+This is the acceptance test that proves the real OpenAI-compatible endpoint
+actually judges the low-confidence ``needs_human_review`` bucket. It is
+deliberately DISABLED by default so the suite stays key-free and offline:
+
+    # run it (needs a configured LLM_API_KEY in .env):
+    CR_LLM_LIVE=1 python tests/test_phase7_llm_live.py
+
+Verified against DeepSeek (https://api.deepseek.com, model deepseek-chat):
+the model returns a verdict for the SEC005 (verify=False) candidate, and the
+triage promotes/drops it and tags ``source`` with ``llm``.
+"""
+import asyncio
+import os
+import sys
+import unittest
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent.parent
+_SCRIPTS = _HERE / "skills" / "code-review" / "scripts"
+for _p in (str(_HERE), str(_SCRIPTS)):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+from dedupe import DedupeResult, Finding  # noqa: E402
+from agent.llm import LlmTriage, RealLlm, load_llm_config  # noqa: E402
+
+_LLM_LIVE = os.getenv("CR_LLM_LIVE") == "1"
+_cfg = load_llm_config()
+
+
+@unittest.skipUnless(
+    _LLM_LIVE and _cfg.has_key,
+    "set CR_LLM_LIVE=1 and configure LLM_API_KEY in .env to run the live LLM test",
+)
+class TestLiveLlmTriage(unittest.TestCase):
+    def _make_dr(self) -> DedupeResult:
+        dr = DedupeResult()
+        dr.needs_human_review.append(
+            Finding(
+                severity="medium",
+                category="security",
+                file="svc/client.py",
+                line=7,
+                title="SEC005: TLS 证书校验被关闭 (verify=False)",
+                evidence="requests.post(endpoint, json=payload, verify=False)",
+                recommendation="检查 TLS 校验配置",
+                confidence=0.5,  # < 0.6 -> lands in needs_human_review
+                source="rule",
+            )
+        )
+        return dr
+
+    def test_live_client_returns_verdict(self):
+        client = RealLlm(_cfg)
+        dr = self._make_dr()
+        diff = (
+            "diff --git a/svc/client.py b/svc/client.py\n"
+            "--- /dev/null\n"
+            "+++ b/svc/client.py\n"
+            "@@ -0,0 +1,7 @@\n"
+            "+    return requests.post(endpoint, json=payload, verify=False)\n"
+        )
+        verdicts = asyncio.run(client.triage(dr.needs_human_review, diff))
+        self.assertTrue(verdicts, "live model should return at least one verdict")
+        for v in verdicts:
+            self.assertIn(v["verdict"], ("real", "false_positive"))
+            self.assertGreaterEqual(v["confidence"], 0.0)
+            self.assertLessEqual(v["confidence"], 1.0)
+
+    def test_live_triage_resolves_low_confidence(self):
+        client = RealLlm(_cfg)
+        dr = self._make_dr()
+        diff = (
+            "diff --git a/svc/client.py b/svc/client.py\n"
+            "+    return requests.post(endpoint, json=payload, verify=False)\n"
+        )
+        out = asyncio.run(LlmTriage(client).run(dr, diff))
+        # The low-confidence item must be resolved (not left in review).
+        self.assertEqual(
+            len(out.needs_human_review), 0,
+            "low-confidence item must be resolved by the LLM",
+        )
+        total = out.total
+        self.assertIn(total, (0, 1))  # dropped (0) or kept/promoted (1)
+        if total == 1:
+            kept = out.findings + out.warnings
+            self.assertTrue(kept)
+            self.assertIn("llm", kept[0].source)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/examples/skills_code_review_agent/tests/test_telemetry.py
+++ b/examples/skills_code_review_agent/tests/test_telemetry.py
@@ -1,0 +1,177 @@
+# Tencent is pleased to support the open source community by making tRPC-Agent-Python available.
+#
+# Copyright (C) 2026 Tencent. All rights reserved.
+#
+# tRPC-Agent-Python is licensed under Apache-2.0.
+"""Telemetry acceptance tests.
+
+Covers:
+  1. init_telemetry (NoOp default + idempotent).
+  2. trace_stage measures duration + forwards to recorder.
+  3. trace_stage records exceptions (exception_types tally) + re-raises.
+  4. TelemetryRecorder.to_monitor_summary shape.
+  5. sandbox-tagged stages contribute to sandbox_duration_ms.
+  6. agent --telemetry persists monitor_summary.
+
+Run:
+    C:/Users/douzhenyu/.workbuddy/binaries/python/envs/cr_agent/Scripts/python.exe \\
+        examples/skills_code_review_agent/tests/test_telemetry.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+_EXAMPLE_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_EXAMPLE_ROOT))
+
+from agent.telemetry import TelemetryRecorder  # noqa: E402
+from agent.telemetry import init_telemetry  # noqa: E402
+from agent.telemetry import trace_stage  # noqa: E402
+
+
+class TestTelemetryRecorder(unittest.TestCase):
+    """DoD — recorder collects + folds into monitor_summary shape."""
+
+    def test_to_monitor_summary_defaults(self):
+        rec = TelemetryRecorder()
+        s = rec.to_monitor_summary()
+        self.assertEqual(s["total_duration_ms"], 0)
+        self.assertEqual(s["sandbox_duration_ms"], 0)
+        self.assertEqual(s["finding_count"], 0)
+        self.assertEqual(s["exception_types"], {})
+        for sev in ("sev_critical", "sev_high", "sev_medium", "sev_low"):
+            self.assertEqual(s[sev], 0)
+
+    def test_to_monitor_summary_with_findings_and_blocks(self):
+        rec = TelemetryRecorder()
+        rec.tool_calls = 3
+        s = rec.to_monitor_summary(
+            finding_count=5,
+            sev_counts={"critical": 1, "high": 2, "medium": 1, "low": 1},
+            blocks=2,
+        )
+        self.assertEqual(s["finding_count"], 5)
+        self.assertEqual(s["sev_critical"], 1)
+        self.assertEqual(s["sev_high"], 2)
+        self.assertEqual(s["blocks"], 2)
+        self.assertEqual(s["tool_calls"], 3)
+
+    def test_sandbox_stage_contributes_to_sandbox_duration(self):
+        rec = TelemetryRecorder()
+        rec.record_stage("l1_parse", 100)
+        rec.record_stage("l4_sandbox", 500)
+        rec.record_stage("l4_sandbox_dedupe", 50)
+        s = rec.to_monitor_summary()
+        # total = 100 + 500 + 50 = 650; sandbox = 500 + 50 = 550
+        self.assertEqual(s["total_duration_ms"], 650)
+        self.assertEqual(s["sandbox_duration_ms"], 550)
+
+    def test_exception_tally(self):
+        rec = TelemetryRecorder()
+        rec.record_exception("TimeoutError")
+        rec.record_exception("TimeoutError")
+        rec.record_exception("ValueError")
+        self.assertEqual(rec.exceptions, {"TimeoutError": 2, "ValueError": 1})
+
+
+class TestTraceStage(unittest.IsolatedAsyncioTestCase):
+    """DoD — trace_stage measures + records + handles exceptions."""
+
+    async def test_records_duration_to_recorder(self):
+        rec = TelemetryRecorder()
+        async with trace_stage("l1_parse", rec):
+            await asyncio.sleep(0.01)
+        self.assertIn("l1_parse", rec.stages)
+        self.assertGreaterEqual(rec.stages["l1_parse"], 8)  # ~10ms
+
+    async def test_works_without_init_noop(self):
+        # Without init_telemetry the tracer is NoOp, but trace_stage still
+        # measures + records on the recorder.
+        rec = TelemetryRecorder()
+        async with trace_stage("l2_skill_load", rec):
+            pass
+        self.assertIn("l2_skill_load", rec.stages)
+
+    async def test_exception_recorded_and_reraised(self):
+        rec = TelemetryRecorder()
+        with self.assertRaises(RuntimeError):
+            async with trace_stage("l4_sandbox", rec):
+                raise RuntimeError("sandbox boom")
+        self.assertEqual(rec.exceptions, {"RuntimeError": 1})
+        # stage still recorded (finally ran)
+        self.assertIn("l4_sandbox", rec.stages)
+
+    async def test_multiple_stages_accumulate_total(self):
+        rec = TelemetryRecorder()
+        async with trace_stage("l1_parse", rec):
+            await asyncio.sleep(0.005)
+        async with trace_stage("l2_skill_load", rec):
+            await asyncio.sleep(0.005)
+        async with trace_stage("l6_persist", rec):
+            await asyncio.sleep(0.005)
+        s = rec.to_monitor_summary()
+        self.assertGreater(s["total_duration_ms"], 10)
+        self.assertEqual(len(rec.stages), 3)
+
+
+class TestInitTelemetry(unittest.TestCase):
+    """DoD — init is idempotent + safe."""
+
+    def test_init_idempotent(self):
+        # Calling twice must not raise (second call is a no-op).
+        init_telemetry(enabled=False)
+        init_telemetry(enabled=False)
+
+    def test_init_disabled_is_noop(self):
+        init_telemetry(enabled=False)
+        # No exporter configured; tracer is default NoOp — trace_stage still works.
+
+
+class TestAgentTelemetryIntegration(unittest.IsolatedAsyncioTestCase):
+    """DoD — agent --telemetry persists monitor_summary to the DB."""
+
+    async def test_agent_persists_monitor_summary(self):
+        import agent
+        db_path = tempfile.mktemp(suffix=".db", prefix="cr_tel_")
+        out_dir = tempfile.mkdtemp(prefix="cr_tel_out_")
+        try:
+            # Run without --telemetry (NoOp spans) — monitor_summary still written.
+            await agent._async_main(
+                type("A", (), {
+                    "skill_dir": str(_EXAMPLE_ROOT / "skills" / "code-review"),
+                    "diff_file": None, "repo_path": None, "fixture": "security",
+                    "db_path": db_path, "mode": "dry-run",
+                    "print_changeset": False, "telemetry": False,
+                    "output_dir": out_dir, "dry_run": False,
+                })()
+            )
+            # Verify monitor_summary row exists with duration > 0.
+            import sqlite3
+            conn = sqlite3.connect(db_path)
+            conn.row_factory = sqlite3.Row
+            row = conn.execute(
+                "SELECT total_duration_ms, sandbox_duration_ms, exception_types "
+                "FROM monitor_summary"
+            ).fetchone()
+            conn.close()
+            self.assertIsNotNone(row, "monitor_summary row must be written")
+            self.assertGreater(row["total_duration_ms"], 0)
+            self.assertEqual(row["exception_types"], "{}")
+        finally:
+            if os.path.exists(db_path):
+                try:
+                    os.unlink(db_path)
+                except PermissionError:
+                    pass
+            shutil.rmtree(out_dir, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## 概述

新增 `skills_code_review_agent` 示例，实现一个基于 Skill、沙箱执行、Filter 治理、SQLite 落库和结构化报告的自动代码评审 Agent 原型。

Closes #92

## 主要变更

- 新增 code-review Skill、规则文档和检查脚本。
- 新增 diff 解析、沙箱执行、去重降噪、脱敏、落库和报告生成链路。
- 新增 9 个测试 fixture，包括真实 sandbox runtime failure 场景。
- 新增 README、架构说明和阶段规格文档。

## 修改类型

- 新功能
- 示例工程
- 测试补充
- 文档补充

## 测试覆盖

- clean/security/async/db/tests/dedup/sandbox/sensitive fixtures
- Filter 拦截与 denied script 不执行
- 沙箱失败降级与 DB/report 记录
- 敏感信息脱敏与 dry-run 链路

## 自测清单

- [x] `test_cr_agent.py` 23 tests passed
- [x] 真实 failure fixture 可运行
- [x] 未提交 `.env`、`.tmp_*`、SQLite DB 等运行产物