### PR TITLE
Bugfix: 修复模型调用失败未显示异常信息的问题

### DIFF
--- a/trpc_agent_sdk/models/_retry.py
+++ b/trpc_agent_sdk/models/_retry.py
@@ -143,6 +143,7 @@ def _compute_exponential_backoff(
 
 
 def _build_error_response(ex: Exception, error_code: str) -> LlmResponse:
+    logger.error("Model call failed: %s", ex, exc_info=True)
     return LlmResponse(
         content=None,
         error_code=error_code,


### PR DESCRIPTION
- 在模型支持重试的特性支持里，把这个信息打印给移除了，现在修复这个问题