### PR TITLE
Bugfix: 修复hy3模型调用不带思考内容导致思维链断裂的问题

### DIFF
--- a/trpc_agent_sdk/models/_openai_model.py
+++ b/trpc_agent_sdk/models/_openai_model.py
@@ -335,12 +335,17 @@ class OpenAIModel(LLMModel):
                 # Separate function responses from other content
                 function_responses: list[FunctionResponse] = []
                 text_parts = []
+                reasoning_parts: list[str] = []
                 image_parts = []
                 tool_calls = []
 
                 for part in parts:  # type: ignore
                     if part.text:
                         if part.thought:
+                            # Reasoning is stripped by default, but some providers
+                            # (e.g. Hunyuan hy3) require it to be replayed.
+                            if self._adapter.should_preserve_reasoning_content():
+                                reasoning_parts.append(part.text)
                             continue
                         text_parts.append(part.text)
                     elif part.inline_data and part.inline_data.mime_type:
@@ -445,7 +450,9 @@ class OpenAIModel(LLMModel):
                     if tool_calls and not self.add_tools_to_prompt:
                         message[const.TOOL_CALLS] = tool_calls
 
-                    if self._adapter.should_backfill_reasoning_content(role, message):
+                    if reasoning_parts and self._adapter.should_preserve_reasoning_content():
+                        message[const.REASONING_CONTENT] = "".join(reasoning_parts)
+                    elif self._adapter.should_backfill_reasoning_content(role, message):
                         message[const.REASONING_CONTENT] = ""
 
                     formatted_messages.append(message)

--- a/trpc_agent_sdk/models/openai_adapter/__init__.py
+++ b/trpc_agent_sdk/models/openai_adapter/__init__.py
@@ -13,6 +13,7 @@ from ._base import DefaultOpenAIAdapter
 from ._base import OpenAIAdapter
 from ._base import ToolPromptTextFilterMixin
 from ._deepseek import DeepSeekAdapter
+from ._hunyuan import HunyuanHy3Adapter
 from ._hunyuan import HunyuanHy3PreviewAdapter
 
 
@@ -21,6 +22,8 @@ def get_openai_adapter(model_name: str, base_url: Optional[str] = None) -> OpenA
     model_name_lower = model_name.lower()
     if model_name_lower == "hy3-preview":
         return HunyuanHy3PreviewAdapter(model_name=model_name, base_url=base_url)
+    if model_name_lower == "hy3":
+        return HunyuanHy3Adapter(model_name=model_name, base_url=base_url)
     if model_name_lower.startswith("deepseek-"):
         return DeepSeekAdapter(model_name=model_name, base_url=base_url)
     return DefaultOpenAIAdapter(model_name=model_name, base_url=base_url)
@@ -29,6 +32,7 @@ def get_openai_adapter(model_name: str, base_url: Optional[str] = None) -> OpenA
 __all__ = [
     "DefaultOpenAIAdapter",
     "DeepSeekAdapter",
+    "HunyuanHy3Adapter",
     "HunyuanHy3PreviewAdapter",
     "OpenAIAdapter",
     "ToolPromptTextFilterMixin",

--- a/trpc_agent_sdk/models/openai_adapter/_base.py
+++ b/trpc_agent_sdk/models/openai_adapter/_base.py
@@ -64,6 +64,15 @@ class OpenAIAdapter:
         """Whether assistant history should include an empty reasoning_content field."""
         return False
 
+    def should_preserve_reasoning_content(self) -> bool:
+        """Whether assistant history should carry back the model's reasoning_content.
+
+        Most OpenAI-compatible reasoning models expect prior thinking to be
+        stripped from the request. Providers that require the reasoning to be
+        replayed (e.g. Hunyuan hy3) override this to return True.
+        """
+        return False
+
     def build_response_format(self, config: Any) -> tuple[bool, Optional[dict[str, Any]]]:
         """Return provider-specific response_format.
 

--- a/trpc_agent_sdk/models/openai_adapter/_hunyuan.py
+++ b/trpc_agent_sdk/models/openai_adapter/_hunyuan.py
@@ -11,7 +11,6 @@ import json
 import re
 from typing import Any
 from typing import List
-from typing import Optional
 
 from trpc_agent_sdk.types import FunctionCall
 
@@ -19,23 +18,25 @@ from ._base import OpenAIAdapter
 from ._base import ToolPromptTextFilterMixin
 
 
-class HunyuanHy3PreviewAdapter(ToolPromptTextFilterMixin, OpenAIAdapter):
-    """Provider-specific behavior for the hy3-preview model."""
+class _HunyuanAdapterBase(ToolPromptTextFilterMixin, OpenAIAdapter):
+    """Shared behavior for Hunyuan models using the XML tool-call format.
 
-    def __init__(self, model_name: str, base_url: Optional[str] = None):
-        super().__init__(model_name=model_name, base_url=base_url)
-
-    def parse_tool_prompt_function_calls(self, content: str, tool_prompt: Any) -> List[FunctionCall]:
-        function_calls = self._parse_hunyuan_tool_calls(content)
-        if function_calls:
-            return function_calls
-        return tool_prompt.parse_function(content)
+    Hunyuan models do not use native OpenAI function calling: tools are injected
+    into the prompt and tool calls are returned as
+    ``<tool_call>NAME<tool_sep>...</tool_call>`` XML which we parse back here.
+    """
 
     def requires_add_tools_to_prompt(self) -> bool:
         return True
 
     def should_filter_reasoning_text(self) -> bool:
         return True
+
+    def parse_tool_prompt_function_calls(self, content: str, tool_prompt: Any) -> List[FunctionCall]:
+        function_calls = self._parse_hunyuan_tool_calls(content)
+        if function_calls:
+            return function_calls
+        return tool_prompt.parse_function(content)
 
     def _parse_hunyuan_tool_calls(self, content: str) -> List[FunctionCall]:
         function_calls = []
@@ -82,3 +83,22 @@ class HunyuanHy3PreviewAdapter(ToolPromptTextFilterMixin, OpenAIAdapter):
             return json.loads(value)
         except json.JSONDecodeError:
             return value
+
+
+class HunyuanHy3Adapter(_HunyuanAdapterBase):
+    """Provider-specific behavior for the Hunyuan hy3 model.
+
+    hy3 requires the model's previous reasoning_content to be replayed in the
+    request instead of being stripped. ``thought_signature`` is a Gemini-only
+    concept and is disabled for Hunyuan.
+    """
+
+    def should_preserve_reasoning_content(self) -> bool:
+        return True
+
+    def should_include_thought_signature(self) -> bool:
+        return False
+
+
+class HunyuanHy3PreviewAdapter(_HunyuanAdapterBase):
+    """Provider-specific behavior for the hy3-preview model."""


### PR DESCRIPTION
- 问题：hy3要求开思考的时候，后面的对话要带上思考内容，如果不带上，会导致思维链断裂