### PR TITLE
Bugfix: 修复LLM返回工具参数非法JSON导致Agent丢弃此工具调用的问题

### DIFF
--- a/tests/models/test_openai_model_ext.py
+++ b/tests/models/test_openai_model_ext.py
@@ -9,7 +9,7 @@ import json
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
-from trpc_agent_sdk.models import LlmRequest, OpenAIModel
+from trpc_agent_sdk.models import LlmRequest, OpenAIModel, TOOL_CALL_ARGUMENT_ERRORS
 from trpc_agent_sdk.models._llm_response import LlmResponse
 from trpc_agent_sdk.models._openai_model import (
     ApiParamsKey,
@@ -285,14 +285,24 @@ class TestCreateCompleteToolCalls:
         assert result[0].name == "search"
         assert result[0].arguments == {"q": "test"}
 
-    def test_incomplete_json_skipped(self):
-        """Incomplete JSON arguments are skipped."""
+    def test_malformed_json_repaired(self):
+        """Malformed JSON arguments are repaired after stream completion."""
         model = _model()
         acc = [{
             ToolKey.ID: "call_1",
-            ToolKey.FUNCTION: {ToolKey.NAME: "f", ToolKey.ARGUMENTS: '{"incomplete":'},
+            ToolKey.FUNCTION: {
+                ToolKey.NAME: "f",
+                ToolKey.ARGUMENTS: '{"queries": [{"sql": "xxx", "csv_filename": "xxx"]}}',
+            },
         }]
-        assert model._create_complete_tool_calls(acc) is None
+        result = model._create_complete_tool_calls(acc)
+        assert result is not None
+        assert result[0].arguments == {
+            "queries": [{
+                "sql": "xxx",
+                "csv_filename": "xxx",
+            }],
+        }
 
     def test_empty_arguments_yields_empty_dict(self):
         """Empty argument string produces empty dict."""
@@ -388,8 +398,8 @@ class TestProcessToolCallsFromMessage:
         assert result[0].name == "search"
         assert result[0].arguments == {"q": "hello"}
 
-    def test_malformed_json_skipped(self):
-        """Malformed JSON arguments cause the tool call to be skipped."""
+    def test_unrecoverable_json_preserved(self):
+        """Unrecoverable arguments retain their raw value and JSON error."""
         model = _model()
         message = {
             "tool_calls": [{
@@ -398,7 +408,11 @@ class TestProcessToolCallsFromMessage:
                 "function": {"name": "f", "arguments": "NOT_JSON"},
             }]
         }
-        assert model._process_tool_calls_from_message(message) is None
+        result = model._process_tool_calls_from_message(message)
+        assert result is not None
+        argument_errors = result[0].arguments[TOOL_CALL_ARGUMENT_ERRORS]
+        assert argument_errors["raw_arguments"] == "NOT_JSON"
+        assert "Expecting value" in argument_errors["json_error"]
 
     def test_none_entry_skipped(self):
         """None entries in tool_calls list are skipped."""

--- a/trpc_agent_sdk/agents/core/_tools_processor.py
+++ b/trpc_agent_sdk/agents/core/_tools_processor.py
@@ -38,7 +38,6 @@ from trpc_agent_sdk.tools import convert_toolunion_to_tool_list
 from trpc_agent_sdk.types import Content
 from trpc_agent_sdk.types import FunctionCall
 from trpc_agent_sdk.types import Part
-from trpc_agent_sdk.utils import json_loads_repair
 
 # Type aliases for tool definitions
 ToolUnion: TypeAlias = Union[BaseTool, BaseToolSet]
@@ -351,31 +350,7 @@ class ToolsProcessor:
             # Capture state before tool execution
             state_begin = dict(context.session.state)
 
-            # Parse arguments (FunctionCall uses 'args' field).
-            # json_repair tolerates malformed JSON from models, but it can also
-            # silently turn plain text (e.g. "Beijing") into "" or wrap loose
-            # values into lists. Guard the result so downstream tools always
-            # receive a dict, falling back to {} when repair cannot recover a
-            # structured object.
-            if isinstance(tool_call.args, str):
-                try:
-                    arguments = json_loads_repair(tool_call.args)
-                except Exception as ex:  # pylint: disable=broad-except
-                    logger.warning(
-                        "Failed to repair string tool args for %s: %s",
-                        tool_call.name,
-                        ex,
-                    )
-                    arguments = {}
-                if not isinstance(arguments, dict):
-                    logger.warning(
-                        "Discarding non-dict repaired tool args for %s: %r",
-                        tool_call.name,
-                        arguments,
-                    )
-                    arguments = {}
-            else:
-                arguments = tool_call.args or {}
+            arguments = tool_call.args or {}
 
             # Set function call ID for context
             context.function_call_id = tool_call.id
@@ -508,10 +483,18 @@ class ToolsProcessor:
         ):
             state_begin = dict(context.session.state)
 
-            if isinstance(tool_call.args, str):
-                arguments = json.loads(tool_call.args)
-            else:
-                arguments = tool_call.args or {}
+            arguments = tool_call.args or {}
+            argument_error_response = tool._get_argument_error_response(arguments)
+            if argument_error_response is not None:
+                yield self._create_error_event(
+                    context,
+                    argument_error_response["error"],
+                    argument_error_response["message"],
+                    tool_call.id,
+                    tool_call.name,
+                    error_details=argument_error_response,
+                )
+                return
 
             context.function_call_id = tool_call.id
             start_time = time.monotonic()
@@ -725,6 +708,7 @@ class ToolsProcessor:
         error_message: str,
         tool_call_id: Optional[str] = None,
         tool_name: Optional[str] = None,
+        error_details: Optional[dict[str, Any]] = None,
     ) -> Event:
         """Create an error event with proper function_response structure.
 
@@ -737,6 +721,7 @@ class ToolsProcessor:
             error_message: The error message for the event
             tool_call_id: The ID of the failed tool call (optional)
             tool_name: The name of the failed tool (optional)
+            error_details: Additional structured error details (optional)
 
         Returns:
             Event: Error event with proper function_response structure
@@ -747,6 +732,8 @@ class ToolsProcessor:
             "message": error_message,
             "status": "failed",
         }
+        if error_details:
+            error_response.update(error_details)
 
         # Create function response part
         part_function_response = Part.from_function_response(

--- a/trpc_agent_sdk/models/__init__.py
+++ b/trpc_agent_sdk/models/__init__.py
@@ -30,6 +30,7 @@ from ._constants import SYSTEM
 from ._constants import THINKING_ENABLED
 from ._constants import THINKING_TOKENS
 from ._constants import TOOL
+from ._constants import TOOL_CALL_ARGUMENT_ERRORS
 from ._constants import TOOL_CALLS
 from ._constants import TOOL_CALL_ID
 from ._constants import TOOL_STREAMING
@@ -67,6 +68,7 @@ __all__ = [
     "CHOICES",
     "USAGE",
     "MESSAGE",
+    "TOOL_CALL_ARGUMENT_ERRORS",
     "TOOL_CALLS",
     "TOOL_CALL_ID",
     "DELTA",

--- a/trpc_agent_sdk/models/_constants.py
+++ b/trpc_agent_sdk/models/_constants.py
@@ -61,6 +61,9 @@ TOOL_CALLS: str = 'tool_calls'
 TOOL_CALL_ID: str = 'tool_call_id'
 """Tool call ID field name in API responses."""
 
+TOOL_CALL_ARGUMENT_ERRORS: str = "__trpc_agent_sdk_tool_call_argument_errors__"
+"""Internal envelope key for unrecoverable tool-call arguments."""
+
 DELTA: str = 'delta'
 """Delta field name in streaming responses."""
 

--- a/trpc_agent_sdk/models/_openai_model.py
+++ b/trpc_agent_sdk/models/_openai_model.py
@@ -351,14 +351,22 @@ class OpenAIModel(LLMModel):
                     elif part.function_call:
                         # Only convert function call to OpenAI tool call format if add_tools_to_prompt is disabled
                         if not self.add_tools_to_prompt:
+                            function_args = part.function_call.args
+                            if (isinstance(function_args, dict) and const.TOOL_CALL_ARGUMENT_ERRORS in function_args):
+                                # The matching function response describes the
+                                # parsing failure. Keep the historical call
+                                # valid without exposing the internal envelope.
+                                formatted_function_args = "{}"
+                            elif isinstance(function_args, str):
+                                formatted_function_args = function_args
+                            else:
+                                formatted_function_args = json.dumps(function_args, ensure_ascii=False)
                             tool_call = {
                                 "id": getattr(part.function_call, "id", None) or f"call_{uuid.uuid4().hex[:24]}",
                                 "type": "function",
                                 "function": {
-                                    "name":
-                                    part.function_call.name,
-                                    "arguments": (part.function_call.args if isinstance(part.function_call.args, str)
-                                                  else json.dumps(part.function_call.args, ensure_ascii=False)),
+                                    "name": part.function_call.name,
+                                    "arguments": formatted_function_args,
                                 },
                             }
                             if self._adapter.should_include_thought_signature():
@@ -808,8 +816,66 @@ class OpenAIModel(LLMModel):
 
         return finish_reason, usage, delta_arguments
 
+    def _parse_tool_call_arguments(self, raw_arguments: Any) -> Dict[str, Any]:
+        """Normalize provider tool-call arguments into a dictionary.
+
+        Strict JSON parsing is attempted first. Malformed JSON is repaired only
+        after the complete provider response has been collected. If repair
+        cannot produce an object, an internal envelope preserves the original
+        parsing error for ``BaseTool`` to return without invoking the tool
+        implementation.
+
+        Args:
+            raw_arguments: Raw arguments supplied by the model provider.
+
+        Returns:
+            Parsed arguments or an internal invalid-arguments envelope.
+        """
+        if raw_arguments is None or raw_arguments == "":
+            return {}
+        if isinstance(raw_arguments, dict):
+            return raw_arguments
+        if not isinstance(raw_arguments, str):
+            return {
+                const.TOOL_CALL_ARGUMENT_ERRORS: {
+                    "raw_arguments":
+                    str(raw_arguments),
+                    "json_error": ("Tool arguments must be a JSON object or a JSON object "
+                                   f"string, got {type(raw_arguments).__name__}."),
+                },
+            }
+        if not raw_arguments.strip():
+            return {}
+
+        original_error: Optional[json.JSONDecodeError] = None
+        try:
+            arguments = json.loads(raw_arguments)
+        except json.JSONDecodeError as ex:
+            original_error = ex
+            try:
+                arguments = json_loads_repair(raw_arguments)
+            except json.JSONDecodeError as repair_error:
+                logger.warning("Failed to repair tool-call arguments: %s", repair_error)
+                arguments = None
+
+        if isinstance(arguments, dict):
+            return arguments
+
+        if original_error is not None:
+            error_message = str(original_error)
+        else:
+            error_message = ("Tool arguments must be a JSON object, "
+                             f"got {type(arguments).__name__}.")
+
+        return {
+            const.TOOL_CALL_ARGUMENT_ERRORS: {
+                "raw_arguments": raw_arguments,
+                "json_error": error_message,
+            },
+        }
+
     def _create_complete_tool_calls(self, accumulated_tool_calls: list[dict]) -> Optional[List[ToolCall]]:
-        """Create ToolCall objects only for complete tool calls with valid data.
+        """Create tool calls from fully accumulated streaming data.
 
         Args:
             accumulated_tool_calls (`list`): The list of accumulated tool calls
@@ -831,15 +897,7 @@ class OpenAIModel(LLMModel):
 
             if has_name and has_arguments:
                 try:
-                    # Streaming tool-call accumulator: keep STRICT json.loads here.
-                    # Incomplete deltas (e.g. ``{"foo":``) must raise so the loop
-                    # can wait for the next chunk; using a repair-style parser
-                    # would prematurely emit half-formed tool calls.
-                    arguments_str: str = function_map[ToolKey.ARGUMENTS].strip()
-                    if arguments_str:
-                        arguments = json.loads(arguments_str)
-                    else:
-                        arguments = {}
+                    arguments = self._parse_tool_call_arguments(function_map[ToolKey.ARGUMENTS])
 
                     # Handle missing or empty ID by generating a fallback
                     tool_call_id = tool_call_data.get(ToolKey.ID, "")
@@ -858,12 +916,13 @@ class OpenAIModel(LLMModel):
                             arguments=arguments,
                             thought_signature=thought_sig,
                         ))
-                except json.JSONDecodeError as ex:
-                    # Arguments not complete yet, skip this tool call
-                    logger.debug("JSON decode error for tool call %s: %s", i, ex)
-                    continue
                 except Exception as ex:  # pylint: disable=broad-except
-                    logger.warning("Failed to create complete tool call: %s, error: %s", tool_call_data, ex)
+                    logger.warning(
+                        "Failed to create complete tool call %s: %s, error: %s",
+                        i,
+                        tool_call_data,
+                        ex,
+                    )
                     continue
 
         return complete_tool_calls if complete_tool_calls else None
@@ -979,17 +1038,7 @@ class OpenAIModel(LLMModel):
                 thought_sig = tool_call.get(ToolKey.THOUGHT_SIGNATURE)
                 if not thought_sig and isinstance(tool_call.get(ToolKey.PROVIDER_SPECIFIC_FIELDS), dict):
                     thought_sig = tool_call[ToolKey.PROVIDER_SPECIFIC_FIELDS].get(ToolKey.THOUGHT_SIGNATURE)
-                arguments = json_loads_repair(tool_call[ToolKey.FUNCTION][ToolKey.ARGUMENTS])
-                if not isinstance(arguments, dict):
-                    # json_repair can turn unrecoverable text (e.g. "NOT_JSON")
-                    # into an empty string or list. Skip those so we never feed
-                    # ToolCall a non-dict ``arguments`` value.
-                    logger.warning(
-                        "Skipping tool call with non-dict repaired arguments: %s -> %r",
-                        tool_call,
-                        arguments,
-                    )
-                    continue
+                arguments = self._parse_tool_call_arguments(tool_call[ToolKey.FUNCTION][ToolKey.ARGUMENTS])
                 tool_calls.append(
                     ToolCall(
                         id=tool_call[ToolKey.ID],

--- a/trpc_agent_sdk/tools/_base_tool.py
+++ b/trpc_agent_sdk/tools/_base_tool.py
@@ -69,6 +69,7 @@ from trpc_agent_sdk.filter import BaseFilter
 from trpc_agent_sdk.filter import FilterRunner
 from trpc_agent_sdk.filter import FilterType
 from trpc_agent_sdk.models import LlmRequest
+from trpc_agent_sdk.models import TOOL_CALL_ARGUMENT_ERRORS
 from trpc_agent_sdk.types import FunctionDeclaration
 from trpc_agent_sdk.types import GenerateContentConfig
 from trpc_agent_sdk.types import Tool
@@ -138,6 +139,26 @@ class BaseTool(ToolABC, FilterRunner):
         """Get API variant."""
         return DEFAULT_API_VARIANT
 
+    def _get_argument_error_response(self, args: dict[str, Any]) -> Optional[dict[str, str]]:
+        """Build a tool response for unrecoverable model arguments."""
+        argument_errors = args.get(TOOL_CALL_ARGUMENT_ERRORS)
+        if not isinstance(argument_errors, dict):
+            return None
+
+        raw_arguments = argument_errors.get("raw_arguments")
+        json_error = argument_errors.get("json_error")
+        if not isinstance(raw_arguments, str) or not isinstance(json_error, str):
+            return None
+
+        return {
+            "error": "invalid_tool_arguments",
+            "message": (f"Tool '{self.name}' arguments were invalid JSON and "
+                        f"could not be repaired: {json_error}"),
+            "raw_arguments": raw_arguments,
+            "json_error": json_error,
+            "status": "failed",
+        }
+
     @override
     def _get_declaration(self) -> Optional[FunctionDeclaration]:
         """Gets the OpenAPI specification of this tool in the form of a FunctionDeclaration.
@@ -168,6 +189,10 @@ class BaseTool(ToolABC, FilterRunner):
          Returns:
            The result of running the tool.
         """
+        argument_error_response = self._get_argument_error_response(args)
+        if argument_error_response is not None:
+            return argument_error_response
+
         agent_context = tool_context.agent_context
         if agent_context is None:
             agent_context = create_agent_context()


### PR DESCRIPTION
- 修复方案：先尝试用json_repair修复，如果无法修复，工具执行时，直接返回参数错误的结果，触发Agent下次执行