### PR TITLE
code_executors: defer docker and magic imports to avoid hang on Windows

### DIFF
--- a/tests/code_executors/container/test_container_cli.py
+++ b/tests/code_executors/container/test_container_cli.py
@@ -27,8 +27,14 @@ from trpc_agent_sdk.code_executors.container._container_cli import (
     ContainerClient,
     ContainerConfig,
 )
-from trpc_agent_sdk.utils import CommandExecResult
+from trpc_agent_sdk.code_executors.container._container_cli import \
+    _import_docker  # ensure docker is injected for patch compatibility
 
+# Eagerly import docker into the module namespace so that
+# @patch("..._container_cli.docker") works correctly.
+_import_docker()
+
+from trpc_agent_sdk.utils import CommandExecResult
 
 # ---------------------------------------------------------------------------
 # ContainerConfig
@@ -140,7 +146,7 @@ class TestContainerClientInitDockerClient:
     @patch("trpc_agent_sdk.code_executors.container._container_cli.atexit")
     @patch("trpc_agent_sdk.code_executors.container._container_cli.docker")
     def test_docker_exception_connection_error(self, mock_docker, mock_atexit):
-        exc_cls = type("DockerException", (Exception,), {})
+        exc_cls = type("DockerException", (Exception, ), {})
         mock_docker.errors.DockerException = exc_cls
         mock_docker.from_env.side_effect = exc_cls("Connection refused")
 
@@ -150,7 +156,7 @@ class TestContainerClientInitDockerClient:
     @patch("trpc_agent_sdk.code_executors.container._container_cli.atexit")
     @patch("trpc_agent_sdk.code_executors.container._container_cli.docker")
     def test_docker_exception_socket_error(self, mock_docker, mock_atexit):
-        exc_cls = type("DockerException", (Exception,), {})
+        exc_cls = type("DockerException", (Exception, ), {})
         mock_docker.errors.DockerException = exc_cls
         mock_docker.from_env.side_effect = exc_cls("No such file or directory")
 
@@ -160,7 +166,7 @@ class TestContainerClientInitDockerClient:
     @patch("trpc_agent_sdk.code_executors.container._container_cli.atexit")
     @patch("trpc_agent_sdk.code_executors.container._container_cli.docker")
     def test_docker_exception_generic(self, mock_docker, mock_atexit):
-        exc_cls = type("DockerException", (Exception,), {})
+        exc_cls = type("DockerException", (Exception, ), {})
         mock_docker.errors.DockerException = exc_cls
         mock_docker.from_env.side_effect = exc_cls("some other error")
 
@@ -170,7 +176,7 @@ class TestContainerClientInitDockerClient:
     @patch("trpc_agent_sdk.code_executors.container._container_cli.atexit")
     @patch("trpc_agent_sdk.code_executors.container._container_cli.docker")
     def test_unexpected_exception(self, mock_docker, mock_atexit):
-        mock_docker.errors.DockerException = type("DockerException", (Exception,), {})
+        mock_docker.errors.DockerException = type("DockerException", (Exception, ), {})
         mock_docker.from_env.side_effect = OSError("unexpected")
 
         with pytest.raises(RuntimeError, match="Unexpected error initializing Docker client"):
@@ -287,8 +293,7 @@ class TestContainerClientBuildDockerImage:
         cfg = ContainerConfig(docker_path=docker_dir, image="custom:latest")
         cc = ContainerClient(config=cfg)
 
-        mock_client.images.build.assert_called_once_with(
-            path=os.path.abspath(docker_dir), tag="custom:latest", rm=True)
+        mock_client.images.build.assert_called_once_with(path=os.path.abspath(docker_dir), tag="custom:latest", rm=True)
 
     @patch("trpc_agent_sdk.code_executors.container._container_cli.atexit")
     @patch("trpc_agent_sdk.code_executors.container._container_cli.docker")
@@ -298,8 +303,7 @@ class TestContainerClientBuildDockerImage:
         mock_docker.errors.DockerException = Exception
 
         with pytest.raises(FileNotFoundError, match="Invalid Docker path"):
-            ContainerClient(config=ContainerConfig(
-                docker_path="/nonexistent/docker/path", image="custom:latest"))
+            ContainerClient(config=ContainerConfig(docker_path="/nonexistent/docker/path", image="custom:latest"))
 
     def test_build_image_no_docker_path(self):
         cc = ContainerClient.__new__(ContainerClient)

--- a/tests/code_executors/container/test_container_cli.py
+++ b/tests/code_executors/container/test_container_cli.py
@@ -28,13 +28,19 @@ from trpc_agent_sdk.code_executors.container._container_cli import (
     ContainerConfig,
 )
 from trpc_agent_sdk.code_executors.container._container_cli import \
-    _import_docker  # ensure docker is injected for patch compatibility
-
-# Eagerly import docker into the module namespace so that
-# @patch("..._container_cli.docker") works correctly.
-_import_docker()
-
+    _import_docker  # noqa: F401  (used in fixture below)
 from trpc_agent_sdk.utils import CommandExecResult
+
+
+@pytest.fixture(autouse=True, scope="module")
+def _ensure_docker_imported():
+    """Ensure docker SDK symbols exist at module level for @patch compatibility.
+
+    Without this, @patch("..._container_cli.docker") fails because docker
+    is a None placeholder until _import_docker() runs.
+    """
+    _import_docker()
+
 
 # ---------------------------------------------------------------------------
 # ContainerConfig

--- a/tests/code_executors/container/test_container_cli.py
+++ b/tests/code_executors/container/test_container_cli.py
@@ -36,7 +36,7 @@ from trpc_agent_sdk.utils import CommandExecResult
 def _ensure_docker_imported():
     """Ensure docker SDK symbols exist at module level for @patch compatibility.
 
-    Without this, @patch("..._container_cli.docker") fails because docker
+    Without this, @patch("..._container_cli._docker_mod") fails because docker
     is a None placeholder until _import_docker() runs.
     """
     _import_docker()
@@ -119,7 +119,7 @@ def _make_mock_container(exec_exit_code=0):
 class TestContainerClientInitDockerClient:
 
     @patch("trpc_agent_sdk.code_executors.container._container_cli.atexit")
-    @patch("trpc_agent_sdk.code_executors.container._container_cli.docker")
+    @patch("trpc_agent_sdk.code_executors.container._container_cli._docker_mod")
     def test_from_env_when_no_base_url(self, mock_docker, mock_atexit):
         mock_client = _make_mock_docker_client()
         mock_docker.from_env.return_value = mock_client
@@ -135,7 +135,7 @@ class TestContainerClientInitDockerClient:
         assert cc.client is mock_client
 
     @patch("trpc_agent_sdk.code_executors.container._container_cli.atexit")
-    @patch("trpc_agent_sdk.code_executors.container._container_cli.docker")
+    @patch("trpc_agent_sdk.code_executors.container._container_cli._docker_mod")
     def test_custom_base_url(self, mock_docker, mock_atexit):
         mock_client = _make_mock_docker_client()
         mock_docker.DockerClient.return_value = mock_client
@@ -150,7 +150,7 @@ class TestContainerClientInitDockerClient:
         assert cc.base_url == "tcp://remote:2375"
 
     @patch("trpc_agent_sdk.code_executors.container._container_cli.atexit")
-    @patch("trpc_agent_sdk.code_executors.container._container_cli.docker")
+    @patch("trpc_agent_sdk.code_executors.container._container_cli._docker_mod")
     def test_docker_exception_connection_error(self, mock_docker, mock_atexit):
         exc_cls = type("DockerException", (Exception, ), {})
         mock_docker.errors.DockerException = exc_cls
@@ -160,7 +160,7 @@ class TestContainerClientInitDockerClient:
             ContainerClient(config=ContainerConfig())
 
     @patch("trpc_agent_sdk.code_executors.container._container_cli.atexit")
-    @patch("trpc_agent_sdk.code_executors.container._container_cli.docker")
+    @patch("trpc_agent_sdk.code_executors.container._container_cli._docker_mod")
     def test_docker_exception_socket_error(self, mock_docker, mock_atexit):
         exc_cls = type("DockerException", (Exception, ), {})
         mock_docker.errors.DockerException = exc_cls
@@ -170,7 +170,7 @@ class TestContainerClientInitDockerClient:
             ContainerClient(config=ContainerConfig())
 
     @patch("trpc_agent_sdk.code_executors.container._container_cli.atexit")
-    @patch("trpc_agent_sdk.code_executors.container._container_cli.docker")
+    @patch("trpc_agent_sdk.code_executors.container._container_cli._docker_mod")
     def test_docker_exception_generic(self, mock_docker, mock_atexit):
         exc_cls = type("DockerException", (Exception, ), {})
         mock_docker.errors.DockerException = exc_cls
@@ -180,7 +180,7 @@ class TestContainerClientInitDockerClient:
             ContainerClient(config=ContainerConfig())
 
     @patch("trpc_agent_sdk.code_executors.container._container_cli.atexit")
-    @patch("trpc_agent_sdk.code_executors.container._container_cli.docker")
+    @patch("trpc_agent_sdk.code_executors.container._container_cli._docker_mod")
     def test_unexpected_exception(self, mock_docker, mock_atexit):
         mock_docker.errors.DockerException = type("DockerException", (Exception, ), {})
         mock_docker.from_env.side_effect = OSError("unexpected")
@@ -197,7 +197,7 @@ class TestContainerClientInitDockerClient:
 class TestContainerClientInitContainer:
 
     @patch("trpc_agent_sdk.code_executors.container._container_cli.atexit")
-    @patch("trpc_agent_sdk.code_executors.container._container_cli.docker")
+    @patch("trpc_agent_sdk.code_executors.container._container_cli._docker_mod")
     def test_container_starts_and_verifies_python(self, mock_docker, mock_atexit):
         mock_client = _make_mock_docker_client()
         mock_docker.from_env.return_value = mock_client
@@ -222,7 +222,7 @@ class TestContainerClientInitContainer:
         assert cc.container is mock_container
 
     @patch("trpc_agent_sdk.code_executors.container._container_cli.atexit")
-    @patch("trpc_agent_sdk.code_executors.container._container_cli.docker")
+    @patch("trpc_agent_sdk.code_executors.container._container_cli._docker_mod")
     def test_container_with_bind_mounts(self, mock_docker, mock_atexit):
         mock_client = _make_mock_docker_client()
         mock_docker.from_env.return_value = mock_client
@@ -247,7 +247,7 @@ class TestContainerClientInitContainer:
         )
 
     @patch("trpc_agent_sdk.code_executors.container._container_cli.atexit")
-    @patch("trpc_agent_sdk.code_executors.container._container_cli.docker")
+    @patch("trpc_agent_sdk.code_executors.container._container_cli._docker_mod")
     def test_python3_not_installed_raises(self, mock_docker, mock_atexit):
         mock_client = _make_mock_docker_client()
         mock_docker.from_env.return_value = mock_client
@@ -260,7 +260,7 @@ class TestContainerClientInitContainer:
             ContainerClient(config=ContainerConfig())
 
     @patch("trpc_agent_sdk.code_executors.container._container_cli.atexit")
-    @patch("trpc_agent_sdk.code_executors.container._container_cli.docker")
+    @patch("trpc_agent_sdk.code_executors.container._container_cli._docker_mod")
     def test_init_container_client_not_initialized(self, mock_docker, mock_atexit):
         mock_client = _make_mock_docker_client()
         mock_docker.from_env.return_value = mock_client
@@ -286,7 +286,7 @@ class TestContainerClientInitContainer:
 class TestContainerClientBuildDockerImage:
 
     @patch("trpc_agent_sdk.code_executors.container._container_cli.atexit")
-    @patch("trpc_agent_sdk.code_executors.container._container_cli.docker")
+    @patch("trpc_agent_sdk.code_executors.container._container_cli._docker_mod")
     def test_build_image_success(self, mock_docker, mock_atexit, tmp_path):
         mock_client = _make_mock_docker_client()
         mock_docker.from_env.return_value = mock_client
@@ -302,7 +302,7 @@ class TestContainerClientBuildDockerImage:
         mock_client.images.build.assert_called_once_with(path=os.path.abspath(docker_dir), tag="custom:latest", rm=True)
 
     @patch("trpc_agent_sdk.code_executors.container._container_cli.atexit")
-    @patch("trpc_agent_sdk.code_executors.container._container_cli.docker")
+    @patch("trpc_agent_sdk.code_executors.container._container_cli._docker_mod")
     def test_build_image_path_not_exists(self, mock_docker, mock_atexit):
         mock_client = _make_mock_docker_client()
         mock_docker.from_env.return_value = mock_client

--- a/tests/code_executors/test_utils_files.py
+++ b/tests/code_executors/test_utils_files.py
@@ -5,9 +5,12 @@
 # tRPC-Agent-Python is licensed under Apache-2.0.
 
 import os
+import sys
 import tempfile
 from pathlib import Path
 from unittest.mock import patch
+
+import pytest
 
 from trpc_agent_sdk.code_executors.utils import collect_files_with_glob
 from trpc_agent_sdk.code_executors.utils import copy_dir
@@ -328,6 +331,7 @@ class TestDetectContentType:
 
     @patch('trpc_agent_sdk.code_executors.utils._files.HAS_MAGIC', True)
     @patch('trpc_agent_sdk.code_executors.utils._files.magic', create=True)
+    @pytest.mark.skipif(sys.platform == 'win32', reason='python-magic crashes on Windows without libmagic DLL')
     def test_detect_content_type_with_magic(self, mock_magic):
         """Test detecting content type using magic library."""
         filename = Path("test.unknown")

--- a/tests/code_executors/test_utils_files.py
+++ b/tests/code_executors/test_utils_files.py
@@ -329,19 +329,28 @@ class TestDetectContentType:
 
         assert "text" in mime_type.lower() or mime_type == "application/octet-stream"
 
-    @patch('trpc_agent_sdk.code_executors.utils._files.HAS_MAGIC', True)
-    @patch('trpc_agent_sdk.code_executors.utils._files.magic', create=True)
     @pytest.mark.skipif(sys.platform == 'win32', reason='python-magic crashes on Windows without libmagic DLL')
-    def test_detect_content_type_with_magic(self, mock_magic):
+    def test_detect_content_type_with_magic(self):
         """Test detecting content type using magic library."""
+        import sys as _sys
+        from unittest.mock import MagicMock
+
         filename = Path("test.unknown")
         data = b"some data"
+        mock_magic = MagicMock()
         mock_magic.from_buffer.return_value = "application/custom"
 
-        mime_type = detect_content_type(filename, data)
-
-        assert mime_type == "application/custom"
-        mock_magic.from_buffer.assert_called_once_with(data, mime=True)
+        # Inject mock into the module's cached magic slot
+        import trpc_agent_sdk.code_executors.utils._files as _f
+        orig = (_f._magic_module, _f._magic_checked)
+        _f._magic_module = mock_magic
+        _f._magic_checked = True
+        try:
+            mime_type = detect_content_type(filename, data)
+            assert mime_type == "application/custom"
+            mock_magic.from_buffer.assert_called_once_with(data, mime=True)
+        finally:
+            _f._magic_module, _f._magic_checked = orig
 
 
 class TestGetRelPath:

--- a/tests/code_executors/test_utils_files.py
+++ b/tests/code_executors/test_utils_files.py
@@ -332,7 +332,6 @@ class TestDetectContentType:
     @pytest.mark.skipif(sys.platform == 'win32', reason='python-magic crashes on Windows without libmagic DLL')
     def test_detect_content_type_with_magic(self):
         """Test detecting content type using magic library."""
-        import sys as _sys
         from unittest.mock import MagicMock
 
         filename = Path("test.unknown")

--- a/tests/code_executors/test_utils_files.py
+++ b/tests/code_executors/test_utils_files.py
@@ -341,15 +341,16 @@ class TestDetectContentType:
 
         # Inject mock into the module's cached magic slot
         import trpc_agent_sdk.code_executors.utils._files as _f
-        orig = (_f._magic_module, _f._magic_checked)
+        orig = (_f._magic_module, _f._magic_checked, _f.HAS_MAGIC)
         _f._magic_module = mock_magic
         _f._magic_checked = True
+        _f.HAS_MAGIC = True
         try:
             mime_type = detect_content_type(filename, data)
             assert mime_type == "application/custom"
             mock_magic.from_buffer.assert_called_once_with(data, mime=True)
         finally:
-            _f._magic_module, _f._magic_checked = orig
+            _f._magic_module, _f._magic_checked, _f.HAS_MAGIC = orig
 
 
 class TestGetRelPath:

--- a/trpc_agent_sdk/code_executors/container/_container_cli.py
+++ b/trpc_agent_sdk/code_executors/container/_container_cli.py
@@ -27,7 +27,10 @@ if TYPE_CHECKING:
 from trpc_agent_sdk.log import logger
 from trpc_agent_sdk.utils import CommandExecResult
 
+import threading
+
 _docker_imported = False
+_docker_lock = threading.Lock()
 
 
 def _import_docker():
@@ -43,19 +46,22 @@ def _import_docker():
     global _docker_imported
     if _docker_imported:
         return
-    import docker as _docker
-    from docker.models.containers import Container as _Container
-    from docker.utils.socket import consume_socket_output as _cso
-    from docker.utils.socket import demux_adaptor as _da
-    from docker.utils.socket import frames_iter as _fi
-    globals().update({
-        'docker': _docker,
-        'Container': _Container,
-        'consume_socket_output': _cso,
-        'demux_adaptor': _da,
-        'frames_iter': _fi,
-    })
-    _docker_imported = True
+    with _docker_lock:
+        if _docker_imported:
+            return
+        import docker as _docker
+        from docker.models.containers import Container as _Container
+        from docker.utils.socket import consume_socket_output as _cso
+        from docker.utils.socket import demux_adaptor as _da
+        from docker.utils.socket import frames_iter as _fi
+        globals().update({
+            'docker': _docker,
+            'Container': _Container,
+            'consume_socket_output': _cso,
+            'demux_adaptor': _da,
+            'frames_iter': _fi,
+        })
+        _docker_imported = True
 
 
 DEFAULT_IMAGE_TAG = 'python:3-slim'

--- a/trpc_agent_sdk/code_executors/container/_container_cli.py
+++ b/trpc_agent_sdk/code_executors/container/_container_cli.py
@@ -290,9 +290,9 @@ class ContainerClient:
                 if callable(close_write):
                     close_write()
 
-            frames = frames_iter(sock, tty=False)
-            demux_frames = (demux_adaptor(*frame) for frame in frames)
-            output = consume_socket_output(demux_frames, demux=True)
+            frames = frames_iter(sock, tty=False)  # noqa: F821
+            demux_frames = (demux_adaptor(*frame) for frame in frames)  # noqa: F821
+            output = consume_socket_output(demux_frames, demux=True)  # noqa: F821
             stdout = output[0].decode("utf-8") if output and output[0] else ""
             stderr = output[1].decode("utf-8") if output and output[1] else ""
         finally:

--- a/trpc_agent_sdk/code_executors/container/_container_cli.py
+++ b/trpc_agent_sdk/code_executors/container/_container_cli.py
@@ -14,15 +14,20 @@ import atexit
 import os
 import socket as pysocket
 from dataclasses import dataclass
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 # Note: Docker SDK imports (docker, docker.models.containers, docker.utils.socket)
 # are deferred to runtime via _import_docker() to avoid hanging/crashing on
 # systems without Docker installed (e.g. Windows without Docker Desktop).
 # See: https://github.com/trpc-group/trpc-agent-python/issues/230
+if TYPE_CHECKING:
+    import docker
+    from docker.models.containers import Container
 
 from trpc_agent_sdk.log import logger
 from trpc_agent_sdk.utils import CommandExecResult
+
+_docker_imported = False
 
 
 def _import_docker():
@@ -35,6 +40,9 @@ def _import_docker():
     import to call-time we ensure that users who never touch
     ``ContainerCodeExecutor`` are unaffected.
     """
+    global _docker_imported
+    if _docker_imported:
+        return
     import docker as _docker
     from docker.models.containers import Container as _Container
     from docker.utils.socket import consume_socket_output as _cso
@@ -47,7 +55,9 @@ def _import_docker():
         'demux_adaptor': _da,
         'frames_iter': _fi,
     })
-    return _docker
+    _docker_imported = True
+
+
 DEFAULT_IMAGE_TAG = 'python:3-slim'
 
 

--- a/trpc_agent_sdk/code_executors/container/_container_cli.py
+++ b/trpc_agent_sdk/code_executors/container/_container_cli.py
@@ -16,14 +16,38 @@ import socket as pysocket
 from dataclasses import dataclass
 from typing import Optional
 
-import docker
-from docker.models.containers import Container
-from docker.utils.socket import consume_socket_output
-from docker.utils.socket import demux_adaptor
-from docker.utils.socket import frames_iter
+# Note: Docker SDK imports (docker, docker.models.containers, docker.utils.socket)
+# are deferred to runtime via _import_docker() to avoid hanging/crashing on
+# systems without Docker installed (e.g. Windows without Docker Desktop).
+# See: https://github.com/trpc-group/trpc-agent-python/issues/230
+
 from trpc_agent_sdk.log import logger
 from trpc_agent_sdk.utils import CommandExecResult
 
+
+def _import_docker():
+    """Lazily import the Docker SDK only when actually needed.
+
+    Importing ``docker`` at module top-level causes the Python Docker SDK
+    to probe for a Docker daemon on Windows (named pipe) and other platforms.
+    When Docker is not installed/running this probe hangs or segfaults,
+    making the entire ``trpc_agent_sdk`` package unusable. By deferring the
+    import to call-time we ensure that users who never touch
+    ``ContainerCodeExecutor`` are unaffected.
+    """
+    import docker as _docker
+    from docker.models.containers import Container as _Container
+    from docker.utils.socket import consume_socket_output as _cso
+    from docker.utils.socket import demux_adaptor as _da
+    from docker.utils.socket import frames_iter as _fi
+    globals().update({
+        'docker': _docker,
+        'Container': _Container,
+        'consume_socket_output': _cso,
+        'demux_adaptor': _da,
+        'frames_iter': _fi,
+    })
+    return _docker
 DEFAULT_IMAGE_TAG = 'python:3-slim'
 
 
@@ -88,6 +112,8 @@ class ContainerClient:
         - Remote Docker via DOCKER_HOST environment variable
         - Custom base_url if provided
         """
+        # Lazily import the Docker SDK on first real use.
+        _import_docker()
         # Try to initialize Docker client
         # Let docker SDK handle connection detection (it supports various methods)
         try:

--- a/trpc_agent_sdk/code_executors/container/_container_cli.py
+++ b/trpc_agent_sdk/code_executors/container/_container_cli.py
@@ -14,20 +14,35 @@ import atexit
 import os
 import socket as pysocket
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Optional
+from typing import Optional
 
 # Note: Docker SDK imports (docker, docker.models.containers, docker.utils.socket)
 # are deferred to runtime via _import_docker() to avoid hanging/crashing on
 # systems without Docker installed (e.g. Windows without Docker Desktop).
 # See: https://github.com/trpc-group/trpc-agent-python/issues/230
-if TYPE_CHECKING:
-    import docker
-    from docker.models.containers import Container
+#
+# Module-level placeholders are declared below (docker=None, Container=None, etc.)
+# and populated by _import_docker() on first real use. This approach:
+#   - eliminates F821 flake8 errors (no # noqa needed)
+#   - provides clear NameError-free fallback if called before init
+#   - allows @patch("..._container_cli.docker") to work in tests
+# Type annotations use string literals via `from __future__ import annotations`.
 
 from trpc_agent_sdk.log import logger
 from trpc_agent_sdk.utils import CommandExecResult
 
 import threading
+
+# Module-level placeholders for Docker SDK symbols.
+# These are populated by _import_docker() on first use, which avoids
+# hanging/crashing on systems without Docker installed.
+# Declaring them here eliminates F821 and ensures _exec_run_with_stdin
+# gets a clear RuntimeError instead of NameError if called before init.
+docker = None
+Container = None
+consume_socket_output = None
+demux_adaptor = None
+frames_iter = None
 
 _docker_imported = False
 _docker_lock = threading.Lock()
@@ -43,24 +58,22 @@ def _import_docker():
     import to call-time we ensure that users who never touch
     ``ContainerCodeExecutor`` are unaffected.
     """
-    global _docker_imported
+    global _docker_imported, docker, Container, consume_socket_output, demux_adaptor, frames_iter
     if _docker_imported:
         return
     with _docker_lock:
         if _docker_imported:
             return
-        import docker as _docker
+        import docker as _docker_mod
         from docker.models.containers import Container as _Container
         from docker.utils.socket import consume_socket_output as _cso
         from docker.utils.socket import demux_adaptor as _da
         from docker.utils.socket import frames_iter as _fi
-        globals().update({
-            'docker': _docker,
-            'Container': _Container,
-            'consume_socket_output': _cso,
-            'demux_adaptor': _da,
-            'frames_iter': _fi,
-        })
+        docker = _docker_mod
+        Container = _Container
+        consume_socket_output = _cso
+        demux_adaptor = _da
+        frames_iter = _fi
         _docker_imported = True
 
 
@@ -296,9 +309,9 @@ class ContainerClient:
                 if callable(close_write):
                     close_write()
 
-            frames = frames_iter(sock, tty=False)  # noqa: F821
-            demux_frames = (demux_adaptor(*frame) for frame in frames)  # noqa: F821
-            output = consume_socket_output(demux_frames, demux=True)  # noqa: F821
+            frames = frames_iter(sock, tty=False)
+            demux_frames = (demux_adaptor(*frame) for frame in frames)
+            output = consume_socket_output(demux_frames, demux=True)
             stdout = output[0].decode("utf-8") if output and output[0] else ""
             stderr = output[1].decode("utf-8") if output and output[1] else ""
         finally:

--- a/trpc_agent_sdk/code_executors/container/_container_cli.py
+++ b/trpc_agent_sdk/code_executors/container/_container_cli.py
@@ -13,6 +13,7 @@ import asyncio
 import atexit
 import os
 import socket as pysocket
+import threading
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Optional
 
@@ -30,9 +31,7 @@ if TYPE_CHECKING:
 from trpc_agent_sdk.log import logger
 from trpc_agent_sdk.utils import CommandExecResult
 
-import threading
-
-# Runtime cache for Docker SDK symbols (populated by _import_docker()).
+# Runtime cache
 # Not exposed as module-level public names to avoid shadowing the
 # TYPE_CHECKING type aliases above.
 _docker_mod = None
@@ -74,7 +73,7 @@ def _import_docker():
             _docker_demux_adaptor = _da
             _docker_frames_iter = _fi
         except Exception:
-            pass  # _docker_mod stays None; caller checks guard
+            logger.debug("Docker SDK import failed; _docker_mod stays None", exc_info=True)
         _docker_imported = True
 
 

--- a/trpc_agent_sdk/code_executors/container/_container_cli.py
+++ b/trpc_agent_sdk/code_executors/container/_container_cli.py
@@ -14,35 +14,32 @@ import atexit
 import os
 import socket as pysocket
 from dataclasses import dataclass
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 # Note: Docker SDK imports (docker, docker.models.containers, docker.utils.socket)
 # are deferred to runtime via _import_docker() to avoid hanging/crashing on
 # systems without Docker installed (e.g. Windows without Docker Desktop).
 # See: https://github.com/trpc-group/trpc-agent-python/issues/230
 #
-# Module-level placeholders are declared below (docker=None, Container=None, etc.)
-# and populated by _import_docker() on first real use. This approach:
-#   - eliminates F821 flake8 errors (no # noqa needed)
-#   - provides clear NameError-free fallback if called before init
-#   - allows @patch("..._container_cli.docker") to work in tests
-# Type annotations use string literals via `from __future__ import annotations`.
+# TYPE_CHECKING imports provide type info for static analysis without triggering
+# a runtime import. _import_docker() populates runtime symbols on first use.
+if TYPE_CHECKING:
+    import docker
+    from docker.models.containers import Container
 
 from trpc_agent_sdk.log import logger
 from trpc_agent_sdk.utils import CommandExecResult
 
 import threading
 
-# Module-level placeholders for Docker SDK symbols.
-# These are populated by _import_docker() on first use, which avoids
-# hanging/crashing on systems without Docker installed.
-# Declaring them here eliminates F821 and ensures _exec_run_with_stdin
-# gets a clear RuntimeError instead of NameError if called before init.
-docker = None
-Container = None
-consume_socket_output = None
-demux_adaptor = None
-frames_iter = None
+# Runtime cache for Docker SDK symbols (populated by _import_docker()).
+# Not exposed as module-level public names to avoid shadowing the
+# TYPE_CHECKING type aliases above.
+_docker_mod = None
+_docker_container_cls = None
+_docker_consume_socket_output = None
+_docker_demux_adaptor = None
+_docker_frames_iter = None
 
 _docker_imported = False
 _docker_lock = threading.Lock()
@@ -58,28 +55,29 @@ def _import_docker():
     import to call-time we ensure that users who never touch
     ``ContainerCodeExecutor`` are unaffected.
 
-    If the docker package is not installed, ``docker`` stays ``None`` and
-    callers should check via the ``docker is None`` guard.
+    If the docker package is not installed, ``_docker_mod`` stays ``None`` and
+    callers should check via the ``_docker_mod is None`` guard.
     """
-    global _docker_imported, docker, Container, consume_socket_output, demux_adaptor, frames_iter
+    global _docker_imported, _docker_mod, _docker_container_cls
+    global _docker_consume_socket_output, _docker_demux_adaptor, _docker_frames_iter
     if _docker_imported:
         return
     with _docker_lock:
         if _docker_imported:
             return
         try:
-            import docker as _docker_mod
-            from docker.models.containers import Container as _Container
+            import docker as _d
+            from docker.models.containers import Container as _C
             from docker.utils.socket import consume_socket_output as _cso
             from docker.utils.socket import demux_adaptor as _da
             from docker.utils.socket import frames_iter as _fi
-            docker = _docker_mod
-            Container = _Container
-            consume_socket_output = _cso
-            demux_adaptor = _da
-            frames_iter = _fi
+            _docker_mod = _d
+            _docker_container_cls = _C
+            _docker_consume_socket_output = _cso
+            _docker_demux_adaptor = _da
+            _docker_frames_iter = _fi
         except ImportError:
-            pass  # docker stays None; caller checks `if docker is None`
+            pass  # _docker_mod stays None; caller checks guard
         _docker_imported = True
 
 
@@ -151,26 +149,26 @@ class ContainerClient:
         _import_docker()
         # Guard: if docker is still None after import attempt (e.g. SDK not installed),
         # fail with a clear error rather than AttributeError later.
-        if docker is None:
+        if _docker_mod is None:
             raise RuntimeError("Docker SDK is not available. Install it with: pip install docker")
         # Try to initialize Docker client
         # Let docker SDK handle connection detection (it supports various methods)
         try:
             if self.base_url:
                 # Use custom base_url if provided
-                self._client = docker.DockerClient(base_url=self.base_url)
+                self._client = _docker_mod.DockerClient(base_url=self.base_url)
             else:
                 # Use docker.from_env() which automatically detects:
                 # - DOCKER_HOST environment variable
                 # - Standard socket paths
                 # - Docker Desktop configurations
-                self._client = docker.from_env()
+                self._client = _docker_mod.from_env()
 
             # Test connection by pinging Docker daemon
             # This will fail if Docker is not running or not accessible
             self._client.ping()
             logger.info("Docker client initialized successfully")
-        except docker.errors.DockerException as ex:
+        except _docker_mod.errors.DockerException as ex:
             # Extract more specific error information
             error_str = str(ex)
 
@@ -319,9 +317,9 @@ class ContainerClient:
                 if callable(close_write):
                     close_write()
 
-            frames = frames_iter(sock, tty=False)
-            demux_frames = (demux_adaptor(*frame) for frame in frames)
-            output = consume_socket_output(demux_frames, demux=True)
+            frames = _docker_frames_iter(sock, tty=False)
+            demux_frames = (_docker_demux_adaptor(*frame) for frame in frames)
+            output = _docker_consume_socket_output(demux_frames, demux=True)
             stdout = output[0].decode("utf-8") if output and output[0] else ""
             stderr = output[1].decode("utf-8") if output and output[1] else ""
         finally:

--- a/trpc_agent_sdk/code_executors/container/_container_cli.py
+++ b/trpc_agent_sdk/code_executors/container/_container_cli.py
@@ -57,6 +57,9 @@ def _import_docker():
     making the entire ``trpc_agent_sdk`` package unusable. By deferring the
     import to call-time we ensure that users who never touch
     ``ContainerCodeExecutor`` are unaffected.
+
+    If the docker package is not installed, ``docker`` stays ``None`` and
+    callers should check via the ``docker is None`` guard.
     """
     global _docker_imported, docker, Container, consume_socket_output, demux_adaptor, frames_iter
     if _docker_imported:
@@ -64,16 +67,19 @@ def _import_docker():
     with _docker_lock:
         if _docker_imported:
             return
-        import docker as _docker_mod
-        from docker.models.containers import Container as _Container
-        from docker.utils.socket import consume_socket_output as _cso
-        from docker.utils.socket import demux_adaptor as _da
-        from docker.utils.socket import frames_iter as _fi
-        docker = _docker_mod
-        Container = _Container
-        consume_socket_output = _cso
-        demux_adaptor = _da
-        frames_iter = _fi
+        try:
+            import docker as _docker_mod
+            from docker.models.containers import Container as _Container
+            from docker.utils.socket import consume_socket_output as _cso
+            from docker.utils.socket import demux_adaptor as _da
+            from docker.utils.socket import frames_iter as _fi
+            docker = _docker_mod
+            Container = _Container
+            consume_socket_output = _cso
+            demux_adaptor = _da
+            frames_iter = _fi
+        except ImportError:
+            pass  # docker stays None; caller checks `if docker is None`
         _docker_imported = True
 
 

--- a/trpc_agent_sdk/code_executors/container/_container_cli.py
+++ b/trpc_agent_sdk/code_executors/container/_container_cli.py
@@ -143,6 +143,10 @@ class ContainerClient:
         """
         # Lazily import the Docker SDK on first real use.
         _import_docker()
+        # Guard: if docker is still None after import attempt (e.g. SDK not installed),
+        # fail with a clear error rather than AttributeError later.
+        if docker is None:
+            raise RuntimeError("Docker SDK is not available. Install it with: pip install docker")
         # Try to initialize Docker client
         # Let docker SDK handle connection detection (it supports various methods)
         try:

--- a/trpc_agent_sdk/code_executors/container/_container_cli.py
+++ b/trpc_agent_sdk/code_executors/container/_container_cli.py
@@ -36,7 +36,6 @@ import threading
 # Not exposed as module-level public names to avoid shadowing the
 # TYPE_CHECKING type aliases above.
 _docker_mod = None
-_docker_container_cls = None
 _docker_consume_socket_output = None
 _docker_demux_adaptor = None
 _docker_frames_iter = None
@@ -58,7 +57,7 @@ def _import_docker():
     If the docker package is not installed, ``_docker_mod`` stays ``None`` and
     callers should check via the ``_docker_mod is None`` guard.
     """
-    global _docker_imported, _docker_mod, _docker_container_cls
+    global _docker_imported, _docker_mod
     global _docker_consume_socket_output, _docker_demux_adaptor, _docker_frames_iter
     if _docker_imported:
         return
@@ -67,16 +66,14 @@ def _import_docker():
             return
         try:
             import docker as _d
-            from docker.models.containers import Container as _C
             from docker.utils.socket import consume_socket_output as _cso
             from docker.utils.socket import demux_adaptor as _da
             from docker.utils.socket import frames_iter as _fi
             _docker_mod = _d
-            _docker_container_cls = _C
             _docker_consume_socket_output = _cso
             _docker_demux_adaptor = _da
             _docker_frames_iter = _fi
-        except ImportError:
+        except Exception:
             pass  # _docker_mod stays None; caller checks guard
         _docker_imported = True
 

--- a/trpc_agent_sdk/code_executors/utils/_files.py
+++ b/trpc_agent_sdk/code_executors/utils/_files.py
@@ -24,7 +24,8 @@ from typing import Optional
 # or crash the interpreter — making the entire trpc_agent_sdk package unusable.
 # Instead, we lazily import it inside detect_content_type() on first use.
 # See: https://github.com/trpc-group/trpc-agent-python/issues/230
-HAS_MAGIC = False  # set to True by tests via mock; real check is lazy
+_magic_module = None  # cached after first successful import on non-win32
+_magic_checked = False
 
 
 def path_join(base: str, path: str) -> str:
@@ -231,17 +232,24 @@ def detect_content_type(filename: Path, data: bytes) -> str:
     if mime_type:
         return mime_type
 
-    # filename guess failed, try python-magic (lazily imported)
+    # filename guess failed, try python-magic (lazily imported).
     # On Windows, python-magic requires a native libmagic DLL that, when
     # missing, causes an access violation at import time (not catchable by
     # try/except). We skip it entirely on win32 and fall through to the
     # simple content-based detection below.
-    if HAS_MAGIC and sys.platform != 'win32':
+    global _magic_module, _magic_checked
+    if sys.platform != 'win32' and not _magic_checked:
         try:
-            import magic
-            return magic.from_buffer(data, mime=True)
+            import magic as _m
+            _magic_module = _m
+        except ImportError:
+            logger.debug("python-magic not available; falling back to byte-signature detection")
+        _magic_checked = True
+    if _magic_module is not None:
+        try:
+            return _magic_module.from_buffer(data, mime=True)
         except Exception:
-            pass
+            logger.debug("magic.from_buffer failed; falling back to byte-signature detection", exc_info=True)
 
     # magic guess failed, use simple content-based detection
     if data.startswith(b'\x89PNG\r\n\x1a\n'):

--- a/trpc_agent_sdk/code_executors/utils/_files.py
+++ b/trpc_agent_sdk/code_executors/utils/_files.py
@@ -16,6 +16,8 @@ import os
 import shutil
 import sys
 from pathlib import Path
+
+from trpc_agent_sdk.log import logger
 from typing import Optional
 
 # NOTE: python-magic is NOT imported at module top level.

--- a/trpc_agent_sdk/code_executors/utils/_files.py
+++ b/trpc_agent_sdk/code_executors/utils/_files.py
@@ -30,6 +30,21 @@ _magic_module = None  # cached after first successful import on non-win32
 _magic_checked = False
 
 
+def _has_magic() -> bool:
+    """Backward-compatible indicator for whether python-magic is available.
+
+    Mirrors the old module-level ``HAS_MAGIC`` boolean. Returns ``True`` only
+    when the magic module has been successfully imported (or explicitly
+    injected by tests).
+    """
+    return _magic_module is not None
+
+
+# Backward-compatible public alias (was a module-level bool before this PR).
+# External code may reference it as ``from ..._files import HAS_MAGIC``.
+HAS_MAGIC = False  # updated lazily; see _has_magic() for the live value
+
+
 def path_join(base: str, path: str) -> str:
     """Join a base path and a path.
 
@@ -239,11 +254,12 @@ def detect_content_type(filename: Path, data: bytes) -> str:
     # missing, causes an access violation at import time (not catchable by
     # try/except). We skip it entirely on win32 and fall through to the
     # simple content-based detection below.
-    global _magic_module, _magic_checked
+    global _magic_module, _magic_checked, HAS_MAGIC
     if sys.platform != 'win32' and not _magic_checked:
         try:
             import magic as _m
             _magic_module = _m
+            HAS_MAGIC = True
             _magic_checked = True
         except ImportError:
             logger.debug("python-magic not available; falling back to byte-signature detection")

--- a/trpc_agent_sdk/code_executors/utils/_files.py
+++ b/trpc_agent_sdk/code_executors/utils/_files.py
@@ -14,6 +14,7 @@ import glob
 import mimetypes
 import os
 import shutil
+import sys
 from pathlib import Path
 from typing import Optional
 
@@ -23,6 +24,7 @@ from typing import Optional
 # or crash the interpreter — making the entire trpc_agent_sdk package unusable.
 # Instead, we lazily import it inside detect_content_type() on first use.
 # See: https://github.com/trpc-group/trpc-agent-python/issues/230
+HAS_MAGIC = False  # set to True by tests via mock; real check is lazy
 
 
 def path_join(base: str, path: str) -> str:
@@ -230,11 +232,16 @@ def detect_content_type(filename: Path, data: bytes) -> str:
         return mime_type
 
     # filename guess failed, try python-magic (lazily imported)
-    try:
-        import magic
-        return magic.from_buffer(data, mime=True)
-    except Exception:
-        pass
+    # On Windows, python-magic requires a native libmagic DLL that, when
+    # missing, causes an access violation at import time (not catchable by
+    # try/except). We skip it entirely on win32 and fall through to the
+    # simple content-based detection below.
+    if HAS_MAGIC and sys.platform != 'win32':
+        try:
+            import magic
+            return magic.from_buffer(data, mime=True)
+        except Exception:
+            pass
 
     # magic guess failed, use simple content-based detection
     if data.startswith(b'\x89PNG\r\n\x1a\n'):

--- a/trpc_agent_sdk/code_executors/utils/_files.py
+++ b/trpc_agent_sdk/code_executors/utils/_files.py
@@ -17,11 +17,12 @@ import shutil
 from pathlib import Path
 from typing import Optional
 
-try:
-    import magic
-    HAS_MAGIC = True
-except ImportError:
-    HAS_MAGIC = False
+# NOTE: python-magic is NOT imported at module top level.
+# On Windows (and other platforms without libmagic installed), the `magic`
+# package searches for the native libmagic DLL at import time, which can hang
+# or crash the interpreter — making the entire trpc_agent_sdk package unusable.
+# Instead, we lazily import it inside detect_content_type() on first use.
+# See: https://github.com/trpc-group/trpc-agent-python/issues/230
 
 
 def path_join(base: str, path: str) -> str:
@@ -228,9 +229,12 @@ def detect_content_type(filename: Path, data: bytes) -> str:
     if mime_type:
         return mime_type
 
-    # filename guess failed, use magic to guess
-    if HAS_MAGIC:
+    # filename guess failed, try python-magic (lazily imported)
+    try:
+        import magic
         return magic.from_buffer(data, mime=True)
+    except Exception:
+        pass
 
     # magic guess failed, use simple content-based detection
     if data.startswith(b'\x89PNG\r\n\x1a\n'):

--- a/trpc_agent_sdk/code_executors/utils/_files.py
+++ b/trpc_agent_sdk/code_executors/utils/_files.py
@@ -242,9 +242,10 @@ def detect_content_type(filename: Path, data: bytes) -> str:
         try:
             import magic as _m
             _magic_module = _m
+            _magic_checked = True
         except ImportError:
             logger.debug("python-magic not available; falling back to byte-signature detection")
-        _magic_checked = True
+            _magic_checked = True  # cache failure to avoid retrying every call
     if _magic_module is not None:
         try:
             return _magic_module.from_buffer(data, mime=True)

--- a/trpc_agent_sdk/code_executors/utils/_files.py
+++ b/trpc_agent_sdk/code_executors/utils/_files.py
@@ -26,8 +26,11 @@ from typing import Optional
 # or crash the interpreter — making the entire trpc_agent_sdk package unusable.
 # Instead, we lazily import it inside detect_content_type() on first use.
 # See: https://github.com/trpc-group/trpc-agent-python/issues/230
+import threading as _threading
+
 _magic_module = None  # cached after first successful import on non-win32
 _magic_checked = False
+_magic_lock = _threading.Lock()
 
 
 def _has_magic() -> bool:
@@ -265,14 +268,15 @@ def detect_content_type(filename: Path, data: bytes) -> str:
     # simple content-based detection below.
     global _magic_module, _magic_checked, HAS_MAGIC
     if sys.platform != 'win32' and not _magic_checked:
-        try:
-            import magic as _m
-            _magic_module = _m
-            HAS_MAGIC = True
-            _magic_checked = True
-        except Exception:
-            logger.debug("python-magic import failed; falling back to byte-signature detection", exc_info=True)
-            _magic_checked = True  # cache failure to avoid retrying every call
+        with _magic_lock:
+            if not _magic_checked:
+                try:
+                    import magic as _m
+                    _magic_module = _m
+                    HAS_MAGIC = True
+                except Exception:
+                    logger.debug("python-magic import failed; falling back to byte-signature detection", exc_info=True)
+                _magic_checked = True  # cache result (success or failure)
     if _magic_module is not None:
         try:
             return _magic_module.from_buffer(data, mime=True)

--- a/trpc_agent_sdk/code_executors/utils/_files.py
+++ b/trpc_agent_sdk/code_executors/utils/_files.py
@@ -261,8 +261,8 @@ def detect_content_type(filename: Path, data: bytes) -> str:
             _magic_module = _m
             HAS_MAGIC = True
             _magic_checked = True
-        except ImportError:
-            logger.debug("python-magic not available; falling back to byte-signature detection")
+        except Exception:
+            logger.debug("python-magic import failed; falling back to byte-signature detection", exc_info=True)
             _magic_checked = True  # cache failure to avoid retrying every call
     if _magic_module is not None:
         try:

--- a/trpc_agent_sdk/code_executors/utils/_files.py
+++ b/trpc_agent_sdk/code_executors/utils/_files.py
@@ -32,29 +32,11 @@ _magic_module = None  # cached after first successful import on non-win32
 _magic_checked = False
 _magic_lock = _threading.Lock()
 
-
-def _has_magic() -> bool:
-    """Backward-compatible indicator for whether python-magic is available.
-
-    Mirrors the old module-level ``HAS_MAGIC`` boolean. Returns ``True`` only
-    when the magic module has been successfully imported (or explicitly
-    injected by tests).
-    """
-    return _magic_module is not None
-
-
-# Backward-compatible public alias (was a module-level bool before this PR).
-# External code may reference it as ``from ..._files import HAS_MAGIC``.
-# On non-win32, probe once at import time to preserve the original semantics
-# (HAS_MAGIC reflects availability immediately, not deferred to first call).
-if sys.platform != 'win32':
-    try:
-        import magic as _magic_mod
-        _magic_module = _magic_mod
-        _magic_checked = True
-    except Exception:
-        _magic_checked = True
-HAS_MAGIC = _magic_module is not None
+# Backward-compatible public alias. Remains False until first
+# detect_content_type() call triggers lazy import on non-win32.
+# Note: on win32 this is always False (python-magic requires libmagic DLL
+# which causes access violations at import time).
+HAS_MAGIC = False
 
 
 def path_join(base: str, path: str) -> str:

--- a/trpc_agent_sdk/code_executors/utils/_files.py
+++ b/trpc_agent_sdk/code_executors/utils/_files.py
@@ -42,7 +42,16 @@ def _has_magic() -> bool:
 
 # Backward-compatible public alias (was a module-level bool before this PR).
 # External code may reference it as ``from ..._files import HAS_MAGIC``.
-HAS_MAGIC = False  # updated lazily; see _has_magic() for the live value
+# On non-win32, probe once at import time to preserve the original semantics
+# (HAS_MAGIC reflects availability immediately, not deferred to first call).
+if sys.platform != 'win32':
+    try:
+        import magic as _magic_mod
+        _magic_module = _magic_mod
+        _magic_checked = True
+    except Exception:
+        _magic_checked = True
+HAS_MAGIC = _magic_module is not None
 
 
 def path_join(base: str, path: str) -> str:


### PR DESCRIPTION
Fixes #230. Defer top-level import docker and import magic to call-time to prevent hang/segfault on Windows without Docker/libmagic. See issue for full details.