### PR TITLE
feat: Add an Automated Code Review Agent Based on Skills, Sandboxing, and Database Storage

### DIFF
--- a/examples/skills_code_review_agent/DESIGN.md
+++ b/examples/skills_code_review_agent/DESIGN.md
@@ -1,0 +1,217 @@
+# Skills Code Review Agent Design
+
+## 背景与定位
+
+本示例是 `examples` 级 deterministic 代码评审 Agent 原型，目标是展示如何把
+Skill、输入解析、治理策略、沙箱适配、结构化 findings、SQLite 持久化和报告输出
+组合成一个可验证闭环。它不修改 `trpc_agent_sdk/`，不新增 SDK 公共 API，也不把
+代码评审能力抽象成框架级模块。所有实现都位于 `examples/skills_code_review_agent/`
+内，便于独立运行、测试和后续演进。
+
+默认执行路径是 dry-run，不依赖真实模型 API Key、Docker、Cube 或外部服务。
+`container` 和 `cube` runtime 作为可选真实执行后端：环境可用时通过 SDK workspace runtime
+执行规则脚本，环境不可用或未配置时记录为需要人工复核。
+`local-dev` 没有隔离能力，因此必须显式传入 `--allow-local` 才能执行。
+
+## 总体数据流
+
+一次 review 从 CLI 开始：
+
+```text
+run_review.py
+  -> input_parser
+  -> skill_loader
+  -> sandbox.run_rule_script
+  -> review_rules
+  -> governance decision
+  -> report routing and dedupe
+  -> SQLite store
+  -> JSON / Markdown report
+```
+
+CLI 只负责参数解析、基本校验和打印结果；核心编排在 `agent/pipeline.py` 中完成。
+pipeline 会把 `--diff-file`、`--repo-path` 或 `--fixture` 统一解析为
+`InputSummary`，加载本地 `code-review` Skill manifest，执行规则脚本，收集
+`FilterEvent` 与 `SandboxRun`，再生成 `ReviewReport` 并保存到 SQLite。
+
+## Skill 设计
+
+### 目录结构
+
+`skills/code-review/` 是一个完整的本地 Skill 包：
+
+```text
+skills/code-review/
+  SKILL.md
+  README.md
+  rules/
+    security.md
+    async-resource.md
+    testing-db.md
+    runtime.md
+  scripts/
+    rule_runner.py
+```
+
+`SKILL.md` 描述输入、输出、规则文档、脚本入口和安全边界。`skill_loader.py`
+负责读取 front matter、校验规则和脚本路径、计算 digest，并输出 example-local
+`SkillManifest`。这里没有调用 SDK 的 `SkillToolSet`，原因是当前示例要在无模型、
+无真实 Agent session 的环境中稳定测试；但目录组织和 Skill 概念仍与 SDK Skill
+体系保持一致。
+
+### 规则脚本
+
+`scripts/rule_runner.py` 是沙箱或 dry-run 中执行的命令入口。它接收规范化后的
+`InputSummary` JSON 和 Skill manifest JSON，验证 schema 必要字段，然后调用
+`agent.review_rules.run_review_rules()` 生成 deterministic findings。脚本支持直接执行
+时的 import fallback，确保从示例目录运行 CLI 不需要安装额外包。
+
+## 输入解析设计
+
+`agent/input_parser.py` 把三类输入统一转换成 `InputSummary`：
+
+- `--diff-file`：读取 UTF-8 unified diff。
+- `--repo-path`：执行 `git diff`，并把 untracked 文本文件转换为 added-file diff。
+- `--fixture`：读取 `fixtures/<name>.diff` 或显式 fixture 路径。
+
+解析结果保留 file、old_path、status、hunk、context line、added/deleted line、
+candidate line 和 binary marker。解析器对 malformed hunk 和 binary patch 采取
+容错策略：记录 diagnostics，不让整个 review 崩溃。后续规则只扫描 added lines，
+因此 candidate line 是 finding 定位的主要来源。
+
+## Finding 与规则设计
+
+核心输出模型是 `Finding`，字段覆盖：
+
+- `severity`
+- `category`
+- `file`
+- `line`
+- `title`
+- `evidence`
+- `recommendation`
+- `confidence`
+- `source`
+- `fingerprint`
+
+规则引擎当前覆盖 hard-coded secret、`eval` / `exec` / `shell=True`、async client
+生命周期、文件句柄生命周期、数据库连接生命周期和测试缺失。规则优先分析新增行，
+避免对未改动上下文产生过多噪声。secret 规则支持已脱敏输入中的
+`[REDACTED]` assignment 形态，这保证“落盘前脱敏”和“规则仍可检出 secret 类型”
+两个安全目标不会互相冲突。
+
+fingerprint 使用 category、file、line、title 和 redacted evidence 生成，供报告层和
+SQLite 去重使用。低置信度 finding 不进入主 findings，而是进入 warnings。
+
+## Governance 与 Sandbox 设计
+
+`agent/governance.py` 实现 example-local 执行治理模型。它不是 SDK Filter 扩展，
+而是把 Filter 概念落成可测试的 `FilterEvent`：
+
+- `dry-run` 普通规则脚本允许执行。
+- `local-dev` 未显式 `--allow-local` 时拒绝。
+- `container` / `cube` 可用时进入 SDK workspace runtime；不可用或未配置时记录为
+  `needs_human_review`。
+- 高风险命令、网络命令、禁止路径、timeout 超预算、output limit 超预算会被拒绝或
+  进入人工复核。
+
+`agent/sandbox.py` 是统一执行入口，负责治理后的 runtime 分发、dry-run、本地 fallback 和
+结果落盘。`agent/sandbox_workspace.py` 承接可选 SDK workspace runtime 适配，负责
+container/cube 的 lazy 探测、最小 bundle 上传、远端 `rule_runner.py` 执行和 output spec
+收集。任何 sandbox 失败都会转换成 `SandboxRun` 和诊断结果，不抛到 CLI 顶层导致整次
+review 崩溃。
+
+Container 默认使用 `python:3-slim` 并关闭网络；Cube 只从环境变量读取
+`CUBE_TEMPLATE_ID`、`E2B_API_URL` 和 `E2B_API_KEY`，避免把凭证放进 CLI 参数、报告或
+数据库。两类远端后端都只 stage `models.py`、`review_rules.py`、`sanitizer.py`、
+`rule_runner.py`、脱敏后的输入和 manifest，不上传完整仓库。
+
+## 安全边界
+
+安全边界分为四层：
+
+1. 输入解析只保存 summary 和 diff hash，不把完整原始 diff 写入 SQLite。
+2. 治理层在执行前检查 runtime、路径、命令、网络、环境变量白名单和预算。
+3. sandbox 层执行 timeout 控制、stdout/stderr 捕获和 output size 截断。
+4. sanitizer 在 findings、filter events、sandbox output、report 和 store 写入前脱敏。
+
+脱敏覆盖 Bearer token、API key、secret/token/password assignment、private key block
+和常见连接串密码。需要注意，静态治理和脱敏不是完整 sandbox；真正的生产隔离仍应由
+Container、Cube 或等价受控 runtime 提供。
+
+## SQLite 持久化设计
+
+`agent/store.py` 使用标准库 `sqlite3`，避免给 example 引入 ORM 复杂度。它同时暴露最小
+store protocol 和 factory 注入点；SQLite 是默认实现，pipeline 可注入其他 SQL 后端而不改变
+CLI 或报告契约。最小 schema 包括：
+
+- `review_task`
+- `input_diff`
+- `finding`
+- `filter_event`
+- `sandbox_run`
+- `report`
+- `review_metrics`
+
+数据库保存 `InputSummary` JSON 和 diff SHA-256，而不是完整 raw diff。`review_metrics`
+独立保存已有 `ReviewMetrics` 的计数和分布字段，便于不解析 report JSON 也能查询监控摘要。finding 表按
+`task_id + fingerprint + route` 去重，route 区分主 findings、warnings 和
+needs human review。查询 helper 支持按 task id 读取 task、input summary、finding、
+filter event、sandbox run 和 report。
+
+## 报告与降噪设计
+
+`agent/report.py` 负责去重、路由和渲染：
+
+- `dedupe_findings()` 基于 fingerprint 去重。
+- `route_findings()` 将低置信度问题放入 warnings。
+- governance 或 sandbox 不确定性会合成 `GOVERNANCE` 或 `SANDBOX` 类型的人工复核项。
+- `build_review_report()` 汇总 metrics、severity/category 分布、异常分布和结论。
+- `write_review_report()` 输出 JSON 和 Markdown。
+
+报告结论根据高危 finding、人工复核项、warning 数量决定。Markdown 保持简单可读，
+不引入模板引擎。
+
+## 监控与审计字段
+
+`ReviewMetrics` 记录：
+
+- 总耗时
+- sandbox 耗时
+- tool call 数
+- interception 数
+- finding / warning / human-review 数
+- severity 分布
+- category 分布
+- exception 分布
+
+这些字段用于展示每次 review 的风险和执行状态，也为后续 Evaluation、回放或优化闭环
+保留基础数据。
+
+## 测试策略
+
+测试只关注业务代码行为，不验证 README 或 sample output。8 条公开 fixture 位于
+`fixtures/`，由端到端业务测试驱动，覆盖：
+
+- clean diff
+- security issue
+- async leak
+- DB lifecycle
+- missing tests
+- duplicate finding
+- sandbox failure
+- secret redaction
+
+其余测试覆盖 parser、Skill loader、rule runner contract、governance、sandbox、
+pipeline、store、report 和 sanitizer。质量门禁测试用公开 deterministic corpus 固定高危召回、
+高置信误报和脱敏率代理指标。所有测试默认不依赖真实模型、Docker 或 Cube；真实 runtime 成功路径
+通过 fake workspace runtime 覆盖。
+
+## 已知边界
+
+- 当前没有真实 LLM planner/executor 调用。
+- 当前没有 SDK Filter 注册或 SDK CodeExecutor 扩展。
+- `container` / `cube` 真实后端依赖本机 Docker 或 Cube/E2B 配置；默认测试环境使用 fake 或
+  unavailable 分支，不要求外部服务。
+- 规则是启发式 deterministic 检查，目标是可测试原型，不是完整静态分析器。
+- SQLite schema 是 example-local v1，当前不提供 migration 机制。

--- a/examples/skills_code_review_agent/README.md
+++ b/examples/skills_code_review_agent/README.md
@@ -1,0 +1,118 @@
+# Skills 代码评审 Agent
+
+这个示例演示一个 examples 级 deterministic 自动代码评审 Agent：它会规范化代码评审输入，加载本地
+`code-review` Skill 包，执行确定性规则，记录示例内治理和沙箱执行信息，将结果写入 SQLite，并输出
+`review_report.json` 与 `review_report.md`。
+
+该示例不调用真实模型 API，不要求 Docker 或 Cube 环境；默认 `dry-run` 可以在普通开发环境中跑通解析、规则、治理、落库和报告链路。
+
+## 快速运行
+
+运行前先进入示例目录：
+
+```bash
+cd examples/skills_code_review_agent
+python run_review.py --fixture clean
+python run_review.py --fixture secret --output-dir out-secret
+```
+
+也可以从仓库根目录运行测试：
+
+```bash
+python -m pytest examples/skills_code_review_agent/tests -q
+```
+
+## 输入模式
+
+CLI 支持四种互斥输入：
+
+- `--diff-file PATH`：读取 UTF-8 unified diff 或 patch 文件。
+- `--repo-path PATH`：读取 Git 工作区变更，包括 tracked、staged、unstaged 和 untracked 文本文件。
+- `--fixture NAME`：读取 `fixtures/<name>.diff`，也可以传显式 fixture 路径。
+- `--file-list PATH`：读取 UTF-8 文件路径列表，每行一个文件；可读文本文件按 added-file 方式参与评审。
+
+常用参数：
+
+- `--output-dir PATH`：输出目录，默认 `output`。
+- `--db-path PATH`：SQLite 路径；未显式设置时跟随 `--output-dir`，使用 `review.sqlite3`。
+- `--runtime {dry-run,container,cube,local-dev}`：规则执行 runtime，默认 `dry-run`。
+- `--allow-local`：允许无隔离的 `local-dev` runtime。
+- `--timeout-sec SECONDS`：规则执行超时，默认 `30`。
+- `--output-limit-bytes BYTES`：stdout/stderr 单流捕获上限，默认 `65536`。
+- `--container-image IMAGE`：`container` runtime 使用的镜像，默认 `python:3-slim`。
+- `--docker-base-url URL`：可选 Docker daemon 地址，不传时使用 Docker SDK 默认发现逻辑。
+
+## Runtime 策略
+
+- `dry-run`：默认路径，进程内执行规则脚本，不依赖外部服务。
+- `local-dev`：本地 subprocess fallback，没有隔离能力，必须显式传入 `--allow-local`。
+- `container`：通过 SDK Container workspace runtime 执行规则脚本，默认镜像为 `python:3-slim`，默认关闭网络；Docker 不可用时不会崩溃，而是记录为 `needs_human_review`。
+- `cube`：通过 SDK Cube/E2B workspace runtime 执行规则脚本；需要环境变量 `CUBE_TEMPLATE_ID`、`E2B_API_URL`、`E2B_API_KEY`。缺少依赖、配置或后端不可达时记录为 `needs_human_review`。
+
+所有 runtime 执行前都会经过治理策略，覆盖危险命令、禁止路径、网络命令、timeout、output limit 和环境变量白名单。
+Container/Cube 执行时只上传 rule runner 所需的最小 Python bundle 和脱敏输入，不上传完整仓库。
+
+## 输出文件
+
+每次运行会写出以下文件：
+
+- `parsed_input.json`：规范化后的 `InputSummary`，包含文件、hunk、上下文、候选行、诊断和 diff 摘要。
+- `skill_manifest.json`：本地 Skill manifest，包含规则文档、脚本路径和 digest。
+- `rule_result.json`：规则脚本输出的结构化 findings 和 diagnostics。
+- `findings.json`：规则 findings 的独立切分结果。
+- `filter_events.json`：示例内治理决策。
+- `sandbox_runs.json`：沙箱或 dry-run 执行状态、耗时、退出码、stdout/stderr 和截断标记。
+- `review_report.json`：最终结构化报告。
+- `review_report.md`：人工可读 Markdown 报告。
+- `review.sqlite3`：SQLite 数据库，保存 task、input summary、finding、filter event、sandbox run、metrics 和 report。
+
+`sample_outputs/review_report.json` 和 `sample_outputs/review_report.md` 是基于 `secret` fixture 整理的脱敏样例输出，路径相对于本示例目录。
+
+## SQLite 查询示例
+
+```bash
+sqlite3 output/review.sqlite3 \
+  "select id, status, summary from review_task order by created_at desc limit 1;"
+sqlite3 output/review.sqlite3 \
+  "select route, severity, category, file, line, title from finding;"
+sqlite3 output/review.sqlite3 \
+  "select runtime, status, exit_code, error_type from sandbox_run;"
+sqlite3 output/review.sqlite3 \
+  "select finding_count, warning_count, needs_human_review_count from review_metrics;"
+sqlite3 output/review.sqlite3 \
+  "select json_path, md_path from report;"
+```
+
+`agent/store.py` 默认使用 SQLite，同时暴露最小 store protocol 和 factory 注入点；因此示例 CLI 不变，
+但 pipeline 可以替换为其他 SQL 后端实现。
+
+## 公开 Fixture
+
+示例包含 8 条公开 diff 样本：
+
+| Fixture | 覆盖内容 |
+| --- | --- |
+| `clean` | 源码和测试同步变更，无 findings、无 warnings |
+| `security` | 动态执行和 `shell=True` 安全风险 |
+| `async_leak` | async client 生命周期未闭合 |
+| `db_lifecycle` | 数据库连接生命周期未闭合 |
+| `missing_tests` | 低置信度缺测试 warning |
+| `duplicate` | fingerprint 去重 |
+| `sandbox_failure` | sandbox timeout / failure 转人工复核 |
+| `secret` | secret finding 和报告/数据库脱敏 |
+
+这些 fixture 会在示例业务测试中端到端运行，覆盖解析、规则、沙箱、落库和报告链路。
+
+## 质量门禁
+
+示例测试中维护了一组公开 deterministic 质量门禁，用于防止规则和脱敏能力回退：
+
+- 高危问题召回代理指标不低于 `80%`。
+- 高置信误报代理指标不高于 `15%`。
+- 常见 API Key、token、password、private key、连接串密码脱敏命中率不低于 `95%`。
+
+这些指标是示例内公开样本的回归代理，不等同于对外部隐藏样本的完整质量保证。
+
+## 设计文档
+
+更详细的架构、数据流、安全边界、持久化和测试策略见 `DESIGN.md`。

--- a/examples/skills_code_review_agent/README.md
+++ b/examples/skills_code_review_agent/README.md
@@ -35,6 +35,7 @@ CLI 支持四种互斥输入：
 
 - `--output-dir PATH`：输出目录，默认 `output`。
 - `--db-path PATH`：SQLite 路径；未显式设置时跟随 `--output-dir`，使用 `review.sqlite3`。
+- `--dry-run`：显式选择默认的进程内 dry-run runtime；不能与其他 runtime 同时使用。
 - `--runtime {dry-run,container,cube,local-dev}`：规则执行 runtime，默认 `dry-run`。
 - `--allow-local`：允许无隔离的 `local-dev` runtime。
 - `--timeout-sec SECONDS`：规则执行超时，默认 `30`。
@@ -44,7 +45,7 @@ CLI 支持四种互斥输入：
 
 ## Runtime 策略
 
-- `dry-run`：默认路径，进程内执行规则脚本，不依赖外部服务。
+- `dry-run`：默认路径，进程内执行规则脚本，不依赖外部服务；`--dry-run` 可显式确认该选择。
 - `local-dev`：本地 subprocess fallback，没有隔离能力，必须显式传入 `--allow-local`。
 - `container`：通过 SDK Container workspace runtime 执行规则脚本，默认镜像为 `python:3-slim`，默认关闭网络；Docker 不可用时不会崩溃，而是记录为 `needs_human_review`。
 - `cube`：通过 SDK Cube/E2B workspace runtime 执行规则脚本；需要环境变量 `CUBE_TEMPLATE_ID`、`E2B_API_URL`、`E2B_API_KEY`。缺少依赖、配置或后端不可达时记录为 `needs_human_review`。
@@ -66,7 +67,9 @@ Container/Cube 执行时只上传 rule runner 所需的最小 Python bundle 和�
 - `review_report.md`：人工可读 Markdown 报告。
 - `review.sqlite3`：SQLite 数据库，保存 task、input summary、finding、filter event、sandbox run、metrics 和 report。
 
-`sample_outputs/review_report.json` 和 `sample_outputs/review_report.md` 是基于 `secret` fixture 整理的脱敏样例输出，路径相对于本示例目录。
+`sample_outputs/review_report.json` 和 `sample_outputs/review_report.md` 是通过真实 pipeline
+运行 `secret` fixture 后规范化动态 task id、时间、耗时和本机路径得到的脱敏样例输出。
+其中 finding evidence 和 fingerprint 来自实际规则逻辑，路径相对于本示例目录。
 
 ## SQLite 查询示例
 

--- a/examples/skills_code_review_agent/agent/__init__.py
+++ b/examples/skills_code_review_agent/agent/__init__.py
@@ -1,0 +1,102 @@
+# Tencent is pleased to support the open source community by making tRPC-Agent-Python available.
+#
+# Copyright (C) 2026 Tencent. All rights reserved.
+#
+# tRPC-Agent-Python is licensed under Apache-2.0.
+"""Public contracts for the skills code review agent example."""
+
+from .input_parser import InputParseError
+from .input_parser import parse_diff_file
+from .input_parser import parse_file_list
+from .input_parser import parse_fixture
+from .input_parser import parse_repo_path
+from .input_parser import parse_unified_diff
+from .governance import ExecutionRequest
+from .governance import evaluate_execution_request
+from .models import ChangedFile
+from .models import ChangedLine
+from .models import DiffHunk
+from .models import FilterDecision
+from .models import FilterEvent
+from .models import FilterReasonCode
+from .models import FilterTargetType
+from .models import Finding
+from .models import FindingCategory
+from .models import FindingSeverity
+from .models import FindingSource
+from .models import InputSummary
+from .models import InputType
+from .models import ReviewMetrics
+from .models import ReviewReport
+from .models import ReviewTask
+from .models import RuntimeKind
+from .models import SandboxRun
+from .models import SandboxStatus
+from .models import TaskStatus
+from .pipeline import ReviewPipelineConfig
+from .pipeline import ReviewPipelineResult
+from .pipeline import run_review_pipeline
+from .report import build_review_report
+from .report import dedupe_findings
+from .report import route_findings
+from .report import write_review_report
+from .review_rules import run_review_rules
+from .sandbox import run_rule_script
+from .sanitizer import redact_mapping
+from .sanitizer import redact_text
+from .skill_loader import LoadedSkill
+from .skill_loader import SkillLoadError
+from .skill_loader import SkillManifest
+from .skill_loader import load_skill
+from .store import ReviewStore
+from .store import ReviewStoreFactory
+from .store import ReviewStoreProtocol
+
+__all__ = [
+    "ChangedFile",
+    "ChangedLine",
+    "DiffHunk",
+    "ExecutionRequest",
+    "FilterDecision",
+    "FilterEvent",
+    "FilterReasonCode",
+    "FilterTargetType",
+    "Finding",
+    "FindingCategory",
+    "FindingSeverity",
+    "FindingSource",
+    "InputParseError",
+    "InputSummary",
+    "InputType",
+    "LoadedSkill",
+    "ReviewMetrics",
+    "ReviewPipelineConfig",
+    "ReviewPipelineResult",
+    "ReviewReport",
+    "ReviewStore",
+    "ReviewStoreFactory",
+    "ReviewStoreProtocol",
+    "ReviewTask",
+    "RuntimeKind",
+    "SandboxRun",
+    "SandboxStatus",
+    "SkillLoadError",
+    "SkillManifest",
+    "TaskStatus",
+    "build_review_report",
+    "dedupe_findings",
+    "evaluate_execution_request",
+    "load_skill",
+    "parse_diff_file",
+    "parse_file_list",
+    "parse_fixture",
+    "parse_repo_path",
+    "parse_unified_diff",
+    "redact_mapping",
+    "redact_text",
+    "route_findings",
+    "run_review_rules",
+    "run_review_pipeline",
+    "run_rule_script",
+    "write_review_report",
+]

--- a/examples/skills_code_review_agent/agent/governance.py
+++ b/examples/skills_code_review_agent/agent/governance.py
@@ -7,6 +7,7 @@
 
 from __future__ import annotations
 
+import re
 import shlex
 from dataclasses import dataclass
 from dataclasses import field
@@ -24,18 +25,10 @@ from .sanitizer import redact_text
 MAX_TIMEOUT_SEC = 120.0
 MAX_OUTPUT_LIMIT_BYTES = 1024 * 1024
 DEFAULT_ALLOWED_ENV_KEYS = ("LANG", "LC_ALL", "PATH", "PYTHONPATH")
-_DANGEROUS_COMMAND_FRAGMENTS = (
-    "rm -rf",
-    "sudo ",
-    "chmod -R",
-    "chown -R",
-    "mkfs",
-    "dd if=",
-    "> /etc/",
-    "> /usr/",
-    "> /var/",
-)
 _NETWORK_COMMANDS = ("curl", "wget", "nc", "ncat", "telnet", "ssh", "scp")
+_SHELL_EXECUTABLES = {"sh", "bash"}
+_SHELL_PAYLOAD_FLAGS = {"-c", "-lc"}
+_SENSITIVE_REDIRECT_ROOTS = ("/etc/", "/usr/", "/var/")
 
 
 @dataclass(frozen=True)
@@ -51,6 +44,7 @@ class ExecutionRequest:
     network_allowed: bool = False
     script_path: str = ""
     allowed_roots: tuple[str, ...] = field(default_factory=tuple)
+    referenced_paths: tuple[str, ...] = field(default_factory=tuple)
     env: dict[str, str] = field(default_factory=dict)
     allowed_env_keys: tuple[str, ...] = DEFAULT_ALLOWED_ENV_KEYS
     metadata: dict[str, Any] = field(default_factory=dict)
@@ -121,7 +115,7 @@ def evaluate_execution_request(task_id: str, request: ExecutionRequest) -> Filte
             reason_code=FilterReasonCode.NETWORK_DENIED,
             target_type=FilterTargetType.NETWORK,
         )
-    if _is_dangerous_command(command_text):
+    if _is_dangerous_command(request.command):
         return _event(
             **base,
             decision=FilterDecision.DENY,
@@ -174,15 +168,19 @@ def _event(
 def _paths_are_allowed(request: ExecutionRequest) -> bool:
     if not request.allowed_roots:
         return True
-    roots = [Path(root).expanduser().resolve() for root in request.allowed_roots]
-    paths = [Path(request.cwd).expanduser()]
+    roots = [_resolve_governance_path(root) for root in request.allowed_roots]
+    paths = [_resolve_governance_path(request.cwd)]
     if request.script_path:
-        paths.append(Path(request.script_path).expanduser())
-    for path in paths:
-        resolved = path.resolve()
+        paths.append(_resolve_governance_path(request.script_path))
+    paths.extend(_resolve_governance_path(path) for path in request.referenced_paths if path)
+    for resolved in paths:
         if not any(_is_relative_to(resolved, root) for root in roots):
             return False
     return True
+
+
+def _resolve_governance_path(path: str) -> Path:
+    return Path(path).expanduser().resolve(strict=False)
 
 
 def _is_relative_to(path: Path, root: Path) -> bool:
@@ -194,7 +192,13 @@ def _is_relative_to(path: Path, root: Path) -> bool:
 
 
 def _uses_network(command: list[str]) -> bool:
-    return any(Path(part).name in _NETWORK_COMMANDS for part in command)
+    analysis = _analyze_command(command)
+    if analysis.executable in _NETWORK_COMMANDS:
+        return True
+    for payload in analysis.shell_payloads:
+        if _payload_invokes_known_command(payload, _NETWORK_COMMANDS):
+            return True
+    return False
 
 
 def _disallowed_env_keys(request: ExecutionRequest) -> list[str]:
@@ -202,10 +206,81 @@ def _disallowed_env_keys(request: ExecutionRequest) -> list[str]:
     return sorted(key for key in request.env if key.upper() not in allowed)
 
 
-def _is_dangerous_command(command_text: str) -> bool:
-    lowered = command_text.lower()
-    return any(fragment.lower() in lowered for fragment in _DANGEROUS_COMMAND_FRAGMENTS)
+def _is_dangerous_command(command: list[str]) -> bool:
+    analysis = _analyze_command(command)
+    argv = analysis.argv
+    if _argv_is_dangerous(argv):
+        return True
+    return any(_payload_is_dangerous(payload) for payload in analysis.shell_payloads)
 
 
 def _command_text(command: list[str]) -> str:
     return shlex.join(command)
+
+
+@dataclass(frozen=True)
+class _CommandAnalysis:
+    argv: tuple[str, ...]
+    executable: str
+    shell_payloads: tuple[str, ...] = ()
+
+
+def _analyze_command(command: list[str]) -> _CommandAnalysis:
+    argv = tuple(command)
+    executable = Path(argv[0]).name.lower() if argv else ""
+    shell_payloads: list[str] = []
+    if executable in _SHELL_EXECUTABLES:
+        for index, part in enumerate(argv[:-1]):
+            if part in _SHELL_PAYLOAD_FLAGS:
+                shell_payloads.append(argv[index + 1])
+    return _CommandAnalysis(argv=argv, executable=executable, shell_payloads=tuple(shell_payloads))
+
+
+def _argv_is_dangerous(argv: tuple[str, ...]) -> bool:
+    if not argv:
+        return False
+    executable = Path(argv[0]).name.lower()
+    arguments = [item.lower() for item in argv[1:]]
+    flags = {item for item in arguments if item.startswith("-")}
+    if executable == "rm" and ({"-rf", "-fr"} & flags or {"--recursive", "--force"} <= flags):
+        return True
+    if executable == "chmod" and ("-R" in argv[1:] or "-r" in flags or "--recursive" in flags):
+        return True
+    if executable == "chown" and ("-R" in argv[1:] or "-r" in flags or "--recursive" in flags):
+        return True
+    if executable == "mkfs":
+        return True
+    if executable == "dd" and any(item.startswith("if=") for item in arguments):
+        return True
+    return False
+
+
+def _payload_invokes_known_command(payload: str, known_commands: tuple[str, ...]) -> bool:
+    lowered = payload.lower()
+    for command_name in known_commands:
+        pattern = rf"(^|[;&|][&|]?\s*){re.escape(command_name)}(\s|$)"
+        if re.search(pattern, lowered):
+            return True
+    return False
+
+
+def _payload_is_dangerous(payload: str) -> bool:
+    lowered = payload.lower()
+    for root in _SENSITIVE_REDIRECT_ROOTS:
+        trimmed_root = root.rstrip("/")
+        redirect_markers = (f"> {root}", f">> {root}", f"> {trimmed_root}", f">> {trimmed_root}")
+        if any(marker in lowered for marker in redirect_markers):
+            return True
+    if re.search(r"(^|[;&|][&|]?\s*)mkfs(\s|$)", lowered):
+        return True
+    if re.search(r"(^|[;&|][&|]?\s*)dd\s+[^;&|]*\bif=", lowered):
+        return True
+    if re.search(r"(^|[;&|][&|]?\s*)rm\s+[^;&|]*(?:-rf|-fr)\b", lowered):
+        return True
+    if re.search(r"(^|[;&|][&|]?\s*)rm\s+[^;&|]*--recursive\b[^;&|]*--force\b", lowered):
+        return True
+    if re.search(r"(^|[;&|][&|]?\s*)chmod\s+[^;&|]*(?:-r\b|--recursive\b)", lowered):
+        return True
+    if re.search(r"(^|[;&|][&|]?\s*)chown\s+[^;&|]*(?:-r\b|--recursive\b)", lowered):
+        return True
+    return False

--- a/examples/skills_code_review_agent/agent/governance.py
+++ b/examples/skills_code_review_agent/agent/governance.py
@@ -241,17 +241,36 @@ def _argv_is_dangerous(argv: tuple[str, ...]) -> bool:
         return False
     executable = Path(argv[0]).name.lower()
     arguments = [item.lower() for item in argv[1:]]
-    flags = {item for item in arguments if item.startswith("-")}
-    if executable == "rm" and ({"-rf", "-fr"} & flags or {"--recursive", "--force"} <= flags):
+    if executable == "rm" and _rm_is_recursive_force(arguments):
         return True
-    if executable == "chmod" and ("-R" in argv[1:] or "-r" in flags or "--recursive" in flags):
+    if executable == "chmod" and _has_recursive_flag(arguments):
         return True
-    if executable == "chown" and ("-R" in argv[1:] or "-r" in flags or "--recursive" in flags):
+    if executable == "chown" and _has_recursive_flag(arguments):
         return True
     if executable == "mkfs":
         return True
     if executable == "dd" and any(item.startswith("if=") for item in arguments):
         return True
+    return False
+
+
+def _rm_is_recursive_force(arguments: list[str]) -> bool:
+    long_flags = {item for item in arguments if item.startswith("--")}
+    if {"--recursive", "--force"} <= long_flags:
+        return True
+    short_flags: set[str] = set()
+    for item in arguments:
+        if item.startswith("-") and not item.startswith("--"):
+            short_flags.update(item[1:])
+    return "r" in short_flags and "f" in short_flags
+
+
+def _has_recursive_flag(arguments: list[str]) -> bool:
+    for item in arguments:
+        if item == "--recursive":
+            return True
+        if item.startswith("-") and not item.startswith("--") and "r" in item[1:]:
+            return True
     return False
 
 
@@ -271,13 +290,16 @@ def _payload_is_dangerous(payload: str) -> bool:
         redirect_markers = (f"> {root}", f">> {root}", f"> {trimmed_root}", f">> {trimmed_root}")
         if any(marker in lowered for marker in redirect_markers):
             return True
+    for command in re.split(r"[;&|]+", payload):
+        try:
+            argv = tuple(shlex.split(command))
+        except ValueError:
+            argv = tuple(command.split())
+        if _argv_is_dangerous(argv):
+            return True
     if re.search(r"(^|[;&|][&|]?\s*)mkfs(\s|$)", lowered):
         return True
     if re.search(r"(^|[;&|][&|]?\s*)dd\s+[^;&|]*\bif=", lowered):
-        return True
-    if re.search(r"(^|[;&|][&|]?\s*)rm\s+[^;&|]*(?:-rf|-fr)\b", lowered):
-        return True
-    if re.search(r"(^|[;&|][&|]?\s*)rm\s+[^;&|]*--recursive\b[^;&|]*--force\b", lowered):
         return True
     if re.search(r"(^|[;&|][&|]?\s*)chmod\s+[^;&|]*(?:-r\b|--recursive\b)", lowered):
         return True

--- a/examples/skills_code_review_agent/agent/governance.py
+++ b/examples/skills_code_review_agent/agent/governance.py
@@ -28,7 +28,10 @@ DEFAULT_ALLOWED_ENV_KEYS = ("LANG", "LC_ALL", "PATH", "PYTHONPATH")
 _NETWORK_COMMANDS = ("curl", "wget", "nc", "ncat", "telnet", "ssh", "scp")
 _SHELL_EXECUTABLES = {"sh", "bash"}
 _SHELL_PAYLOAD_FLAGS = {"-c", "-lc"}
-_SENSITIVE_REDIRECT_ROOTS = ("/etc/", "/usr/", "/var/")
+_SENSITIVE_PATH_ROOTS = ("/etc", "/usr", "/var", "/dev")
+_WRITE_COMMANDS = {"tee", "cp", "mv", "install"}
+_SENSITIVE_REDIRECT_RE = re.compile(r"(?i)(?:^|[\s;&|\n])(?:\d+)?\s*>{1,2}\s*/\s*(?:etc|usr|var|dev)(?:/|\b)")
+_UNSUPPORTED_SHELL_RE = re.compile(r"(?:\$\(|`)")
 
 
 @dataclass(frozen=True)
@@ -249,7 +252,10 @@ def _argv_is_dangerous(argv: tuple[str, ...]) -> bool:
         return True
     if executable == "mkfs":
         return True
-    if executable == "dd" and any(item.startswith("if=") for item in arguments):
+    if executable == "dd" and any(
+            item.startswith(("if=", "of=")) and _is_sensitive_path(item.split("=", 1)[1]) for item in arguments):
+        return True
+    if executable in _WRITE_COMMANDS and _argv_writes_sensitive_path(arguments):
         return True
     return False
 
@@ -277,32 +283,34 @@ def _has_recursive_flag(arguments: list[str]) -> bool:
 def _payload_invokes_known_command(payload: str, known_commands: tuple[str, ...]) -> bool:
     lowered = payload.lower()
     for command_name in known_commands:
-        pattern = rf"(^|[;&|][&|]?\s*){re.escape(command_name)}(\s|$)"
+        pattern = rf"(^|[;&|\n][&|]?\s*){re.escape(command_name)}(\s|$)"
         if re.search(pattern, lowered):
             return True
     return False
 
 
 def _payload_is_dangerous(payload: str) -> bool:
-    lowered = payload.lower()
-    for root in _SENSITIVE_REDIRECT_ROOTS:
-        trimmed_root = root.rstrip("/")
-        redirect_markers = (f"> {root}", f">> {root}", f"> {trimmed_root}", f">> {trimmed_root}")
-        if any(marker in lowered for marker in redirect_markers):
-            return True
-    for command in re.split(r"[;&|]+", payload):
+    if _UNSUPPORTED_SHELL_RE.search(payload):
+        return True
+    if _SENSITIVE_REDIRECT_RE.search(payload):
+        return True
+    for command in re.split(r"[;&|\n]+", payload):
         try:
             argv = tuple(shlex.split(command))
         except ValueError:
             argv = tuple(command.split())
         if _argv_is_dangerous(argv):
             return True
-    if re.search(r"(^|[;&|][&|]?\s*)mkfs(\s|$)", lowered):
-        return True
-    if re.search(r"(^|[;&|][&|]?\s*)dd\s+[^;&|]*\bif=", lowered):
-        return True
-    if re.search(r"(^|[;&|][&|]?\s*)chmod\s+[^;&|]*(?:-r\b|--recursive\b)", lowered):
-        return True
-    if re.search(r"(^|[;&|][&|]?\s*)chown\s+[^;&|]*(?:-r\b|--recursive\b)", lowered):
-        return True
     return False
+
+
+def _argv_writes_sensitive_path(arguments: list[str]) -> bool:
+    return any(not item.startswith("-") and _is_sensitive_path(item) for item in arguments)
+
+
+def _is_sensitive_path(value: str) -> bool:
+    normalized = value.replace("\\", "/")
+    if not normalized.startswith("/"):
+        return False
+    normalized = "/" + normalized.lstrip("/")
+    return any(normalized == root or normalized.startswith(f"{root}/") for root in _SENSITIVE_PATH_ROOTS)

--- a/examples/skills_code_review_agent/agent/governance.py
+++ b/examples/skills_code_review_agent/agent/governance.py
@@ -1,0 +1,211 @@
+# Tencent is pleased to support the open source community by making tRPC-Agent-Python available.
+#
+# Copyright (C) 2026 Tencent. All rights reserved.
+#
+# tRPC-Agent-Python is licensed under Apache-2.0.
+"""Example-local execution governance for rule and sandbox commands."""
+
+from __future__ import annotations
+
+import shlex
+from dataclasses import dataclass
+from dataclasses import field
+from pathlib import Path
+from typing import Any
+
+from .models import FilterDecision
+from .models import FilterEvent
+from .models import FilterReasonCode
+from .models import FilterTargetType
+from .models import RuntimeKind
+from .sanitizer import redact_mapping
+from .sanitizer import redact_text
+
+MAX_TIMEOUT_SEC = 120.0
+MAX_OUTPUT_LIMIT_BYTES = 1024 * 1024
+DEFAULT_ALLOWED_ENV_KEYS = ("LANG", "LC_ALL", "PATH", "PYTHONPATH")
+_DANGEROUS_COMMAND_FRAGMENTS = (
+    "rm -rf",
+    "sudo ",
+    "chmod -R",
+    "chown -R",
+    "mkfs",
+    "dd if=",
+    "> /etc/",
+    "> /usr/",
+    "> /var/",
+)
+_NETWORK_COMMANDS = ("curl", "wget", "nc", "ncat", "telnet", "ssh", "scp")
+
+
+@dataclass(frozen=True)
+class ExecutionRequest:
+    """A proposed command execution reviewed by the example governance policy."""
+
+    command: list[str]
+    runtime: RuntimeKind
+    cwd: str
+    timeout_sec: float = 30.0
+    output_limit_bytes: int = 65536
+    allow_local: bool = False
+    network_allowed: bool = False
+    script_path: str = ""
+    allowed_roots: tuple[str, ...] = field(default_factory=tuple)
+    env: dict[str, str] = field(default_factory=dict)
+    allowed_env_keys: tuple[str, ...] = DEFAULT_ALLOWED_ENV_KEYS
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+def evaluate_execution_request(task_id: str, request: ExecutionRequest) -> FilterEvent:
+    """Evaluate whether a proposed execution may continue."""
+    command_text = _command_text(request.command)
+    base = {
+        "task_id": task_id,
+        "target": redact_text(command_text),
+        "command": redact_text(command_text),
+        "runtime": request.runtime,
+        "cwd": str(Path(request.cwd).expanduser()),
+        "script_path": request.script_path,
+        "timeout_sec": request.timeout_sec,
+        "output_limit_bytes": request.output_limit_bytes,
+        "metadata": redact_mapping({
+            **request.metadata, "env": request.env
+        } if request.env else request.metadata),
+    }
+    if request.runtime is RuntimeKind.LOCAL_DEV and not request.allow_local:
+        return _event(
+            **base,
+            decision=FilterDecision.DENY,
+            reason="local-dev runtime requires explicit --allow-local",
+            reason_code=FilterReasonCode.LOCAL_RUNTIME_DENIED,
+            target_type=FilterTargetType.RUNTIME,
+        )
+    if request.timeout_sec <= 0 or request.timeout_sec > MAX_TIMEOUT_SEC:
+        return _event(
+            **base,
+            decision=FilterDecision.DENY,
+            reason=f"timeout must be between 0 and {MAX_TIMEOUT_SEC:g} seconds",
+            reason_code=FilterReasonCode.BUDGET_EXCEEDED,
+            target_type=FilterTargetType.BUDGET,
+        )
+    if request.output_limit_bytes <= 0 or request.output_limit_bytes > MAX_OUTPUT_LIMIT_BYTES:
+        return _event(
+            **base,
+            decision=FilterDecision.DENY,
+            reason=f"output limit must be between 1 and {MAX_OUTPUT_LIMIT_BYTES} bytes",
+            reason_code=FilterReasonCode.OUTPUT_LIMIT_EXCEEDED,
+            target_type=FilterTargetType.BUDGET,
+        )
+    if not _paths_are_allowed(request):
+        return _event(
+            **base,
+            decision=FilterDecision.DENY,
+            reason="execution path escapes the allowed example workspace",
+            reason_code=FilterReasonCode.FORBIDDEN_PATH,
+            target_type=FilterTargetType.PATH,
+        )
+    disallowed_env = _disallowed_env_keys(request)
+    if disallowed_env:
+        return _event(
+            **base,
+            decision=FilterDecision.DENY,
+            reason=f"environment variable is not allowed: {disallowed_env[0]}",
+            reason_code=FilterReasonCode.ENV_NOT_ALLOWED,
+            target_type=FilterTargetType.ENV,
+        )
+    if _uses_network(request.command) and not request.network_allowed:
+        return _event(
+            **base,
+            decision=FilterDecision.NEEDS_HUMAN_REVIEW,
+            reason="network-capable command requires human review",
+            reason_code=FilterReasonCode.NETWORK_DENIED,
+            target_type=FilterTargetType.NETWORK,
+        )
+    if _is_dangerous_command(command_text):
+        return _event(
+            **base,
+            decision=FilterDecision.DENY,
+            reason="high-risk command is not allowed by the example policy",
+            reason_code=FilterReasonCode.HIGH_RISK_COMMAND,
+            target_type=FilterTargetType.COMMAND,
+        )
+    return _event(
+        **base,
+        decision=FilterDecision.ALLOW,
+        reason="execution request allowed by example policy",
+        reason_code=FilterReasonCode.UNKNOWN,
+        target_type=FilterTargetType.COMMAND,
+    )
+
+
+def _event(
+    *,
+    task_id: str,
+    decision: FilterDecision,
+    reason: str,
+    reason_code: FilterReasonCode,
+    target_type: FilterTargetType,
+    target: str,
+    command: str,
+    runtime: RuntimeKind,
+    cwd: str,
+    script_path: str,
+    timeout_sec: float,
+    output_limit_bytes: int,
+    metadata: dict[str, Any],
+) -> FilterEvent:
+    return FilterEvent(
+        task_id=task_id,
+        decision=decision,
+        reason=redact_text(reason),
+        reason_code=reason_code,
+        target_type=target_type,
+        target=target,
+        command=command,
+        runtime=runtime,
+        cwd=cwd,
+        script_path=script_path,
+        timeout_sec=timeout_sec,
+        output_limit_bytes=output_limit_bytes,
+        metadata=metadata,
+    )
+
+
+def _paths_are_allowed(request: ExecutionRequest) -> bool:
+    if not request.allowed_roots:
+        return True
+    roots = [Path(root).expanduser().resolve() for root in request.allowed_roots]
+    paths = [Path(request.cwd).expanduser()]
+    if request.script_path:
+        paths.append(Path(request.script_path).expanduser())
+    for path in paths:
+        resolved = path.resolve()
+        if not any(_is_relative_to(resolved, root) for root in roots):
+            return False
+    return True
+
+
+def _is_relative_to(path: Path, root: Path) -> bool:
+    try:
+        path.relative_to(root)
+    except ValueError:
+        return False
+    return True
+
+
+def _uses_network(command: list[str]) -> bool:
+    return any(Path(part).name in _NETWORK_COMMANDS for part in command)
+
+
+def _disallowed_env_keys(request: ExecutionRequest) -> list[str]:
+    allowed = {key.upper() for key in request.allowed_env_keys}
+    return sorted(key for key in request.env if key.upper() not in allowed)
+
+
+def _is_dangerous_command(command_text: str) -> bool:
+    lowered = command_text.lower()
+    return any(fragment.lower() in lowered for fragment in _DANGEROUS_COMMAND_FRAGMENTS)
+
+
+def _command_text(command: list[str]) -> str:
+    return shlex.join(command)

--- a/examples/skills_code_review_agent/agent/input_parser.py
+++ b/examples/skills_code_review_agent/agent/input_parser.py
@@ -1,0 +1,451 @@
+# Tencent is pleased to support the open source community by making tRPC-Agent-Python available.
+#
+# Copyright (C) 2026 Tencent. All rights reserved.
+#
+# tRPC-Agent-Python is licensed under Apache-2.0.
+"""Normalize diff files, fixtures, and Git worktrees into review input data."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+import subprocess
+from pathlib import Path
+from typing import Iterable
+
+from .models import ChangedFile
+from .models import ChangedLine
+from .models import DiffHunk
+from .models import InputSummary
+from .models import InputType
+
+_DIFF_HEADER = re.compile(r"^diff --git a/(.*?) b/(.*?)$")
+_HUNK_HEADER = re.compile(r"^@@ -(?P<old_start>\d+)(?:,(?P<old_count>\d+))? "
+                          r"\+(?P<new_start>\d+)(?:,(?P<new_count>\d+))? @@(?P<section>.*)$")
+_QUOTED_PATH = re.compile(r'^"(.*)"$')
+_GIT_TIMEOUT_SECONDS = 15.0
+
+
+class InputParseError(ValueError):
+    """Raised when an input source cannot be normalized."""
+
+
+def parse_unified_diff(
+    diff_text: str,
+    *,
+    task_id: str = "",
+    input_type: InputType = InputType.DIFF_FILE,
+    input_ref: str = "<diff>",
+) -> InputSummary:
+    """Parse a unified diff while retaining hunk and line-number semantics.
+
+    The parser is deliberately tolerant at file boundaries. A malformed hunk
+    produces a diagnostic and does not discard files and hunks parsed before
+    it, which is useful when a patch contains a binary section or truncated
+    output.
+    """
+    normalized = diff_text.replace("\r\n", "\n").replace("\r", "\n")
+    changed_files: list[ChangedFile] = []
+    diagnostics: list[str] = []
+    current: ChangedFile | None = None
+    current_hunk: DiffHunk | None = None
+    old_line = 0
+    new_line = 0
+
+    def finish_file() -> None:
+        nonlocal current, current_hunk
+        if current is not None:
+            current.candidate_lines = sorted(set(current.candidate_lines))
+            changed_files.append(current)
+        current = None
+        current_hunk = None
+
+    for raw_line in normalized.splitlines():
+        header = _DIFF_HEADER.match(raw_line)
+        if header:
+            finish_file()
+            old_path, new_path = header.groups()
+            current = ChangedFile(path=_unquote_path(new_path), old_path=_unquote_path(old_path))
+            continue
+
+        if current is None:
+            if raw_line.strip():
+                diagnostics.append("input contains content before a diff file header")
+            continue
+
+        if raw_line.startswith("new file mode "):
+            current.status = "added"
+            continue
+        if raw_line.startswith("deleted file mode "):
+            current.status = "deleted"
+            continue
+        if raw_line.startswith("rename from "):
+            current.old_path = _unquote_path(raw_line[len("rename from "):])
+            current.status = "renamed"
+            continue
+        if raw_line.startswith("rename to "):
+            current.path = _unquote_path(raw_line[len("rename to "):])
+            current.status = "renamed"
+            continue
+        if raw_line.startswith("similarity index ") or raw_line.startswith("index "):
+            continue
+        if raw_line.startswith("Binary files ") or raw_line.startswith("GIT binary patch"):
+            current.is_binary = True
+            diagnostics.append(f"{current.path}: binary patch content is not parsed")
+            current_hunk = None
+            continue
+        if raw_line.startswith("--- "):
+            old_path = _parse_patch_path(raw_line[4:])
+            if old_path and old_path != "/dev/null":
+                current.old_path = old_path
+            continue
+        if raw_line.startswith("+++ "):
+            new_path = _parse_patch_path(raw_line[4:])
+            if new_path and new_path != "/dev/null":
+                current.path = new_path
+            continue
+
+        hunk_match = _HUNK_HEADER.match(raw_line)
+        if hunk_match:
+            current_hunk = DiffHunk(
+                old_start=int(hunk_match.group("old_start")),
+                old_count=int(hunk_match.group("old_count") or "1"),
+                new_start=int(hunk_match.group("new_start")),
+                new_count=int(hunk_match.group("new_count") or "1"),
+                section_header=hunk_match.group("section").strip(),
+            )
+            current.hunks.append(current_hunk)
+            old_line = current_hunk.old_start
+            new_line = current_hunk.new_start
+            continue
+        if raw_line.startswith("@@"):
+            diagnostics.append(f"{current.path}: malformed hunk header: {raw_line}")
+            current_hunk = None
+            continue
+        if current_hunk is None:
+            if raw_line.strip() and not raw_line.startswith("\\ "):
+                diagnostics.append(f"{current.path}: unexpected diff metadata: {raw_line}")
+            continue
+        if raw_line.startswith("\\ No newline at end of file"):
+            diagnostics.append(f"{current.path}: missing newline at end of file")
+            continue
+        if not raw_line:
+            diagnostics.append(f"{current.path}: malformed empty hunk line")
+            continue
+
+        marker = raw_line[0]
+        content = raw_line[1:]
+        if marker == " ":
+            current_hunk.lines.append(ChangedLine("context", content, old_line=old_line, new_line=new_line))
+            old_line += 1
+            new_line += 1
+        elif marker == "+":
+            current_hunk.lines.append(ChangedLine("added", content, new_line=new_line))
+            current.added_lines += 1
+            current.candidate_lines.append(new_line)
+            new_line += 1
+        elif marker == "-":
+            current_hunk.lines.append(ChangedLine("deleted", content, old_line=old_line))
+            current.deleted_lines += 1
+            old_line += 1
+        else:
+            diagnostics.append(f"{current.path}: malformed hunk line: {raw_line}")
+
+    finish_file()
+    if not changed_files and normalized.strip():
+        diagnostics.append("input contains no parseable git diff file headers")
+
+    return _build_summary(
+        task_id=task_id,
+        input_type=input_type,
+        input_ref=input_ref,
+        changed_files=changed_files,
+        raw_text=normalized,
+        diagnostics=_unique(diagnostics),
+    )
+
+
+def parse_diff_file(path: str | Path, *, task_id: str = "") -> InputSummary:
+    """Read a UTF-8 unified diff file and normalize it."""
+    source = Path(path).expanduser()
+    if not source.is_file():
+        raise InputParseError(f"diff file not found: {source}")
+    try:
+        text = source.read_text(encoding="utf-8")
+    except UnicodeDecodeError as ex:
+        raise InputParseError(f"diff file is not UTF-8 text: {source}") from ex
+    return parse_unified_diff(
+        text,
+        task_id=task_id,
+        input_type=InputType.DIFF_FILE,
+        input_ref=str(source.resolve()),
+    )
+
+
+def parse_repo_path(path: str | Path, *, task_id: str = "") -> InputSummary:
+    """Parse tracked, staged, unstaged, and untracked Git worktree changes."""
+    requested = Path(path).expanduser()
+    if not requested.is_dir():
+        raise InputParseError(f"repository path not found: {requested}")
+    root_text = _run_git(requested, ["rev-parse", "--show-toplevel"])
+    root = Path(root_text.strip()).resolve()
+
+    if _has_head(root):
+        tracked_diff = _run_git(root, ["diff", "--binary", "HEAD", "--"])
+    else:
+        staged_diff = _run_git(root, ["diff", "--binary", "--cached", "--"])
+        unstaged_diff = _run_git(root, ["diff", "--binary", "--"])
+        tracked_diff = _merge_diff_texts(staged_diff, unstaged_diff)
+
+    untracked_paths = _untracked_paths(root)
+    untracked_diff, untracked_diagnostics = _build_untracked_diff(root, untracked_paths)
+    combined = _merge_diff_texts(tracked_diff, untracked_diff)
+    summary = parse_unified_diff(
+        combined,
+        task_id=task_id,
+        input_type=InputType.REPO_PATH,
+        input_ref=str(root),
+    )
+    summary.diagnostics.extend(untracked_diagnostics)
+    summary.diagnostics = _unique(summary.diagnostics)
+    summary.warnings = list(summary.diagnostics)
+    if not combined and not untracked_paths:
+        summary.warnings.append("repository has no tracked, staged, or untracked changes")
+    return summary
+
+
+def parse_fixture(name: str | Path, *, task_id: str = "") -> InputSummary:
+    """Parse a named fixture or an explicit fixture path."""
+    source = Path(name).expanduser()
+    if not source.is_file():
+        source = Path(__file__).parents[1] / "fixtures" / f"{name}.diff"
+    if not source.is_file():
+        raise InputParseError(f"fixture not found: {name}")
+    try:
+        text = source.read_text(encoding="utf-8")
+    except UnicodeDecodeError as ex:
+        raise InputParseError(f"fixture is not UTF-8 text: {source}") from ex
+    return parse_unified_diff(
+        text,
+        task_id=task_id,
+        input_type=InputType.FIXTURE,
+        input_ref=str(source.resolve()),
+    )
+
+
+def parse_file_list(path: str | Path, *, task_id: str = "") -> InputSummary:
+    """Parse a UTF-8 file-list input into added-file style review data."""
+    source = Path(path).expanduser()
+    if not source.is_file():
+        raise InputParseError(f"file list not found: {source}")
+    try:
+        list_text = source.read_text(encoding="utf-8")
+    except UnicodeDecodeError as ex:
+        raise InputParseError(f"file list is not UTF-8 text: {source}") from ex
+
+    base_dir = source.parent.resolve()
+    changed_files: list[ChangedFile] = []
+    diagnostics: list[str] = []
+    digest = hashlib.sha256(list_text.encode("utf-8"))
+    for raw_line in list_text.splitlines():
+        entry = raw_line.strip()
+        if not entry or entry.startswith("#"):
+            continue
+        requested = Path(entry).expanduser()
+        file_path = requested if requested.is_absolute() else base_dir / requested
+        try:
+            resolved = file_path.resolve()
+        except OSError as ex:
+            diagnostics.append(f"{entry}: unable to resolve path: {ex}")
+            continue
+        if not resolved.exists():
+            diagnostics.append(f"{entry}: file not found")
+            continue
+        if not resolved.is_file():
+            diagnostics.append(f"{entry}: not a regular file")
+            continue
+        try:
+            content = resolved.read_bytes()
+        except OSError as ex:
+            diagnostics.append(f"{entry}: unable to read file: {ex}")
+            continue
+        digest.update(str(resolved).encode("utf-8"))
+        digest.update(content)
+        if b"\0" in content:
+            diagnostics.append(f"{entry}: binary file content is not parsed")
+            changed_files.append(
+                ChangedFile(path=_relative_file_list_path(resolved, base_dir), status="added", is_binary=True))
+            continue
+        try:
+            text = content.decode("utf-8")
+        except UnicodeDecodeError:
+            diagnostics.append(f"{entry}: file is not UTF-8 text")
+            changed_files.append(
+                ChangedFile(path=_relative_file_list_path(resolved, base_dir), status="added", is_binary=True))
+            continue
+        rel_path = _relative_file_list_path(resolved, base_dir)
+        lines = text.splitlines()
+        hunk = DiffHunk(old_start=0, old_count=0, new_start=1, new_count=len(lines))
+        changed = ChangedFile(path=rel_path, old_path="/dev/null", status="added", hunks=[hunk])
+        for index, line in enumerate(lines, start=1):
+            hunk.lines.append(ChangedLine("added", line, new_line=index))
+            changed.added_lines += 1
+            changed.candidate_lines.append(index)
+        changed.candidate_lines = sorted(set(changed.candidate_lines))
+        changed_files.append(changed)
+
+    return _build_summary(
+        task_id=task_id,
+        input_type=InputType.FILE_LIST,
+        input_ref=str(source.resolve()),
+        changed_files=changed_files,
+        raw_text=digest.hexdigest(),
+        diagnostics=_unique(diagnostics),
+    )
+
+
+def _build_summary(
+    *,
+    task_id: str,
+    input_type: InputType,
+    input_ref: str,
+    changed_files: list[ChangedFile],
+    raw_text: str,
+    diagnostics: list[str],
+) -> InputSummary:
+    hunk_count = sum(len(item.hunks) for item in changed_files)
+    added = sum(item.added_lines for item in changed_files)
+    deleted = sum(item.deleted_lines for item in changed_files)
+    return InputSummary(
+        task_id=task_id,
+        input_type=input_type,
+        input_ref=input_ref,
+        changed_files=changed_files,
+        raw_diff_sha256=hashlib.sha256(raw_text.encode("utf-8")).hexdigest(),
+        file_count=len(changed_files),
+        hunk_count=hunk_count,
+        added_lines=added,
+        deleted_lines=deleted,
+        summary=f"{len(changed_files)} file(s), {hunk_count} hunk(s), {added} added, {deleted} deleted",
+        diagnostics=list(diagnostics),
+        warnings=list(diagnostics),
+    )
+
+
+def _parse_patch_path(value: str) -> str:
+    path = value.split("\t", 1)[0].strip()
+    return _strip_prefix(_unquote_path(path))
+
+
+def _strip_prefix(path: str) -> str:
+    if path.startswith("a/") or path.startswith("b/"):
+        return path[2:]
+    return path
+
+
+def _unquote_path(path: str) -> str:
+    match = _QUOTED_PATH.match(path.strip())
+    return match.group(1) if match else path.strip()
+
+
+def _relative_file_list_path(path: Path, base_dir: Path) -> str:
+    try:
+        return path.relative_to(base_dir).as_posix()
+    except ValueError:
+        return str(path)
+
+
+def _run_git(root: Path, args: list[str]) -> str:
+    try:
+        result = subprocess.run(
+            ["git", *args],
+            cwd=root,
+            check=False,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=_GIT_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired as ex:
+        raise InputParseError(f"git command timed out in {root}: git {' '.join(args)}") from ex
+    except OSError as ex:
+        raise InputParseError(f"unable to execute git in {root}: {ex}") from ex
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip() or "unknown git error"
+        raise InputParseError(f"git command failed in {root}: git {' '.join(args)}: {detail}")
+    return result.stdout
+
+
+def _has_head(root: Path) -> bool:
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--verify", "HEAD"],
+            cwd=root,
+            check=False,
+            capture_output=True,
+            timeout=_GIT_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired as ex:
+        raise InputParseError(f"git HEAD lookup timed out in {root}") from ex
+    except OSError as ex:
+        raise InputParseError(f"unable to execute git in {root}: {ex}") from ex
+    return result.returncode == 0
+
+
+def _untracked_paths(root: Path) -> list[str]:
+    output = _run_git(root, ["status", "--porcelain=v1", "-z", "--untracked-files=all"])
+    paths: list[str] = []
+    records = output.split("\0")
+    for record in records:
+        if len(record) >= 4 and record[:2] == "??":
+            paths.append(record[3:])
+    return paths
+
+
+def _build_untracked_diff(root: Path, paths: Iterable[str]) -> tuple[str, list[str]]:
+    chunks: list[str] = []
+    diagnostics: list[str] = []
+    for rel_path in paths:
+        source = root / rel_path
+        if not source.is_file():
+            diagnostics.append(f"untracked path is not a regular file: {rel_path}")
+            continue
+        try:
+            content = source.read_bytes()
+        except OSError as ex:
+            diagnostics.append(f"unable to read untracked file {rel_path}: {ex}")
+            continue
+        if b"\0" in content:
+            chunks.append(f"diff --git a/{rel_path} b/{rel_path}\n"
+                          f"new file mode 100644\n"
+                          f"Binary files /dev/null and b/{rel_path} differ\n")
+            continue
+        try:
+            text = content.decode("utf-8")
+        except UnicodeDecodeError:
+            chunks.append(f"diff --git a/{rel_path} b/{rel_path}\n"
+                          f"new file mode 100644\n"
+                          f"Binary files /dev/null and b/{rel_path} differ\n")
+            continue
+        content_lines = text.splitlines()
+        chunks.append(f"diff --git a/{rel_path} b/{rel_path}\nnew file mode 100644\n--- /dev/null\n+++ b/{rel_path}\n")
+        if content_lines:
+            chunks.append(f"@@ -0,0 +1,{len(content_lines)} @@\n")
+            chunks.extend(f"+{line}\n" for line in content_lines)
+        else:
+            chunks.append("@@ -0,0 +0 @@\n")
+    return "".join(chunks), diagnostics
+
+
+def _merge_diff_texts(*texts: str) -> str:
+    return "\n".join(text.strip("\n") for text in texts if text.strip())
+
+
+def _unique(values: Iterable[str]) -> list[str]:
+    return list(dict.fromkeys(value for value in values if value))
+
+
+# Compatibility aliases retained for callers of the initial example contract.
+parse_diff_text = parse_unified_diff
+parse_repo = parse_repo_path

--- a/examples/skills_code_review_agent/agent/input_parser.py
+++ b/examples/skills_code_review_agent/agent/input_parser.py
@@ -444,8 +444,3 @@ def _merge_diff_texts(*texts: str) -> str:
 
 def _unique(values: Iterable[str]) -> list[str]:
     return list(dict.fromkeys(value for value in values if value))
-
-
-# Compatibility aliases retained for callers of the initial example contract.
-parse_diff_text = parse_unified_diff
-parse_repo = parse_repo_path

--- a/examples/skills_code_review_agent/agent/models.py
+++ b/examples/skills_code_review_agent/agent/models.py
@@ -1,0 +1,314 @@
+# Tencent is pleased to support the open source community by making tRPC-Agent-Python available.
+#
+# Copyright (C) 2026 Tencent. All rights reserved.
+#
+# tRPC-Agent-Python is licensed under Apache-2.0.
+"""SQLite-friendly data contracts for the skills code review agent example."""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+from dataclasses import dataclass
+from dataclasses import field
+from datetime import datetime
+from datetime import timezone
+from enum import Enum
+from typing import Any
+from uuid import uuid4
+
+
+class InputType(str, Enum):
+    """Supported review input modes."""
+
+    DIFF_FILE = "diff_file"
+    REPO_PATH = "repo_path"
+    FIXTURE = "fixture"
+    FILE_LIST = "file_list"
+
+
+class TaskStatus(str, Enum):
+    """Lifecycle states for a review task."""
+
+    PENDING = "pending"
+    RUNNING = "running"
+    DONE = "done"
+    FAILED = "failed"
+
+
+class RuntimeKind(str, Enum):
+    """Runtime choices for rule and sandbox execution."""
+
+    DRY_RUN = "dry-run"
+    CONTAINER = "container"
+    CUBE = "cube"
+    LOCAL_DEV = "local-dev"
+
+
+class SandboxStatus(str, Enum):
+    """Outcome states for a sandbox command."""
+
+    SUCCESS = "success"
+    TIMEOUT = "timeout"
+    FAILED = "failed"
+    DENIED = "denied"
+    NEEDS_HUMAN_REVIEW = "needs_human_review"
+
+
+class FindingSeverity(str, Enum):
+    """Finding severity levels."""
+
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+    CRITICAL = "critical"
+
+
+class FindingCategory(str, Enum):
+    """Initial review categories covered by the example."""
+
+    SECURITY = "security"
+    ASYNC = "async"
+    RESOURCE = "resource"
+    TEST = "test"
+    SECRET = "secret"
+    DB = "db"
+    GOVERNANCE = "governance"
+    SANDBOX = "sandbox"
+
+
+class FindingSource(str, Enum):
+    """Origin of a finding."""
+
+    RULE = "rule"
+    FAKE_MODEL = "fake_model"
+    SANDBOX = "sandbox"
+    STATIC_CHECK = "static_check"
+    FILTER = "filter"
+
+
+class FilterDecision(str, Enum):
+    """Governance decisions before potentially risky execution."""
+
+    ALLOW = "allow"
+    DENY = "deny"
+    NEEDS_HUMAN_REVIEW = "needs_human_review"
+
+
+class FilterReasonCode(str, Enum):
+    """Machine-readable reason for a governance decision."""
+
+    HIGH_RISK_COMMAND = "high_risk_command"
+    FORBIDDEN_PATH = "forbidden_path"
+    NETWORK_DENIED = "network_denied"
+    BUDGET_EXCEEDED = "budget_exceeded"
+    LOCAL_RUNTIME_DENIED = "local_runtime_denied"
+    ENV_NOT_ALLOWED = "env_not_allowed"
+    OUTPUT_LIMIT_EXCEEDED = "output_limit_exceeded"
+    SANDBOX_UNAVAILABLE = "sandbox_unavailable"
+    UNKNOWN = "unknown"
+
+
+class FilterTargetType(str, Enum):
+    """The reviewed object type for a governance decision."""
+
+    COMMAND = "command"
+    SCRIPT = "script"
+    PATH = "path"
+    NETWORK = "network"
+    RUNTIME = "runtime"
+    BUDGET = "budget"
+    ENV = "env"
+    TOOL = "tool"
+
+
+def new_id(prefix: str) -> str:
+    """Create a compact stable identifier with a human-readable prefix."""
+    clean_prefix = prefix.strip().replace("_", "-")
+    return f"{clean_prefix}-{uuid4().hex}"
+
+
+def utc_now_iso() -> str:
+    """Return the current UTC timestamp in ISO-8601 format."""
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _to_jsonable(value: Any) -> Any:
+    if isinstance(value, Enum):
+        return value.value
+    if isinstance(value, list):
+        return [_to_jsonable(item) for item in value]
+    if isinstance(value, tuple):
+        return [_to_jsonable(item) for item in value]
+    if isinstance(value, dict):
+        return {str(key): _to_jsonable(item) for key, item in value.items()}
+    return value
+
+
+class DictMixin:
+    """Mixin for future JSON, SQLite, and Markdown report rendering."""
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable dictionary representation."""
+        return _to_jsonable(asdict(self))
+
+
+@dataclass
+class ReviewTask(DictMixin):
+    """A single code review task."""
+
+    input_type: InputType
+    input_ref: str
+    id: str = field(default_factory=lambda: new_id("review-task"))
+    status: TaskStatus = TaskStatus.PENDING
+    summary: str = ""
+    created_at: str = field(default_factory=utc_now_iso)
+    finished_at: str | None = None
+
+
+@dataclass
+class ChangedLine(DictMixin):
+    """A changed line inside a unified diff hunk."""
+
+    line_type: str
+    content: str
+    old_line: int | None = None
+    new_line: int | None = None
+
+
+@dataclass
+class DiffHunk(DictMixin):
+    """A unified diff hunk with source and target ranges."""
+
+    old_start: int
+    old_count: int
+    new_start: int
+    new_count: int
+    section_header: str = ""
+    lines: list[ChangedLine] = field(default_factory=list)
+
+
+@dataclass
+class ChangedFile(DictMixin):
+    """A changed file and its parsed hunks."""
+
+    path: str
+    old_path: str = ""
+    status: str = "modified"
+    hunks: list[DiffHunk] = field(default_factory=list)
+    added_lines: int = 0
+    deleted_lines: int = 0
+    candidate_lines: list[int] = field(default_factory=list)
+    is_binary: bool = False
+
+
+@dataclass
+class InputSummary(DictMixin):
+    """SQLite-friendly summary of review input."""
+
+    task_id: str
+    input_type: InputType
+    input_ref: str
+    changed_files: list[ChangedFile] = field(default_factory=list)
+    raw_diff_sha256: str = ""
+    file_count: int = 0
+    hunk_count: int = 0
+    added_lines: int = 0
+    deleted_lines: int = 0
+    summary: str = ""
+    diagnostics: list[str] = field(default_factory=list)
+    parser_version: str = "code-review.input.v1"
+    warnings: list[str] = field(default_factory=list)
+
+
+@dataclass
+class Finding(DictMixin):
+    """A structured code review finding."""
+
+    severity: FindingSeverity
+    category: FindingCategory
+    file: str
+    title: str
+    evidence: str
+    recommendation: str
+    confidence: float
+    source: FindingSource
+    line: int | None = None
+    fingerprint: str | None = None
+
+
+@dataclass
+class FilterEvent(DictMixin):
+    """A governance decision recorded before rule or sandbox execution."""
+
+    task_id: str
+    decision: FilterDecision
+    reason: str
+    target: str
+    id: str = field(default_factory=lambda: new_id("filter-event"))
+    reason_code: FilterReasonCode = FilterReasonCode.UNKNOWN
+    target_type: FilterTargetType = FilterTargetType.COMMAND
+    command: str = ""
+    runtime: RuntimeKind | None = None
+    cwd: str = ""
+    tool_name: str = ""
+    skill_name: str = ""
+    script_path: str = ""
+    path: str = ""
+    network_host: str = ""
+    timeout_sec: float | None = None
+    output_limit_bytes: int | None = None
+    budget_ms: int | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+    created_at: str = field(default_factory=utc_now_iso)
+
+
+@dataclass
+class SandboxRun(DictMixin):
+    """A single sandbox command execution record."""
+
+    task_id: str
+    runtime: RuntimeKind
+    command: str
+    id: str = field(default_factory=lambda: new_id("sandbox-run"))
+    exit_code: int | None = None
+    duration_ms: int = 0
+    stdout: str = ""
+    stderr: str = ""
+    status: SandboxStatus = SandboxStatus.SUCCESS
+    timeout_sec: float | None = None
+    output_limit_bytes: int | None = None
+    stdout_truncated: bool = False
+    stderr_truncated: bool = False
+    error_type: str = ""
+    created_at: str = field(default_factory=utc_now_iso)
+
+
+@dataclass
+class ReviewMetrics(DictMixin):
+    """Operational metrics collected during a review."""
+
+    total_duration_ms: int = 0
+    sandbox_duration_ms: int = 0
+    tool_call_count: int = 0
+    interception_count: int = 0
+    finding_count: int = 0
+    warning_count: int = 0
+    needs_human_review_count: int = 0
+    severity_distribution: dict[str, int] = field(default_factory=dict)
+    category_distribution: dict[str, int] = field(default_factory=dict)
+    exception_distribution: dict[str, int] = field(default_factory=dict)
+
+
+@dataclass
+class ReviewReport(DictMixin):
+    """Final machine-readable review report contract."""
+
+    task_id: str
+    findings: list[Finding] = field(default_factory=list)
+    warnings: list[Finding] = field(default_factory=list)
+    needs_human_review: list[Finding] = field(default_factory=list)
+    stats: dict[str, Any] = field(default_factory=dict)
+    metrics: ReviewMetrics = field(default_factory=ReviewMetrics)
+    interceptions: list[FilterEvent] = field(default_factory=list)
+    sandbox_runs: list[SandboxRun] = field(default_factory=list)
+    conclusion: str = ""

--- a/examples/skills_code_review_agent/agent/pipeline.py
+++ b/examples/skills_code_review_agent/agent/pipeline.py
@@ -1,0 +1,215 @@
+# Tencent is pleased to support the open source community by making tRPC-Agent-Python available.
+#
+# Copyright (C) 2026 Tencent. All rights reserved.
+#
+# tRPC-Agent-Python is licensed under Apache-2.0.
+"""End-to-end pipeline for the code-review example."""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import time
+from dataclasses import dataclass
+from dataclasses import field
+from pathlib import Path
+from typing import Any
+
+from .input_parser import parse_diff_file
+from .input_parser import parse_file_list
+from .input_parser import parse_fixture
+from .input_parser import parse_repo_path
+from .models import FilterEvent
+from .models import Finding
+from .models import FindingCategory
+from .models import FindingSeverity
+from .models import FindingSource
+from .models import InputSummary
+from .models import InputType
+from .models import ReviewReport
+from .models import ReviewTask
+from .models import RuntimeKind
+from .models import SandboxRun
+from .models import TaskStatus
+from .models import utc_now_iso
+from .report import build_review_report
+from .report import route_findings
+from .report import write_review_report
+from .sandbox import run_rule_script
+from .sanitizer import redact_mapping
+from .sanitizer import redact_text
+from .skill_loader import load_skill
+from .store import ReviewStore
+from .store import ReviewStoreFactory
+
+
+@dataclass(frozen=True)
+class ReviewPipelineConfig:
+    """Configuration for one review pipeline run."""
+
+    input_type: InputType
+    input_ref: str
+    output_dir: str | Path = "output"
+    db_path: str | Path = "output/review.sqlite3"
+    runtime: RuntimeKind = RuntimeKind.DRY_RUN
+    allow_local: bool = False
+    timeout_sec: float = 30.0
+    output_limit_bytes: int = 65536
+    container_image: str = "python:3-slim"
+    docker_base_url: str = ""
+    store_factory: ReviewStoreFactory = ReviewStore
+
+
+@dataclass
+class ReviewPipelineResult:
+    """Materialized result of one review pipeline run."""
+
+    task: ReviewTask
+    report: ReviewReport
+    input_summary: InputSummary
+    findings: list[Finding]
+    warnings: list[Finding]
+    needs_human_review: list[Finding]
+    filter_events: list[FilterEvent]
+    sandbox_runs: list[SandboxRun]
+    artifact_paths: dict[str, str] = field(default_factory=dict)
+
+
+def run_review_pipeline(config: ReviewPipelineConfig) -> ReviewPipelineResult:
+    """Run the complete deterministic review pipeline."""
+    started = time.monotonic()
+    output_dir = Path(config.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    task = ReviewTask(input_type=config.input_type, input_ref=config.input_ref, status=TaskStatus.RUNNING)
+    input_summary = _parse_input(config, task.id)
+    input_summary.task_id = task.id
+    loaded_skill = load_skill(Path(__file__).parents[1] / "skills" / "code-review")
+
+    artifact_paths = _artifact_paths(output_dir)
+    _write_json_atomic(Path(artifact_paths["parsed_input"]), redact_mapping(input_summary.to_dict()))
+    _write_json_atomic(Path(artifact_paths["skill_manifest"]), redact_mapping(loaded_skill.manifest.to_dict()))
+
+    sandbox_run, filter_events, rule_result = run_rule_script(
+        task_id=task.id,
+        runtime=config.runtime,
+        allow_local=config.allow_local,
+        input_path=artifact_paths["parsed_input"],
+        manifest_path=artifact_paths["skill_manifest"],
+        output_path=artifact_paths["rule_result"],
+        timeout_sec=config.timeout_sec,
+        output_limit_bytes=config.output_limit_bytes,
+        container_image=config.container_image,
+        docker_base_url=config.docker_base_url,
+    )
+    raw_findings = [_finding_from_dict(item) for item in rule_result.get("findings", []) if isinstance(item, dict)]
+    _write_json_atomic(Path(artifact_paths["findings"]),
+                       redact_mapping({"findings": [item.to_dict() for item in raw_findings]}))
+    _write_json_atomic(Path(artifact_paths["filter_events"]),
+                       redact_mapping({"filter_events": [event.to_dict() for event in filter_events]}))
+    _write_json_atomic(Path(artifact_paths["sandbox_runs"]), redact_mapping({"sandbox_runs": [sandbox_run.to_dict()]}))
+
+    total_duration_ms = int((time.monotonic() - started) * 1000)
+    report = build_review_report(
+        task_id=task.id,
+        input_summary=input_summary,
+        findings=raw_findings,
+        filter_events=filter_events,
+        sandbox_runs=[sandbox_run],
+        total_duration_ms=total_duration_ms,
+    )
+    report_json, report_md = write_review_report(output_dir, report)
+    artifact_paths["review_report_json"] = str(report_json)
+    artifact_paths["review_report_md"] = str(report_md)
+    artifact_paths["db_path"] = str(Path(config.db_path))
+    task.status = TaskStatus.DONE
+    task.summary = report.conclusion
+    task.finished_at = utc_now_iso()
+    routed_findings, warnings, needs_human_review = route_findings(raw_findings, filter_events, [sandbox_run])
+    with config.store_factory(config.db_path) as store:
+        store.save_review(
+            task=task,
+            input_summary=input_summary,
+            findings=routed_findings,
+            warnings=warnings,
+            needs_human_review=needs_human_review,
+            filter_events=filter_events,
+            sandbox_runs=[sandbox_run],
+            report=report,
+            report_json_path=report_json,
+            report_md_path=report_md,
+        )
+    return ReviewPipelineResult(
+        task=task,
+        report=report,
+        input_summary=input_summary,
+        findings=routed_findings,
+        warnings=warnings,
+        needs_human_review=needs_human_review,
+        filter_events=filter_events,
+        sandbox_runs=[sandbox_run],
+        artifact_paths=artifact_paths,
+    )
+
+
+def _parse_input(config: ReviewPipelineConfig, task_id: str) -> InputSummary:
+    if config.input_type is InputType.DIFF_FILE:
+        return parse_diff_file(config.input_ref, task_id=task_id)
+    if config.input_type is InputType.REPO_PATH:
+        return parse_repo_path(config.input_ref, task_id=task_id)
+    if config.input_type is InputType.FILE_LIST:
+        return parse_file_list(config.input_ref, task_id=task_id)
+    return parse_fixture(config.input_ref, task_id=task_id)
+
+
+def _artifact_paths(output_dir: Path) -> dict[str, str]:
+    return {
+        "parsed_input": str(output_dir / "parsed_input.json"),
+        "skill_manifest": str(output_dir / "skill_manifest.json"),
+        "rule_result": str(output_dir / "rule_result.json"),
+        "findings": str(output_dir / "findings.json"),
+        "filter_events": str(output_dir / "filter_events.json"),
+        "sandbox_runs": str(output_dir / "sandbox_runs.json"),
+    }
+
+
+def _finding_from_dict(payload: dict[str, Any]) -> Finding:
+    try:
+        severity = FindingSeverity(str(payload["severity"]))
+    except (KeyError, ValueError):
+        severity = FindingSeverity.MEDIUM
+    try:
+        category = FindingCategory(str(payload["category"]))
+    except (KeyError, ValueError):
+        category = FindingCategory.SANDBOX
+    try:
+        source = FindingSource(str(payload.get("source", FindingSource.RULE.value)))
+    except ValueError:
+        source = FindingSource.RULE
+    return Finding(
+        severity=severity,
+        category=category,
+        file=redact_text(str(payload.get("file", ""))),
+        line=payload.get("line"),
+        title=redact_text(str(payload.get("title", ""))),
+        evidence=redact_text(str(payload.get("evidence", ""))),
+        recommendation=redact_text(str(payload.get("recommendation", ""))),
+        confidence=float(payload.get("confidence", 0.0)),
+        source=source,
+        fingerprint=str(payload.get("fingerprint") or ""),
+    )
+
+
+def _write_json_atomic(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    rendered = json.dumps(redact_mapping(payload), ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+    fd, tmp_name = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=path.parent)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(rendered)
+            handle.flush()
+            os.fsync(handle.fileno())
+        Path(tmp_name).replace(path)
+    except Exception:
+        Path(tmp_name).unlink(missing_ok=True)
+        raise

--- a/examples/skills_code_review_agent/agent/pipeline.py
+++ b/examples/skills_code_review_agent/agent/pipeline.py
@@ -33,8 +33,8 @@ from .models import RuntimeKind
 from .models import SandboxRun
 from .models import TaskStatus
 from .models import utc_now_iso
+from .report import _route_findings
 from .report import build_review_report
-from .report import route_findings
 from .report import write_review_report
 from .sandbox import run_rule_script
 from .sanitizer import redact_mapping
@@ -110,6 +110,7 @@ def run_review_pipeline(config: ReviewPipelineConfig) -> ReviewPipelineResult:
     _write_json_atomic(Path(artifact_paths["sandbox_runs"]), redact_mapping({"sandbox_runs": [sandbox_run.to_dict()]}))
 
     total_duration_ms = int((time.monotonic() - started) * 1000)
+    routed = _route_findings(raw_findings, filter_events, [sandbox_run])
     report = build_review_report(
         task_id=task.id,
         input_summary=input_summary,
@@ -117,6 +118,7 @@ def run_review_pipeline(config: ReviewPipelineConfig) -> ReviewPipelineResult:
         filter_events=filter_events,
         sandbox_runs=[sandbox_run],
         total_duration_ms=total_duration_ms,
+        routed=routed,
     )
     report_json, report_md = write_review_report(output_dir, report)
     artifact_paths["review_report_json"] = str(report_json)
@@ -125,7 +127,9 @@ def run_review_pipeline(config: ReviewPipelineConfig) -> ReviewPipelineResult:
     task.status = TaskStatus.DONE
     task.summary = report.conclusion
     task.finished_at = utc_now_iso()
-    routed_findings, warnings, needs_human_review = route_findings(raw_findings, filter_events, [sandbox_run])
+    routed_findings = routed.findings
+    warnings = routed.warnings
+    needs_human_review = routed.needs_human_review
     with config.store_factory(config.db_path) as store:
         store.save_review(
             task=task,

--- a/examples/skills_code_review_agent/agent/report.py
+++ b/examples/skills_code_review_agent/agent/report.py
@@ -1,0 +1,273 @@
+# Tencent is pleased to support the open source community by making tRPC-Agent-Python available.
+#
+# Copyright (C) 2026 Tencent. All rights reserved.
+#
+# tRPC-Agent-Python is licensed under Apache-2.0.
+"""Report assembly and rendering for the code-review example."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+from .models import FilterDecision
+from .models import FilterEvent
+from .models import Finding
+from .models import FindingCategory
+from .models import FindingSeverity
+from .models import FindingSource
+from .models import InputSummary
+from .models import ReviewMetrics
+from .models import ReviewReport
+from .models import SandboxRun
+from .models import SandboxStatus
+from .sanitizer import redact_mapping
+from .sanitizer import redact_text
+
+_WARNING_CONFIDENCE_THRESHOLD = 0.7
+
+
+def dedupe_findings(findings: list[Finding]) -> list[Finding]:
+    """Return findings with stable fingerprints and duplicates removed."""
+    seen: set[str] = set()
+    unique: list[Finding] = []
+    for finding in findings:
+        fingerprint = finding.fingerprint or _fallback_fingerprint(finding)
+        finding.fingerprint = fingerprint
+        if fingerprint in seen:
+            continue
+        seen.add(fingerprint)
+        unique.append(_redact_finding(finding))
+    return unique
+
+
+def route_findings(
+    findings: list[Finding],
+    filter_events: list[FilterEvent],
+    sandbox_runs: list[SandboxRun],
+) -> tuple[list[Finding], list[Finding], list[Finding]]:
+    """Split findings into report findings, warnings, and human-review items."""
+    routed_findings: list[Finding] = []
+    warnings: list[Finding] = []
+    needs_human_review: list[Finding] = []
+    for finding in dedupe_findings(findings):
+        if finding.confidence < _WARNING_CONFIDENCE_THRESHOLD:
+            warnings.append(finding)
+        else:
+            routed_findings.append(finding)
+    for event in filter_events:
+        if event.decision is FilterDecision.NEEDS_HUMAN_REVIEW:
+            needs_human_review.append(_governance_finding(event))
+    for sandbox_run in sandbox_runs:
+        if sandbox_run.status is not SandboxStatus.SUCCESS:
+            needs_human_review.append(_sandbox_finding(sandbox_run))
+    return routed_findings, warnings, dedupe_findings(needs_human_review)
+
+
+def build_review_report(
+    *,
+    task_id: str,
+    input_summary: InputSummary,
+    findings: list[Finding],
+    filter_events: list[FilterEvent],
+    sandbox_runs: list[SandboxRun],
+    total_duration_ms: int = 0,
+) -> ReviewReport:
+    """Build the final machine-readable review report."""
+    routed_findings, warnings, needs_human_review = route_findings(findings, filter_events, sandbox_runs)
+    all_items = [*routed_findings, *warnings, *needs_human_review]
+    metrics = ReviewMetrics(
+        total_duration_ms=total_duration_ms,
+        sandbox_duration_ms=sum(item.duration_ms for item in sandbox_runs),
+        tool_call_count=len(sandbox_runs),
+        interception_count=sum(1 for item in filter_events if item.decision is not FilterDecision.ALLOW),
+        finding_count=len(routed_findings),
+        warning_count=len(warnings),
+        needs_human_review_count=len(needs_human_review),
+        severity_distribution=_count_by(all_items, "severity"),
+        category_distribution=_count_by(all_items, "category"),
+        exception_distribution=_exception_distribution(sandbox_runs),
+    )
+    conclusion = _conclusion(routed_findings, warnings, needs_human_review)
+    return ReviewReport(
+        task_id=task_id,
+        findings=routed_findings,
+        warnings=warnings,
+        needs_human_review=needs_human_review,
+        stats={
+            "input_summary": redact_mapping(input_summary.to_dict()),
+            "files": input_summary.file_count,
+            "hunks": input_summary.hunk_count,
+            "added_lines": input_summary.added_lines,
+            "deleted_lines": input_summary.deleted_lines,
+        },
+        metrics=metrics,
+        interceptions=filter_events,
+        sandbox_runs=sandbox_runs,
+        conclusion=conclusion,
+    )
+
+
+def write_review_report(output_dir: str | Path, report: ReviewReport) -> tuple[Path, Path]:
+    """Write JSON and Markdown reports and return their paths."""
+    root = Path(output_dir)
+    root.mkdir(parents=True, exist_ok=True)
+    json_path = root / "review_report.json"
+    md_path = root / "review_report.md"
+    rendered_json = json.dumps(redact_mapping(report.to_dict()), ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+    json_path.write_text(rendered_json, encoding="utf-8")
+    md_path.write_text(_render_markdown(report), encoding="utf-8")
+    return json_path, md_path
+
+
+def _render_markdown(report: ReviewReport) -> str:
+    lines = [
+        "# Code Review Report",
+        "",
+        f"- Task: `{report.task_id}`",
+        f"- Conclusion: {redact_text(report.conclusion)}",
+        f"- Findings: {len(report.findings)}",
+        f"- Warnings: {len(report.warnings)}",
+        f"- Needs human review: {len(report.needs_human_review)}",
+        "",
+        "## Metrics",
+        "",
+        f"- Total duration: {report.metrics.total_duration_ms} ms",
+        f"- Sandbox duration: {report.metrics.sandbox_duration_ms} ms",
+        f"- Tool calls: {report.metrics.tool_call_count}",
+        f"- Interceptions: {report.metrics.interception_count}",
+        f"- Severity distribution: `{json.dumps(report.metrics.severity_distribution, sort_keys=True)}`",
+        f"- Category distribution: `{json.dumps(report.metrics.category_distribution, sort_keys=True)}`",
+        "",
+    ]
+    lines.extend(_render_findings("Findings", report.findings))
+    lines.extend(_render_findings("Warnings", report.warnings))
+    lines.extend(_render_findings("Needs Human Review", report.needs_human_review))
+    lines.extend(_render_filter_events(report.interceptions))
+    lines.extend(_render_sandbox_runs(report.sandbox_runs))
+    lines.extend([
+        "## Fix Suggestions",
+        "",
+        "- Address critical and high findings before merging.",
+        "- Add focused tests for changed source behavior.",
+        "- Review any governance or sandbox items before trusting execution output.",
+        "",
+    ])
+    return "\n".join(lines)
+
+
+def _render_findings(title: str, findings: list[Finding]) -> list[str]:
+    lines = [f"## {title}", ""]
+    if not findings:
+        return [*lines, "None.", ""]
+    for item in findings:
+        location = f"{item.file}:{item.line}" if item.line is not None else item.file
+        lines.extend([
+            f"- **{redact_text(item.title)}** `{item.severity.value}` `{item.category.value}`",
+            f"  - Location: `{redact_text(location)}`",
+            f"  - Evidence: {redact_text(item.evidence)}",
+            f"  - Recommendation: {redact_text(item.recommendation)}",
+        ])
+    lines.append("")
+    return lines
+
+
+def _render_filter_events(events: list[FilterEvent]) -> list[str]:
+    lines = ["## Filter Events", ""]
+    if not events:
+        return [*lines, "None.", ""]
+    for event in events:
+        lines.append(f"- `{event.decision.value}` `{event.reason_code.value}`: {redact_text(event.reason)}")
+    lines.append("")
+    return lines
+
+
+def _render_sandbox_runs(runs: list[SandboxRun]) -> list[str]:
+    lines = ["## Sandbox Runs", ""]
+    if not runs:
+        return [*lines, "None.", ""]
+    for run in runs:
+        lines.append(f"- `{run.runtime.value}` `{run.status.value}` exit={run.exit_code} duration={run.duration_ms}ms")
+    lines.append("")
+    return lines
+
+
+def _governance_finding(event: FilterEvent) -> Finding:
+    evidence = f"{event.reason_code.value}: {event.reason}"
+    return Finding(
+        severity=FindingSeverity.MEDIUM,
+        category=FindingCategory.GOVERNANCE,
+        file=event.script_path or event.cwd or "<governance>",
+        line=None,
+        title="Execution requires human review",
+        evidence=redact_text(evidence),
+        recommendation="Review the governance decision before relying on this execution path.",
+        confidence=1.0,
+        source=FindingSource.FILTER,
+        fingerprint=_hash("governance", event.task_id, event.reason_code.value, event.target),
+    )
+
+
+def _sandbox_finding(run: SandboxRun) -> Finding:
+    evidence = run.stderr or run.error_type or run.status.value
+    return Finding(
+        severity=FindingSeverity.MEDIUM,
+        category=FindingCategory.SANDBOX,
+        file="<sandbox>",
+        line=None,
+        title="Sandbox execution did not complete successfully",
+        evidence=redact_text(evidence),
+        recommendation="Inspect sandbox status, diagnostics, and execution policy before trusting results.",
+        confidence=1.0,
+        source=FindingSource.SANDBOX,
+        fingerprint=_hash("sandbox", run.task_id, run.runtime.value, run.status.value, run.error_type),
+    )
+
+
+def _redact_finding(finding: Finding) -> Finding:
+    finding.evidence = redact_text(finding.evidence)
+    finding.recommendation = redact_text(finding.recommendation)
+    finding.title = redact_text(finding.title)
+    return finding
+
+
+def _fallback_fingerprint(finding: Finding) -> str:
+    return _hash(
+        finding.category.value,
+        finding.file,
+        str(finding.line or ""),
+        finding.title,
+        finding.evidence,
+    )
+
+
+def _hash(*parts: str) -> str:
+    return hashlib.sha256("|".join(parts).encode("utf-8")).hexdigest()
+
+
+def _count_by(findings: list[Finding], attr: str) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for finding in findings:
+        value = getattr(finding, attr)
+        key = value.value if hasattr(value, "value") else str(value)
+        counts[key] = counts.get(key, 0) + 1
+    return counts
+
+
+def _exception_distribution(sandbox_runs: list[SandboxRun]) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for run in sandbox_runs:
+        if run.error_type:
+            counts[run.error_type] = counts.get(run.error_type, 0) + 1
+    return counts
+
+
+def _conclusion(findings: list[Finding], warnings: list[Finding], needs_human_review: list[Finding]) -> str:
+    if any(item.severity in {FindingSeverity.CRITICAL, FindingSeverity.HIGH} for item in findings):
+        return "High risk findings require changes before merge."
+    if needs_human_review:
+        return "Human review is required for execution or sandbox uncertainty."
+    if findings or warnings:
+        return "Review completed with findings or warnings."
+    return "Review completed with no findings."

--- a/examples/skills_code_review_agent/agent/report.py
+++ b/examples/skills_code_review_agent/agent/report.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import hashlib
 import json
 from dataclasses import dataclass
+from dataclasses import replace
 from pathlib import Path
 
 from .models import FilterDecision
@@ -41,12 +42,12 @@ def dedupe_findings(findings: list[Finding]) -> list[Finding]:
     seen: set[str] = set()
     unique: list[Finding] = []
     for finding in findings:
-        fingerprint = finding.fingerprint or _fallback_fingerprint(finding)
-        finding.fingerprint = fingerprint
+        redacted = _redact_finding(finding)
+        fingerprint = finding.fingerprint or _fallback_fingerprint(redacted)
         if fingerprint in seen:
             continue
         seen.add(fingerprint)
-        unique.append(_redact_finding(finding))
+        unique.append(replace(redacted, fingerprint=fingerprint))
     return unique
 
 
@@ -251,10 +252,12 @@ def _sandbox_finding(run: SandboxRun) -> Finding:
 
 
 def _redact_finding(finding: Finding) -> Finding:
-    finding.evidence = redact_text(finding.evidence)
-    finding.recommendation = redact_text(finding.recommendation)
-    finding.title = redact_text(finding.title)
-    return finding
+    return replace(
+        finding,
+        evidence=redact_text(finding.evidence),
+        recommendation=redact_text(finding.recommendation),
+        title=redact_text(finding.title),
+    )
 
 
 def _fallback_fingerprint(finding: Finding) -> str:

--- a/examples/skills_code_review_agent/agent/report.py
+++ b/examples/skills_code_review_agent/agent/report.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+from dataclasses import dataclass
 from pathlib import Path
 
 from .models import FilterDecision
@@ -26,6 +27,13 @@ from .sanitizer import redact_mapping
 from .sanitizer import redact_text
 
 _WARNING_CONFIDENCE_THRESHOLD = 0.7
+
+
+@dataclass(frozen=True)
+class RoutedFindings:
+    findings: list[Finding]
+    warnings: list[Finding]
+    needs_human_review: list[Finding]
 
 
 def dedupe_findings(findings: list[Finding]) -> list[Finding]:
@@ -48,6 +56,15 @@ def route_findings(
     sandbox_runs: list[SandboxRun],
 ) -> tuple[list[Finding], list[Finding], list[Finding]]:
     """Split findings into report findings, warnings, and human-review items."""
+    routed = _route_findings(findings, filter_events, sandbox_runs)
+    return routed.findings, routed.warnings, routed.needs_human_review
+
+
+def _route_findings(
+    findings: list[Finding],
+    filter_events: list[FilterEvent],
+    sandbox_runs: list[SandboxRun],
+) -> RoutedFindings:
     routed_findings: list[Finding] = []
     warnings: list[Finding] = []
     needs_human_review: list[Finding] = []
@@ -62,7 +79,11 @@ def route_findings(
     for sandbox_run in sandbox_runs:
         if sandbox_run.status is not SandboxStatus.SUCCESS:
             needs_human_review.append(_sandbox_finding(sandbox_run))
-    return routed_findings, warnings, dedupe_findings(needs_human_review)
+    return RoutedFindings(
+        findings=routed_findings,
+        warnings=warnings,
+        needs_human_review=dedupe_findings(needs_human_review),
+    )
 
 
 def build_review_report(
@@ -73,9 +94,13 @@ def build_review_report(
     filter_events: list[FilterEvent],
     sandbox_runs: list[SandboxRun],
     total_duration_ms: int = 0,
+    routed: RoutedFindings | None = None,
 ) -> ReviewReport:
     """Build the final machine-readable review report."""
-    routed_findings, warnings, needs_human_review = route_findings(findings, filter_events, sandbox_runs)
+    routed = routed or _route_findings(findings, filter_events, sandbox_runs)
+    routed_findings = routed.findings
+    warnings = routed.warnings
+    needs_human_review = routed.needs_human_review
     all_items = [*routed_findings, *warnings, *needs_human_review]
     metrics = ReviewMetrics(
         total_duration_ms=total_duration_ms,

--- a/examples/skills_code_review_agent/agent/review_rules.py
+++ b/examples/skills_code_review_agent/agent/review_rules.py
@@ -309,16 +309,24 @@ def _line_content(lines: list[tuple[int | None, str]], line: int | None) -> str:
 
 def _missing_tests_finding(input_summary: InputSummary) -> Finding | None:
     source_files = [item for item in input_summary.changed_files if _is_source_file(item.path)]
-    if not source_files or any(_is_test_file(item.path) for item in input_summary.changed_files):
+    if not source_files:
         return None
-    first = source_files[0]
+    test_paths = [item.path for item in input_summary.changed_files if _is_test_file(item.path)]
+    uncovered = [
+        item for item in source_files
+        if not any(_is_related_test_path(item.path, test_path) for test_path in test_paths)
+    ]
+    if not uncovered:
+        return None
+    first = uncovered[0]
     return _finding(
         severity=FindingSeverity.LOW,
         category=FindingCategory.TEST,
         file=first.path,
         line=first.candidate_lines[0] if first.candidate_lines else None,
         title="Source change has no matching test update",
-        evidence=f"{len(source_files)} source file(s) changed without a test or fixture change.",
+        evidence=(f"{len(uncovered)} of {len(source_files)} source file(s) changed without a matching test "
+                  "or fixture change."),
         recommendation="Add or update focused tests or fixtures for the changed behavior.",
         confidence=0.65,
     )
@@ -356,6 +364,68 @@ def _is_test_file(path: str) -> bool:
     name = lower.rsplit("/", 1)[-1]
     return ("/tests/" in f"/{lower}" or name.startswith("test_") or name.endswith("_test.py") or "fixture" in lower
             or lower.startswith("tests/"))
+
+
+def _is_related_test_path(source_path: str, test_path: str) -> bool:
+    source_parts = _path_parts(source_path)
+    test_parts = _path_parts(test_path)
+    if not source_parts or not test_parts or not _is_test_file(test_path):
+        return False
+
+    source_name = source_parts[-1]
+    source_stem, source_suffix = _split_name(source_name)
+    test_name = test_parts[-1]
+    test_stem, _test_suffix = _split_name(test_name)
+    source_parent = source_parts[:-1]
+    test_parent = _strip_test_roots(test_parts[:-1])
+
+    if "fixture" in "/".join(test_parts):
+        return _fixture_matches(source_stem, test_stem, test_parent, source_parent)
+
+    expected_names = _expected_test_names(source_stem, source_suffix)
+    if test_name not in expected_names:
+        return False
+    return test_parent == source_parent or not test_parent
+
+
+def _path_parts(path: str) -> tuple[str, ...]:
+    return tuple(part for part in path.lower().replace("\\", "/").split("/") if part)
+
+
+def _split_name(name: str) -> tuple[str, str]:
+    if "." not in name:
+        return name, ""
+    stem, suffix = name.rsplit(".", 1)
+    return stem, f".{suffix}"
+
+
+def _strip_test_roots(parts: tuple[str, ...]) -> tuple[str, ...]:
+    return tuple(part for part in parts if part not in {"test", "tests", "__tests__", "fixtures", "fixture"})
+
+
+def _expected_test_names(stem: str, suffix: str) -> set[str]:
+    if suffix in {".js", ".jsx", ".ts", ".tsx"}:
+        return {
+            f"{stem}.test{suffix}",
+            f"{stem}.spec{suffix}",
+            f"test_{stem}{suffix}",
+        }
+    return {
+        f"test_{stem}{suffix}",
+        f"{stem}_test{suffix}",
+    }
+
+
+def _fixture_matches(
+    source_stem: str,
+    fixture_stem: str,
+    fixture_parent: tuple[str, ...],
+    source_parent: tuple[str, ...],
+) -> bool:
+    if fixture_parent and fixture_parent != source_parent:
+        return False
+    tokens = {token for token in re.split(r"[^a-z0-9]+", fixture_stem) if token}
+    return fixture_stem == source_stem or source_stem in tokens
 
 
 def _finding(

--- a/examples/skills_code_review_agent/agent/review_rules.py
+++ b/examples/skills_code_review_agent/agent/review_rules.py
@@ -1,0 +1,391 @@
+# Tencent is pleased to support the open source community by making tRPC-Agent-Python available.
+#
+# Copyright (C) 2026 Tencent. All rights reserved.
+#
+# tRPC-Agent-Python is licensed under Apache-2.0.
+"""Deterministic review rules for normalized diff input."""
+
+from __future__ import annotations
+
+import ast
+import hashlib
+import re
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+from .models import ChangedFile
+from .models import ChangedLine
+from .models import Finding
+from .models import FindingCategory
+from .models import FindingSeverity
+from .models import FindingSource
+from .models import InputSummary
+from .sanitizer import redact_text
+
+_SECRET_ASSIGNMENT_RE = re.compile(
+    r"(?i)\b(api[_-]?key|secret|token|password|passwd|pwd)\b\s*[:=]\s*(?:\[REDACTED\]|['\"][^'\"]{4,}['\"])")
+_SECRET_LITERAL_RE = re.compile(
+    r"\b(?:sk-[A-Za-z0-9_-]{8,}|pk-[A-Za-z0-9_-]{8,}|ghp_[A-Za-z0-9_]{8,}|gho_[A-Za-z0-9_]{8,}|"
+    r"github_pat_[A-Za-z0-9_]{8,}|xox[bp]-[A-Za-z0-9-]{8,}|AKIA[0-9A-Z]{16}|ASIA[0-9A-Z]{16})\b")
+_EVAL_EXEC_RE = re.compile(r"\b(eval|exec)\s*\(")
+_SHELL_TRUE_RE = re.compile(r"\bshell\s*=\s*True\b")
+_ASYNC_RESOURCE_RE = re.compile(r"\b(?:httpx\.AsyncClient|aiohttp\.ClientSession|AsyncClient|ClientSession)\s*\(")
+_FILE_OPEN_RE = re.compile(r"\bopen\s*\(")
+_DB_CONNECT_RE = re.compile(r"\b(?:sqlite3\.connect|psycopg2\.connect|pymysql\.connect|connect)\s*\(")
+_CLOSE_RE = re.compile(r"\b(?:close|aclose|commit|rollback)\s*\(")
+_CONTEXT_RE = re.compile(r"\b(?:with|async\s+with)\b")
+
+
+@dataclass(frozen=True)
+class _AstSignal:
+    """A normalized AST signal anchored to an added-line number."""
+
+    kind: str
+    line: int | None
+    evidence: str
+
+
+def run_review_rules(input_summary: InputSummary) -> list[Finding]:
+    """Run deterministic rules over parsed changed lines."""
+    findings: list[Finding] = []
+    for changed_file in input_summary.changed_files:
+        if changed_file.is_binary:
+            continue
+        added_lines = list(_iter_added_lines(changed_file))
+        if changed_file.path.endswith(".py"):
+            ast_findings, parsed = _scan_python_ast(changed_file, added_lines)
+            findings.extend(ast_findings)
+            if parsed:
+                for line in added_lines:
+                    findings.extend(_scan_added_line(changed_file, line, include_dynamic=False))
+                continue
+        for line in added_lines:
+            findings.extend(_scan_added_line(changed_file, line))
+        findings.extend(_scan_lifecycle_patterns(changed_file, added_lines))
+
+    missing_test = _missing_tests_finding(input_summary)
+    if missing_test is not None:
+        findings.append(missing_test)
+    return findings
+
+
+def _scan_added_line(changed_file: ChangedFile, line: ChangedLine, *, include_dynamic: bool = True) -> list[Finding]:
+    content = line.content
+    findings: list[Finding] = []
+    if _SECRET_ASSIGNMENT_RE.search(content) or _SECRET_LITERAL_RE.search(content):
+        findings.append(
+            _finding(
+                severity=FindingSeverity.CRITICAL,
+                category=FindingCategory.SECRET,
+                file=changed_file.path,
+                line=line.new_line,
+                title="Hard-coded secret in changed code",
+                evidence=content,
+                recommendation="Move secrets to a managed secret store or environment configuration.",
+                confidence=0.95,
+            ))
+    if include_dynamic and (_EVAL_EXEC_RE.search(content) or _SHELL_TRUE_RE.search(content)):
+        findings.append(
+            _finding(
+                severity=FindingSeverity.HIGH,
+                category=FindingCategory.SECURITY,
+                file=changed_file.path,
+                line=line.new_line,
+                title="Dynamic execution or shell invocation introduced",
+                evidence=content,
+                recommendation="Avoid dynamic execution and shell=True; pass validated arguments as a list.",
+                confidence=0.9,
+            ))
+    return findings
+
+
+def _scan_python_ast(changed_file: ChangedFile, lines: list[ChangedLine]) -> tuple[list[Finding], bool]:
+    signals, parsed = _analyze_python_added_lines([(line.new_line, line.content) for line in lines])
+    findings: list[Finding] = []
+    for signal in signals:
+        if signal.kind in {"dynamic_execution", "shell_true"}:
+            findings.append(
+                _finding(
+                    severity=FindingSeverity.HIGH,
+                    category=FindingCategory.SECURITY,
+                    file=changed_file.path,
+                    line=signal.line,
+                    title="Dynamic execution or shell invocation introduced",
+                    evidence=signal.evidence,
+                    recommendation="Avoid dynamic execution and shell=True; pass validated arguments as a list.",
+                    confidence=0.9,
+                ))
+        elif signal.kind == "async_client_unclosed":
+            findings.append(
+                _finding(
+                    severity=FindingSeverity.MEDIUM,
+                    category=FindingCategory.ASYNC,
+                    file=changed_file.path,
+                    line=signal.line,
+                    title="Async client/session may not be closed",
+                    evidence=signal.evidence,
+                    recommendation="Use async with or close the async resource in a finally block.",
+                    confidence=0.72,
+                ))
+        elif signal.kind == "file_open_unclosed":
+            findings.append(
+                _finding(
+                    severity=FindingSeverity.MEDIUM,
+                    category=FindingCategory.RESOURCE,
+                    file=changed_file.path,
+                    line=signal.line,
+                    title="File handle may not be closed",
+                    evidence=signal.evidence,
+                    recommendation="Use a with statement or close the file handle in a finally block.",
+                    confidence=0.7,
+                ))
+        elif signal.kind == "db_connect_unclosed":
+            findings.append(
+                _finding(
+                    severity=FindingSeverity.MEDIUM,
+                    category=FindingCategory.DB,
+                    file=changed_file.path,
+                    line=signal.line,
+                    title="Database connection lifecycle is not bounded",
+                    evidence=signal.evidence,
+                    recommendation="Use a context manager and ensure commit/rollback/close on all paths.",
+                    confidence=0.72,
+                ))
+    return findings, parsed
+
+
+def _scan_lifecycle_patterns(changed_file: ChangedFile, lines: list[ChangedLine]) -> list[Finding]:
+    findings: list[Finding] = []
+    added_text = "\n".join(line.content for line in lines)
+    if _ASYNC_RESOURCE_RE.search(added_text) and not _has_close_or_context(added_text):
+        findings.append(
+            _finding(
+                severity=FindingSeverity.MEDIUM,
+                category=FindingCategory.ASYNC,
+                file=changed_file.path,
+                line=_first_matching_line(lines, _ASYNC_RESOURCE_RE),
+                title="Async client/session may not be closed",
+                evidence=_first_matching_content(lines, _ASYNC_RESOURCE_RE),
+                recommendation="Use async with or close the async resource in a finally block.",
+                confidence=0.72,
+            ))
+    if _FILE_OPEN_RE.search(added_text) and not _has_close_or_context(added_text):
+        findings.append(
+            _finding(
+                severity=FindingSeverity.MEDIUM,
+                category=FindingCategory.RESOURCE,
+                file=changed_file.path,
+                line=_first_matching_line(lines, _FILE_OPEN_RE),
+                title="File handle may not be closed",
+                evidence=_first_matching_content(lines, _FILE_OPEN_RE),
+                recommendation="Use a with statement or close the file handle in a finally block.",
+                confidence=0.7,
+            ))
+    if _DB_CONNECT_RE.search(added_text) and not _has_close_or_context(added_text):
+        findings.append(
+            _finding(
+                severity=FindingSeverity.MEDIUM,
+                category=FindingCategory.DB,
+                file=changed_file.path,
+                line=_first_matching_line(lines, _DB_CONNECT_RE),
+                title="Database connection lifecycle is not bounded",
+                evidence=_first_matching_content(lines, _DB_CONNECT_RE),
+                recommendation="Use a context manager and ensure commit/rollback/close on all paths.",
+                confidence=0.72,
+            ))
+    return findings
+
+
+def _has_close_or_context(text: str) -> bool:
+    return bool(_CLOSE_RE.search(text) or _CONTEXT_RE.search(text))
+
+
+def _analyze_python_added_lines(lines: list[tuple[int | None, str]]) -> tuple[list[_AstSignal], bool]:
+    if not lines:
+        return [], True
+    line_numbers = [line_no for line_no, _content in lines if line_no is not None]
+    base_line = min(line_numbers) if line_numbers else 1
+    source = "\n".join(content for _line_no, content in lines)
+    try:
+        tree = ast.parse(source or "pass")
+    except SyntaxError:
+        return [], False
+    _attach_parents(tree)
+    line_lookup = {index: line_no for index, (line_no, _content) in enumerate(lines, start=1)}
+    context_managed = _context_managed_calls(tree)
+    closed_names = _closed_names(tree)
+    signals: list[_AstSignal] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        name = _call_name(node)
+        line = line_lookup.get(getattr(node, "lineno", 0), base_line + getattr(node, "lineno", 1) - 1)
+        evidence = _line_content(lines, line)
+        if name in {"eval", "exec"}:
+            signals.append(_AstSignal("dynamic_execution", line, evidence))
+        elif name.startswith("subprocess.") and _has_shell_true(node):
+            signals.append(_AstSignal("shell_true", line, evidence))
+        elif name == "open" and id(node) not in context_managed and not _assigned_name_closed(node, closed_names):
+            signals.append(_AstSignal("file_open_unclosed", line, evidence))
+        elif _is_db_connect(name) and id(node) not in context_managed and not _assigned_name_closed(node, closed_names):
+            signals.append(_AstSignal("db_connect_unclosed", line, evidence))
+        elif _is_async_client(name) and id(node) not in context_managed and not _assigned_name_closed(
+                node, closed_names):
+            signals.append(_AstSignal("async_client_unclosed", line, evidence))
+    return signals, True
+
+
+def _context_managed_calls(tree: ast.AST) -> set[int]:
+    calls: set[int] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.With, ast.AsyncWith)):
+            for item in node.items:
+                if isinstance(item.context_expr, ast.Call):
+                    calls.add(id(item.context_expr))
+    return calls
+
+
+def _closed_names(tree: ast.AST) -> set[str]:
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            func = node.func
+            if isinstance(func, ast.Attribute) and func.attr in {"close", "aclose", "commit", "rollback"}:
+                if isinstance(func.value, ast.Name):
+                    names.add(func.value.id)
+    return names
+
+
+def _assigned_name_closed(call: ast.Call, closed_names: set[str]) -> bool:
+    parent = getattr(call, "_parent", None)
+    if isinstance(parent, ast.Assign):
+        for target in parent.targets:
+            if isinstance(target, ast.Name) and target.id in closed_names:
+                return True
+    return False
+
+
+def _attach_parents(root: ast.AST) -> None:
+    for parent in ast.walk(root):
+        for child in ast.iter_child_nodes(parent):
+            setattr(child, "_parent", parent)
+
+
+def _call_name(node: ast.Call) -> str:
+    func = node.func
+    if isinstance(func, ast.Name):
+        return func.id
+    if isinstance(func, ast.Attribute):
+        parts = [func.attr]
+        value = func.value
+        while isinstance(value, ast.Attribute):
+            parts.append(value.attr)
+            value = value.value
+        if isinstance(value, ast.Name):
+            parts.append(value.id)
+        return ".".join(reversed(parts))
+    return ""
+
+
+def _has_shell_true(node: ast.Call) -> bool:
+    return any(keyword.arg == "shell" and isinstance(keyword.value, ast.Constant) and keyword.value.value is True
+               for keyword in node.keywords)
+
+
+def _is_db_connect(name: str) -> bool:
+    return name in {"sqlite3.connect", "psycopg2.connect", "pymysql.connect", "connect"} or name.endswith(".connect")
+
+
+def _is_async_client(name: str) -> bool:
+    return name in {"httpx.AsyncClient", "aiohttp.ClientSession", "AsyncClient", "ClientSession"}
+
+
+def _line_content(lines: list[tuple[int | None, str]], line: int | None) -> str:
+    for line_no, content in lines:
+        if line_no == line:
+            return content
+    return ""
+
+
+def _missing_tests_finding(input_summary: InputSummary) -> Finding | None:
+    source_files = [item for item in input_summary.changed_files if _is_source_file(item.path)]
+    if not source_files or any(_is_test_file(item.path) for item in input_summary.changed_files):
+        return None
+    first = source_files[0]
+    return _finding(
+        severity=FindingSeverity.LOW,
+        category=FindingCategory.TEST,
+        file=first.path,
+        line=first.candidate_lines[0] if first.candidate_lines else None,
+        title="Source change has no matching test update",
+        evidence=f"{len(source_files)} source file(s) changed without a test or fixture change.",
+        recommendation="Add or update focused tests or fixtures for the changed behavior.",
+        confidence=0.65,
+    )
+
+
+def _iter_added_lines(changed_file: ChangedFile) -> Iterable[ChangedLine]:
+    for hunk in changed_file.hunks:
+        for line in hunk.lines:
+            if line.line_type == "added":
+                yield line
+
+
+def _first_matching_line(lines: list[ChangedLine], pattern: re.Pattern[str]) -> int | None:
+    for line in lines:
+        if pattern.search(line.content):
+            return line.new_line
+    return None
+
+
+def _first_matching_content(lines: list[ChangedLine], pattern: re.Pattern[str]) -> str:
+    for line in lines:
+        if pattern.search(line.content):
+            return line.content
+    return ""
+
+
+def _is_source_file(path: str) -> bool:
+    if _is_test_file(path):
+        return False
+    return path.endswith((".py", ".js", ".ts", ".tsx", ".go", ".java", ".kt", ".rs", ".rb", ".php"))
+
+
+def _is_test_file(path: str) -> bool:
+    lower = path.lower()
+    name = lower.rsplit("/", 1)[-1]
+    return ("/tests/" in f"/{lower}" or name.startswith("test_") or name.endswith("_test.py") or "fixture" in lower
+            or lower.startswith("tests/"))
+
+
+def _finding(
+    *,
+    severity: FindingSeverity,
+    category: FindingCategory,
+    file: str,
+    line: int | None,
+    title: str,
+    evidence: str,
+    recommendation: str,
+    confidence: float,
+) -> Finding:
+    redacted_evidence = redact_text(evidence)
+    redacted_recommendation = redact_text(recommendation)
+    fingerprint = _fingerprint(category, file, line, title, redacted_evidence)
+    return Finding(
+        severity=severity,
+        category=category,
+        file=file,
+        line=line,
+        title=title,
+        evidence=redacted_evidence,
+        recommendation=redacted_recommendation,
+        confidence=confidence,
+        source=FindingSource.RULE,
+        fingerprint=fingerprint,
+    )
+
+
+def _fingerprint(category: FindingCategory, file: str, line: int | None, title: str, evidence: str) -> str:
+    raw = f"{category.value}|{file}|{line or ''}|{title}|{evidence}"
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()

--- a/examples/skills_code_review_agent/agent/review_rules.py
+++ b/examples/skills_code_review_agent/agent/review_rules.py
@@ -23,7 +23,9 @@ from .models import InputSummary
 from .sanitizer import redact_text
 
 _SECRET_ASSIGNMENT_RE = re.compile(
-    r"(?i)\b(api[_-]?key|secret|token|password|passwd|pwd)\b\s*[:=]\s*(?:\[REDACTED\]|['\"][^'\"]{4,}['\"])")
+    r"(?i)\b[A-Za-z0-9_.-]*(?:api[_-]?key|secret|token|password|passwd|pwd)[A-Za-z0-9_.-]*\b"
+    r"\s*[:=]\s*(?:\[REDACTED\]|['\"][^'\"]{4,}['\"]|"
+    r"(?!(?:none|true|false|null|undefined)\b)[A-Za-z0-9_./+=:-]{4,})")
 _SECRET_LITERAL_RE = re.compile(
     r"\b(?:sk-[A-Za-z0-9_-]{8,}|pk-[A-Za-z0-9_-]{8,}|ghp_[A-Za-z0-9_]{8,}|gho_[A-Za-z0-9_]{8,}|"
     r"github_pat_[A-Za-z0-9_]{8,}|xox[bp]-[A-Za-z0-9-]{8,}|AKIA[0-9A-Z]{16}|ASIA[0-9A-Z]{16})\b")

--- a/examples/skills_code_review_agent/agent/sandbox.py
+++ b/examples/skills_code_review_agent/agent/sandbox.py
@@ -1,0 +1,270 @@
+# Tencent is pleased to support the open source community by making tRPC-Agent-Python available.
+#
+# Copyright (C) 2026 Tencent. All rights reserved.
+#
+# tRPC-Agent-Python is licensed under Apache-2.0.
+"""Sandbox adapter for the example rule-runner command."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+from .governance import ExecutionRequest
+from .governance import evaluate_execution_request
+from .models import FilterDecision
+from .models import FilterEvent
+from .models import FilterReasonCode
+from .models import FilterTargetType
+from .models import RuntimeKind
+from .models import SandboxRun
+from .models import SandboxStatus
+from .sandbox_workspace import _RuntimeAdapterResult  # noqa: F401
+from .sandbox_workspace import _RuntimeUnavailableError
+from .sandbox_workspace import _WorkspaceRuntimeAdapter  # noqa: F401
+from .sandbox_workspace import _failure_result
+from .sandbox_workspace import _resolve_runtime_adapter
+from .sandbox_workspace import _truncate
+from .sanitizer import redact_mapping
+from .sanitizer import redact_text
+
+
+def run_rule_script(
+    task_id: str,
+    runtime: RuntimeKind,
+    allow_local: bool,
+    input_path: str | Path,
+    manifest_path: str | Path,
+    output_path: str | Path,
+    timeout_sec: float = 30.0,
+    output_limit_bytes: int = 65536,
+    container_image: str = "python:3-slim",
+    docker_base_url: str = "",
+) -> tuple[SandboxRun, list[FilterEvent], dict[str, Any]]:
+    """Run or simulate the bundled rule runner under example governance."""
+    input_file = Path(input_path).expanduser().resolve()
+    manifest_file = Path(manifest_path).expanduser().resolve()
+    output_file = Path(output_path).expanduser().resolve()
+    script_path = Path(__file__).parents[1] / "skills" / "code-review" / "scripts" / "rule_runner.py"
+    command = [
+        sys.executable,
+        str(script_path),
+        "--input",
+        str(input_file),
+        "--manifest",
+        str(manifest_file),
+        "--output",
+        str(output_file),
+    ]
+    request = ExecutionRequest(
+        command=command,
+        runtime=runtime,
+        cwd=str(Path(__file__).parents[1]),
+        timeout_sec=timeout_sec,
+        output_limit_bytes=output_limit_bytes,
+        allow_local=allow_local,
+        script_path=str(script_path),
+        allowed_roots=(str(Path(__file__).parents[1]), str(output_file.parent)),
+        metadata={
+            "input": str(input_file),
+            "manifest": str(manifest_file),
+            "output": str(output_file)
+        },
+    )
+    filter_event = evaluate_execution_request(task_id, request)
+    sandbox_run = SandboxRun(
+        task_id=task_id,
+        runtime=runtime,
+        command=filter_event.command,
+        timeout_sec=timeout_sec,
+        output_limit_bytes=output_limit_bytes,
+    )
+
+    if filter_event.decision is FilterDecision.DENY:
+        sandbox_run.status = SandboxStatus.DENIED
+        sandbox_run.stderr = filter_event.reason
+        sandbox_run.error_type = filter_event.reason_code.value
+        result = _failure_result(filter_event.reason)
+        _write_json(output_file, result)
+        return sandbox_run, [filter_event], result
+    if filter_event.decision is FilterDecision.NEEDS_HUMAN_REVIEW:
+        sandbox_run.status = SandboxStatus.NEEDS_HUMAN_REVIEW
+        sandbox_run.stderr = filter_event.reason
+        sandbox_run.error_type = filter_event.reason_code.value
+        result = _failure_result(filter_event.reason)
+        _write_json(output_file, result)
+        return sandbox_run, [filter_event], result
+    if runtime is RuntimeKind.DRY_RUN:
+        return _run_dry(input_file, manifest_file, output_file, sandbox_run, filter_event, timeout_sec,
+                        output_limit_bytes)
+    if runtime is RuntimeKind.LOCAL_DEV:
+        return _run_local(command, output_file, sandbox_run, filter_event, timeout_sec, output_limit_bytes)
+    resolved = _resolve_runtime_adapter(
+        runtime,
+        container_image=container_image,
+        docker_base_url=docker_base_url,
+        timeout_sec=timeout_sec,
+    )
+    if not resolved.available:
+        filter_event.decision = FilterDecision.NEEDS_HUMAN_REVIEW
+        filter_event.reason = resolved.reason
+        filter_event.reason_code = FilterReasonCode.SANDBOX_UNAVAILABLE
+        filter_event.target_type = FilterTargetType.RUNTIME
+        sandbox_run.status = SandboxStatus.NEEDS_HUMAN_REVIEW
+        sandbox_run.stderr = resolved.reason
+        sandbox_run.error_type = "RuntimeUnavailable"
+        result = _failure_result(resolved.reason)
+        _write_json(output_file, result)
+        return sandbox_run, [filter_event], result
+    if resolved.adapter is not None:
+        try:
+            adapter_run, result = resolved.adapter.run_rule_script(
+                task_id,
+                input_file,
+                manifest_file,
+                output_file,
+                timeout_sec,
+                output_limit_bytes,
+            )
+            adapter_run.command = filter_event.command
+            adapter_run.timeout_sec = timeout_sec
+            adapter_run.output_limit_bytes = output_limit_bytes
+            result = redact_mapping(result)
+            _write_json(output_file, result)
+            return adapter_run, [filter_event], result
+        except _RuntimeUnavailableError as ex:
+            filter_event.decision = FilterDecision.NEEDS_HUMAN_REVIEW
+            filter_event.reason = redact_text(str(ex))
+            filter_event.reason_code = FilterReasonCode.SANDBOX_UNAVAILABLE
+            filter_event.target_type = FilterTargetType.RUNTIME
+            sandbox_run.status = SandboxStatus.NEEDS_HUMAN_REVIEW
+            sandbox_run.stderr = filter_event.reason
+            sandbox_run.error_type = "RuntimeUnavailable"
+            result = _failure_result(str(ex))
+            _write_json(output_file, result)
+            return sandbox_run, [filter_event], result
+        except Exception as ex:  # pragma: no cover - defensive optional adapter boundary
+            sandbox_run.status = SandboxStatus.FAILED
+            sandbox_run.stderr = redact_text(str(ex))
+            sandbox_run.error_type = type(ex).__name__
+            result = _failure_result(str(ex))
+            _write_json(output_file, result)
+            return sandbox_run, [filter_event], result
+    sandbox_run.status = SandboxStatus.NEEDS_HUMAN_REVIEW
+    sandbox_run.stderr = "runtime is not connected in this example"
+    result = _failure_result(sandbox_run.stderr)
+    _write_json(output_file, result)
+    return sandbox_run, [filter_event], result
+
+
+def _run_dry(
+    input_file: Path,
+    manifest_file: Path,
+    output_file: Path,
+    sandbox_run: SandboxRun,
+    filter_event: FilterEvent,
+    timeout_sec: float,
+    output_limit_bytes: int,
+) -> tuple[SandboxRun, list[FilterEvent], dict[str, Any]]:
+    started = time.monotonic()
+    try:
+        result = _load_rule_runner_module().run(input_file, manifest_file)
+        result = redact_mapping(result)
+        _write_json(output_file, result)
+        sandbox_run.stdout, sandbox_run.stdout_truncated = _truncate(json.dumps(result, ensure_ascii=True),
+                                                                     output_limit_bytes)
+        sandbox_run.exit_code = 0
+        sandbox_run.status = SandboxStatus.SUCCESS
+    except Exception as ex:  # pragma: no cover - defensive artifact conversion
+        result = _failure_result(str(ex))
+        _write_json(output_file, result)
+        sandbox_run.status = SandboxStatus.FAILED
+        sandbox_run.exit_code = 1
+        sandbox_run.stderr = redact_text(str(ex))
+        sandbox_run.error_type = type(ex).__name__
+    sandbox_run.duration_ms = int((time.monotonic() - started) * 1000)
+    sandbox_run.timeout_sec = timeout_sec
+    return sandbox_run, [filter_event], result
+
+
+def _run_local(
+    command: list[str],
+    output_file: Path,
+    sandbox_run: SandboxRun,
+    filter_event: FilterEvent,
+    timeout_sec: float,
+    output_limit_bytes: int,
+) -> tuple[SandboxRun, list[FilterEvent], dict[str, Any]]:
+    started = time.monotonic()
+    try:
+        completed = subprocess.run(
+            command,
+            check=False,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=timeout_sec,
+        )
+        stdout, stdout_truncated = _truncate(redact_text(completed.stdout), output_limit_bytes)
+        stderr, stderr_truncated = _truncate(redact_text(completed.stderr), output_limit_bytes)
+        sandbox_run.stdout = stdout
+        sandbox_run.stderr = stderr
+        sandbox_run.stdout_truncated = stdout_truncated
+        sandbox_run.stderr_truncated = stderr_truncated
+        sandbox_run.exit_code = completed.returncode
+        sandbox_run.status = SandboxStatus.SUCCESS if completed.returncode == 0 else SandboxStatus.FAILED
+        sandbox_run.error_type = "" if completed.returncode == 0 else "CommandFailed"
+    except subprocess.TimeoutExpired as ex:
+        stdout, stdout_truncated = _truncate(redact_text((ex.stdout or "") if isinstance(ex.stdout, str) else ""),
+                                             output_limit_bytes)
+        stderr, stderr_truncated = _truncate(redact_text((ex.stderr or "") if isinstance(ex.stderr, str) else ""),
+                                             output_limit_bytes)
+        sandbox_run.stdout = stdout
+        sandbox_run.stderr = stderr or f"Command timed out after {timeout_sec:g}s"
+        sandbox_run.stdout_truncated = stdout_truncated
+        sandbox_run.stderr_truncated = stderr_truncated
+        sandbox_run.status = SandboxStatus.TIMEOUT
+        sandbox_run.exit_code = None
+        sandbox_run.error_type = "TimeoutExpired"
+        _write_json(output_file, _failure_result(sandbox_run.stderr))
+    except OSError as ex:
+        sandbox_run.status = SandboxStatus.FAILED
+        sandbox_run.exit_code = None
+        sandbox_run.stderr = redact_text(str(ex))
+        sandbox_run.error_type = type(ex).__name__
+        _write_json(output_file, _failure_result(str(ex)))
+    sandbox_run.duration_ms = int((time.monotonic() - started) * 1000)
+    if output_file.is_file() and sandbox_run.status is SandboxStatus.SUCCESS:
+        try:
+            result = redact_mapping(json.loads(output_file.read_text(encoding="utf-8")))
+            _write_json(output_file, result)
+        except (OSError, json.JSONDecodeError) as ex:
+            result = _failure_result(f"rule result could not be read: {ex}")
+            sandbox_run.status = SandboxStatus.FAILED
+            sandbox_run.error_type = type(ex).__name__
+    else:
+        result = _failure_result(sandbox_run.stderr)
+    return sandbox_run, [filter_event], result
+
+
+def _load_rule_runner_module():
+    import importlib.util
+
+    script_path = Path(__file__).parents[1] / "skills" / "code-review" / "scripts" / "rule_runner.py"
+    spec = importlib.util.spec_from_file_location("skills_code_review_rule_runner", script_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"unable to load rule runner: {script_path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(redact_mapping(payload), ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+                    encoding="utf-8")

--- a/examples/skills_code_review_agent/agent/sandbox.py
+++ b/examples/skills_code_review_agent/agent/sandbox.py
@@ -48,7 +48,7 @@ def run_rule_script(
     """Run or simulate the bundled rule runner under example governance."""
     input_file = Path(input_path).expanduser().resolve()
     manifest_file = Path(manifest_path).expanduser().resolve()
-    output_file = Path(output_path).expanduser().resolve()
+    output_file = Path(output_path).expanduser().resolve(strict=False)
     script_path = Path(__file__).parents[1] / "skills" / "code-review" / "scripts" / "rule_runner.py"
     command = [
         sys.executable,
@@ -69,6 +69,7 @@ def run_rule_script(
         allow_local=allow_local,
         script_path=str(script_path),
         allowed_roots=(str(Path(__file__).parents[1]), str(output_file.parent)),
+        referenced_paths=(str(input_file), str(manifest_file), str(output_file)),
         metadata={
             "input": str(input_file),
             "manifest": str(manifest_file),

--- a/examples/skills_code_review_agent/agent/sandbox_workspace.py
+++ b/examples/skills_code_review_agent/agent/sandbox_workspace.py
@@ -11,6 +11,7 @@ import asyncio
 import json
 import threading
 import time
+from collections.abc import Callable
 from collections.abc import Coroutine
 from dataclasses import dataclass
 from pathlib import Path
@@ -57,7 +58,6 @@ class _WorkspaceRuntimeAdapter:
 
     runtime: RuntimeKind
     workspace_runtime: Any
-    cube_client: Any = None
 
     def run_rule_script(
         self,
@@ -68,21 +68,43 @@ class _WorkspaceRuntimeAdapter:
         timeout_sec: float,
         output_limit_bytes: int,
     ) -> tuple[SandboxRun, dict[str, Any]]:
-        try:
-            return _run_async(
-                self._run_rule_script_async(
-                    task_id,
-                    input_path,
-                    manifest_path,
-                    timeout_sec,
-                    output_limit_bytes,
-                ))
-        finally:
-            if self.cube_client is not None:
-                try:
-                    _run_async(self.cube_client.destroy())
-                except Exception:
-                    pass
+        return _run_async(
+            _run_workspace_rule_script_async(
+                self.workspace_runtime,
+                self.runtime,
+                task_id,
+                input_path,
+                manifest_path,
+                timeout_sec,
+                output_limit_bytes,
+            ))
+
+
+@dataclass
+class _CubeWorkspaceRuntimeAdapter:
+    """Create and use the Cube client inside one async lifecycle."""
+
+    runtime: RuntimeKind
+    client_factory: Callable[[], Coroutine[Any, Any, Any]]
+    runtime_factory: Callable[[Any], Any]
+
+    def run_rule_script(
+        self,
+        task_id: str,
+        input_path: Path,
+        manifest_path: Path,
+        output_path: Path,
+        timeout_sec: float,
+        output_limit_bytes: int,
+    ) -> tuple[SandboxRun, dict[str, Any]]:
+        return _run_async(
+            self._run_rule_script_async(
+                task_id,
+                input_path,
+                manifest_path,
+                timeout_sec,
+                output_limit_bytes,
+            ))
 
     async def _run_rule_script_async(
         self,
@@ -92,61 +114,122 @@ class _WorkspaceRuntimeAdapter:
         timeout_sec: float,
         output_limit_bytes: int,
     ) -> tuple[SandboxRun, dict[str, Any]]:
-        from trpc_agent_sdk.code_executors import WorkspaceOutputSpec
-        from trpc_agent_sdk.code_executors import WorkspaceRunProgramSpec
-
-        exec_id = f"{task_id}-{int(time.time() * 1000)}"
-        command = ("python3 skills/code-review/scripts/rule_runner.py --input inputs/parsed_input.json "
-                   "--manifest inputs/skill_manifest.json --output outputs/rule_result.json")
-        sandbox_run = SandboxRun(
-            task_id=task_id,
-            runtime=self.runtime,
-            command=command,
-            timeout_sec=timeout_sec,
-            output_limit_bytes=output_limit_bytes,
-        )
-        started = time.monotonic()
-        workspace = None
+        client = None
+        outcome: tuple[SandboxRun, dict[str, Any]] | None = None
         try:
-            manager = self.workspace_runtime.manager()
-            fs = self.workspace_runtime.fs()
-            runner = self.workspace_runtime.runner()
-            workspace = await manager.create_workspace(exec_id)
-            await fs.put_files(workspace, _workspace_bundle(input_path, manifest_path))
-            run_result = await runner.run_program(
-                workspace,
-                WorkspaceRunProgramSpec(
-                    cmd="python3",
-                    args=[
-                        "skills/code-review/scripts/rule_runner.py",
-                        "--input",
-                        "inputs/parsed_input.json",
-                        "--manifest",
-                        "inputs/skill_manifest.json",
-                        "--output",
-                        "outputs/rule_result.json",
-                    ],
-                    cwd="work",
-                    timeout=timeout_sec,
-                    env={"PYTHONPATH": "."},
-                ),
+            client = await self.client_factory()
+            workspace_runtime = self.runtime_factory(client)
+            outcome = await _run_workspace_rule_script_async(
+                workspace_runtime,
+                self.runtime,
+                task_id,
+                input_path,
+                manifest_path,
+                timeout_sec,
+                output_limit_bytes,
             )
-            sandbox_run.exit_code = run_result.exit_code
-            sandbox_run.duration_ms = int(run_result.duration * 1000) if run_result.duration else int(
-                (time.monotonic() - started) * 1000)
-            sandbox_run.stdout, sandbox_run.stdout_truncated = _truncate(redact_text(run_result.stdout),
-                                                                         output_limit_bytes)
-            sandbox_run.stderr, sandbox_run.stderr_truncated = _truncate(redact_text(run_result.stderr),
-                                                                         output_limit_bytes)
-            if run_result.timed_out:
-                sandbox_run.status = SandboxStatus.TIMEOUT
-                sandbox_run.error_type = "TimeoutExpired"
-                return sandbox_run, _failure_result(sandbox_run.stderr or f"Command timed out after {timeout_sec:g}s")
-            if run_result.exit_code != 0:
-                sandbox_run.status = SandboxStatus.FAILED
-                sandbox_run.error_type = "CommandFailed"
-                return sandbox_run, _failure_result(sandbox_run.stderr or sandbox_run.stdout)
+        except Exception as ex:
+            if client is None:
+                raise _RuntimeUnavailableError(f"cube runtime is unavailable: {type(ex).__name__}: {ex}") from ex
+            sandbox_run = SandboxRun(
+                task_id=task_id,
+                runtime=self.runtime,
+                command="python3 skills/code-review/scripts/rule_runner.py",
+                timeout_sec=timeout_sec,
+                output_limit_bytes=output_limit_bytes,
+                status=SandboxStatus.FAILED,
+                stderr=redact_text(str(ex)),
+                error_type=type(ex).__name__,
+            )
+            outcome = sandbox_run, _failure_result(str(ex))
+        finally:
+            if client is not None:
+                try:
+                    await client.destroy()
+                except Exception as ex:
+                    if outcome is None:
+                        raise _RuntimeUnavailableError(
+                            f"cube runtime cleanup failed: {type(ex).__name__}: {ex}") from ex
+                    sandbox_run, result = outcome
+                    if sandbox_run.status is SandboxStatus.SUCCESS:
+                        sandbox_run.status = SandboxStatus.FAILED
+                        sandbox_run.error_type = "ClientDestroyFailed"
+                    if sandbox_run.stderr:
+                        sandbox_run.stderr = f"{sandbox_run.stderr}; {redact_text(str(ex))}"
+                    else:
+                        sandbox_run.stderr = redact_text(str(ex))
+                    outcome = sandbox_run, result
+        if outcome is None:  # pragma: no cover - defensive lifecycle guard
+            raise _RuntimeUnavailableError("cube runtime did not return a result")
+        return outcome
 
+
+async def _run_workspace_rule_script_async(
+    workspace_runtime: Any,
+    runtime: RuntimeKind,
+    task_id: str,
+    input_path: Path,
+    manifest_path: Path,
+    timeout_sec: float,
+    output_limit_bytes: int,
+) -> tuple[SandboxRun, dict[str, Any]]:
+    """Execute a rule script and clean up its workspace in the same loop."""
+    from trpc_agent_sdk.code_executors import WorkspaceOutputSpec
+    from trpc_agent_sdk.code_executors import WorkspaceRunProgramSpec
+
+    exec_id = f"{task_id}-{int(time.time() * 1000)}"
+    command = ("python3 skills/code-review/scripts/rule_runner.py --input inputs/parsed_input.json "
+               "--manifest inputs/skill_manifest.json --output outputs/rule_result.json")
+    sandbox_run = SandboxRun(
+        task_id=task_id,
+        runtime=runtime,
+        command=command,
+        timeout_sec=timeout_sec,
+        output_limit_bytes=output_limit_bytes,
+    )
+    started = time.monotonic()
+    workspace = None
+    workspace_creation_started = False
+    result = _failure_result("")
+    try:
+        manager = workspace_runtime.manager()
+        fs = workspace_runtime.fs()
+        runner = workspace_runtime.runner()
+        workspace_creation_started = True
+        workspace = await manager.create_workspace(exec_id)
+        await fs.put_files(workspace, _workspace_bundle(input_path, manifest_path))
+        run_result = await runner.run_program(
+            workspace,
+            WorkspaceRunProgramSpec(
+                cmd="python3",
+                args=[
+                    "skills/code-review/scripts/rule_runner.py",
+                    "--input",
+                    "inputs/parsed_input.json",
+                    "--manifest",
+                    "inputs/skill_manifest.json",
+                    "--output",
+                    "outputs/rule_result.json",
+                ],
+                cwd="work",
+                timeout=timeout_sec,
+                env={"PYTHONPATH": "."},
+            ),
+        )
+        sandbox_run.exit_code = run_result.exit_code
+        sandbox_run.duration_ms = int(run_result.duration * 1000) if run_result.duration else int(
+            (time.monotonic() - started) * 1000)
+        sandbox_run.stdout, sandbox_run.stdout_truncated = _truncate(redact_text(run_result.stdout), output_limit_bytes)
+        sandbox_run.stderr, sandbox_run.stderr_truncated = _truncate(redact_text(run_result.stderr), output_limit_bytes)
+        if run_result.timed_out:
+            sandbox_run.status = SandboxStatus.TIMEOUT
+            sandbox_run.error_type = "TimeoutExpired"
+            result = _failure_result(sandbox_run.stderr or f"Command timed out after {timeout_sec:g}s")
+        elif run_result.exit_code != 0:
+            sandbox_run.status = SandboxStatus.FAILED
+            sandbox_run.error_type = "CommandFailed"
+            result = _failure_result(sandbox_run.stderr or sandbox_run.stdout)
+        else:
             manifest = await fs.collect_outputs(
                 workspace,
                 WorkspaceOutputSpec(
@@ -160,29 +243,36 @@ class _WorkspaceRuntimeAdapter:
             if not manifest.files:
                 sandbox_run.status = SandboxStatus.FAILED
                 sandbox_run.error_type = "MissingOutput"
-                return sandbox_run, _failure_result("workspace rule_result.json was not collected")
-            if manifest.limits_hit:
+                result = _failure_result("workspace rule_result.json was not collected")
+            elif manifest.limits_hit:
                 sandbox_run.status = SandboxStatus.FAILED
                 sandbox_run.error_type = "OutputLimitExceeded"
-                return sandbox_run, _failure_result("workspace output collection hit configured limits")
-            try:
-                result = redact_mapping(json.loads(manifest.files[0].content or "{}"))
-            except json.JSONDecodeError as ex:
-                sandbox_run.status = SandboxStatus.FAILED
-                sandbox_run.error_type = "InvalidOutput"
-                return sandbox_run, _failure_result(f"workspace rule_result.json is invalid JSON: {ex}")
-            sandbox_run.status = SandboxStatus.SUCCESS
-            return sandbox_run, result
-        finally:
-            sandbox_run.duration_ms = sandbox_run.duration_ms or int((time.monotonic() - started) * 1000)
-            if workspace is not None:
+                result = _failure_result("workspace output collection hit configured limits")
+            else:
                 try:
-                    await self.workspace_runtime.manager().cleanup(exec_id)
-                except Exception as ex:  # pragma: no cover - backend cleanup is best effort
-                    if sandbox_run.status is SandboxStatus.SUCCESS:
-                        sandbox_run.status = SandboxStatus.FAILED
-                        sandbox_run.error_type = type(ex).__name__
-                        sandbox_run.stderr = redact_text(str(ex))
+                    result = redact_mapping(json.loads(manifest.files[0].content or "{}"))
+                    sandbox_run.status = SandboxStatus.SUCCESS
+                except json.JSONDecodeError as ex:
+                    sandbox_run.status = SandboxStatus.FAILED
+                    sandbox_run.error_type = "InvalidOutput"
+                    result = _failure_result(f"workspace rule_result.json is invalid JSON: {ex}")
+    except Exception as ex:
+        sandbox_run.status = SandboxStatus.FAILED
+        sandbox_run.error_type = type(ex).__name__
+        sandbox_run.stderr = redact_text(str(ex))
+        result = _failure_result(str(ex))
+    finally:
+        sandbox_run.duration_ms = sandbox_run.duration_ms or int((time.monotonic() - started) * 1000)
+        if workspace_creation_started:
+            try:
+                await workspace_runtime.manager().cleanup(exec_id)
+            except Exception as ex:  # pragma: no cover - backend cleanup is best effort
+                cleanup_error = redact_text(str(ex))
+                if sandbox_run.status is SandboxStatus.SUCCESS:
+                    sandbox_run.status = SandboxStatus.FAILED
+                    sandbox_run.error_type = "CleanupFailed"
+                sandbox_run.stderr = f"{sandbox_run.stderr}; {cleanup_error}".strip("; ")
+    return sandbox_run, result
 
 
 def _resolve_runtime_adapter(
@@ -231,21 +321,26 @@ def _probe_cube_runtime(*, timeout_sec: float) -> _RuntimeAdapterResult:
         cfg.resolve_template()
         cfg.resolve_api_url()
         cfg.resolve_api_key()
-        client = _run_async(create_cube_sandbox_client(cfg))
-        runtime = create_cube_workspace_runtime(
-            sandbox_client=client,
-            execute_timeout=timeout_sec,
-            workspace_cfg=CubeWorkspaceRuntimeConfig(),
-        )
     except Exception as ex:  # pragma: no cover - depends on optional local environment
         return _RuntimeAdapterResult(
             runtime=RuntimeKind.CUBE,
             available=False,
             reason=f"cube runtime is unavailable: {type(ex).__name__}: {ex}",
         )
+
+    async def create_client() -> Any:
+        return await create_cube_sandbox_client(cfg)
+
+    def create_runtime(client: Any) -> Any:
+        return create_cube_workspace_runtime(
+            sandbox_client=client,
+            execute_timeout=timeout_sec,
+            workspace_cfg=CubeWorkspaceRuntimeConfig(),
+        )
+
     return _RuntimeAdapterResult(runtime=RuntimeKind.CUBE,
                                  available=True,
-                                 adapter=_WorkspaceRuntimeAdapter(RuntimeKind.CUBE, runtime, cube_client=client))
+                                 adapter=_CubeWorkspaceRuntimeAdapter(RuntimeKind.CUBE, create_client, create_runtime))
 
 
 def _workspace_bundle(input_path: Path, manifest_path: Path) -> list[Any]:

--- a/examples/skills_code_review_agent/agent/sandbox_workspace.py
+++ b/examples/skills_code_review_agent/agent/sandbox_workspace.py
@@ -1,0 +1,313 @@
+# Tencent is pleased to support the open source community by making tRPC-Agent-Python available.
+#
+# Copyright (C) 2026 Tencent. All rights reserved.
+#
+# tRPC-Agent-Python is licensed under Apache-2.0.
+"""SDK workspace runtime adapters for the code-review sandbox."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import threading
+import time
+from collections.abc import Coroutine
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from typing import Protocol
+
+from .models import RuntimeKind
+from .models import SandboxRun
+from .models import SandboxStatus
+from .sanitizer import redact_mapping
+from .sanitizer import redact_text
+
+
+class _RuntimeAdapter(Protocol):
+    runtime: RuntimeKind
+
+    def run_rule_script(
+        self,
+        task_id: str,
+        input_path: Path,
+        manifest_path: Path,
+        output_path: Path,
+        timeout_sec: float,
+        output_limit_bytes: int,
+    ) -> tuple[SandboxRun, dict[str, Any]]:
+        """Run the bundled rule script and return a sandbox record plus result."""
+
+
+@dataclass(frozen=True)
+class _RuntimeAdapterResult:
+    runtime: RuntimeKind
+    available: bool
+    reason: str = ""
+    adapter: _RuntimeAdapter | None = None
+
+
+class _RuntimeUnavailableError(RuntimeError):
+    """Raised when an optional workspace backend cannot be reached."""
+
+
+@dataclass
+class _WorkspaceRuntimeAdapter:
+    """Run the rule script through an SDK workspace runtime."""
+
+    runtime: RuntimeKind
+    workspace_runtime: Any
+    cube_client: Any = None
+
+    def run_rule_script(
+        self,
+        task_id: str,
+        input_path: Path,
+        manifest_path: Path,
+        output_path: Path,
+        timeout_sec: float,
+        output_limit_bytes: int,
+    ) -> tuple[SandboxRun, dict[str, Any]]:
+        try:
+            return _run_async(
+                self._run_rule_script_async(
+                    task_id,
+                    input_path,
+                    manifest_path,
+                    timeout_sec,
+                    output_limit_bytes,
+                ))
+        finally:
+            if self.cube_client is not None:
+                try:
+                    _run_async(self.cube_client.destroy())
+                except Exception:
+                    pass
+
+    async def _run_rule_script_async(
+        self,
+        task_id: str,
+        input_path: Path,
+        manifest_path: Path,
+        timeout_sec: float,
+        output_limit_bytes: int,
+    ) -> tuple[SandboxRun, dict[str, Any]]:
+        from trpc_agent_sdk.code_executors import WorkspaceOutputSpec
+        from trpc_agent_sdk.code_executors import WorkspaceRunProgramSpec
+
+        exec_id = f"{task_id}-{int(time.time() * 1000)}"
+        command = ("python3 skills/code-review/scripts/rule_runner.py --input inputs/parsed_input.json "
+                   "--manifest inputs/skill_manifest.json --output outputs/rule_result.json")
+        sandbox_run = SandboxRun(
+            task_id=task_id,
+            runtime=self.runtime,
+            command=command,
+            timeout_sec=timeout_sec,
+            output_limit_bytes=output_limit_bytes,
+        )
+        started = time.monotonic()
+        workspace = None
+        try:
+            manager = self.workspace_runtime.manager()
+            fs = self.workspace_runtime.fs()
+            runner = self.workspace_runtime.runner()
+            workspace = await manager.create_workspace(exec_id)
+            await fs.put_files(workspace, _workspace_bundle(input_path, manifest_path))
+            run_result = await runner.run_program(
+                workspace,
+                WorkspaceRunProgramSpec(
+                    cmd="python3",
+                    args=[
+                        "skills/code-review/scripts/rule_runner.py",
+                        "--input",
+                        "inputs/parsed_input.json",
+                        "--manifest",
+                        "inputs/skill_manifest.json",
+                        "--output",
+                        "outputs/rule_result.json",
+                    ],
+                    cwd="work",
+                    timeout=timeout_sec,
+                    env={"PYTHONPATH": "."},
+                ),
+            )
+            sandbox_run.exit_code = run_result.exit_code
+            sandbox_run.duration_ms = int(run_result.duration * 1000) if run_result.duration else int(
+                (time.monotonic() - started) * 1000)
+            sandbox_run.stdout, sandbox_run.stdout_truncated = _truncate(redact_text(run_result.stdout),
+                                                                         output_limit_bytes)
+            sandbox_run.stderr, sandbox_run.stderr_truncated = _truncate(redact_text(run_result.stderr),
+                                                                         output_limit_bytes)
+            if run_result.timed_out:
+                sandbox_run.status = SandboxStatus.TIMEOUT
+                sandbox_run.error_type = "TimeoutExpired"
+                return sandbox_run, _failure_result(sandbox_run.stderr or f"Command timed out after {timeout_sec:g}s")
+            if run_result.exit_code != 0:
+                sandbox_run.status = SandboxStatus.FAILED
+                sandbox_run.error_type = "CommandFailed"
+                return sandbox_run, _failure_result(sandbox_run.stderr or sandbox_run.stdout)
+
+            manifest = await fs.collect_outputs(
+                workspace,
+                WorkspaceOutputSpec(
+                    globs=["work/outputs/rule_result.json"],
+                    max_files=1,
+                    max_file_bytes=output_limit_bytes,
+                    max_total_bytes=output_limit_bytes,
+                    inline=True,
+                ),
+            )
+            if not manifest.files:
+                sandbox_run.status = SandboxStatus.FAILED
+                sandbox_run.error_type = "MissingOutput"
+                return sandbox_run, _failure_result("workspace rule_result.json was not collected")
+            if manifest.limits_hit:
+                sandbox_run.status = SandboxStatus.FAILED
+                sandbox_run.error_type = "OutputLimitExceeded"
+                return sandbox_run, _failure_result("workspace output collection hit configured limits")
+            try:
+                result = redact_mapping(json.loads(manifest.files[0].content or "{}"))
+            except json.JSONDecodeError as ex:
+                sandbox_run.status = SandboxStatus.FAILED
+                sandbox_run.error_type = "InvalidOutput"
+                return sandbox_run, _failure_result(f"workspace rule_result.json is invalid JSON: {ex}")
+            sandbox_run.status = SandboxStatus.SUCCESS
+            return sandbox_run, result
+        finally:
+            sandbox_run.duration_ms = sandbox_run.duration_ms or int((time.monotonic() - started) * 1000)
+            if workspace is not None:
+                try:
+                    await self.workspace_runtime.manager().cleanup(exec_id)
+                except Exception as ex:  # pragma: no cover - backend cleanup is best effort
+                    if sandbox_run.status is SandboxStatus.SUCCESS:
+                        sandbox_run.status = SandboxStatus.FAILED
+                        sandbox_run.error_type = type(ex).__name__
+                        sandbox_run.stderr = redact_text(str(ex))
+
+
+def _resolve_runtime_adapter(
+    runtime: RuntimeKind,
+    *,
+    container_image: str = "python:3-slim",
+    docker_base_url: str = "",
+    timeout_sec: float = 30.0,
+) -> _RuntimeAdapterResult:
+    if runtime in {RuntimeKind.DRY_RUN, RuntimeKind.LOCAL_DEV}:
+        return _RuntimeAdapterResult(runtime=runtime, available=True)
+    if runtime is RuntimeKind.CONTAINER:
+        return _probe_container_runtime(container_image=container_image, docker_base_url=docker_base_url)
+    if runtime is RuntimeKind.CUBE:
+        return _probe_cube_runtime(timeout_sec=timeout_sec)
+    return _RuntimeAdapterResult(runtime=runtime, available=False, reason=f"unsupported runtime: {runtime.value}")
+
+
+def _probe_container_runtime(*, container_image: str, docker_base_url: str = "") -> _RuntimeAdapterResult:
+    try:
+        from trpc_agent_sdk.code_executors import create_container_workspace_runtime
+        from trpc_agent_sdk.code_executors.container import ContainerConfig
+        runtime = create_container_workspace_runtime(
+            container_config=ContainerConfig(base_url=docker_base_url or None, image=container_image),
+            host_config={"network_mode": "none"},
+            auto_inputs=False,
+        )
+    except Exception as ex:  # pragma: no cover - depends on optional local environment
+        return _RuntimeAdapterResult(
+            runtime=RuntimeKind.CONTAINER,
+            available=False,
+            reason=f"container runtime is unavailable: {type(ex).__name__}: {ex}",
+        )
+    return _RuntimeAdapterResult(runtime=RuntimeKind.CONTAINER,
+                                 available=True,
+                                 adapter=_WorkspaceRuntimeAdapter(RuntimeKind.CONTAINER, runtime))
+
+
+def _probe_cube_runtime(*, timeout_sec: float) -> _RuntimeAdapterResult:
+    try:
+        from trpc_agent_sdk.code_executors.cube import CubeClientConfig
+        from trpc_agent_sdk.code_executors.cube import CubeWorkspaceRuntimeConfig
+        from trpc_agent_sdk.code_executors.cube import create_cube_sandbox_client
+        from trpc_agent_sdk.code_executors.cube import create_cube_workspace_runtime
+        cfg = CubeClientConfig(auto_recover=True, execute_timeout=timeout_sec)
+        cfg.resolve_template()
+        cfg.resolve_api_url()
+        cfg.resolve_api_key()
+        client = _run_async(create_cube_sandbox_client(cfg))
+        runtime = create_cube_workspace_runtime(
+            sandbox_client=client,
+            execute_timeout=timeout_sec,
+            workspace_cfg=CubeWorkspaceRuntimeConfig(),
+        )
+    except Exception as ex:  # pragma: no cover - depends on optional local environment
+        return _RuntimeAdapterResult(
+            runtime=RuntimeKind.CUBE,
+            available=False,
+            reason=f"cube runtime is unavailable: {type(ex).__name__}: {ex}",
+        )
+    return _RuntimeAdapterResult(runtime=RuntimeKind.CUBE,
+                                 available=True,
+                                 adapter=_WorkspaceRuntimeAdapter(RuntimeKind.CUBE, runtime, cube_client=client))
+
+
+def _workspace_bundle(input_path: Path, manifest_path: Path) -> list[Any]:
+    from trpc_agent_sdk.code_executors import WorkspacePutFileInfo
+
+    example_root = Path(__file__).parents[1]
+    rule_runner_path = example_root / "skills" / "code-review" / "scripts" / "rule_runner.py"
+    return [
+        WorkspacePutFileInfo(path="work/agent/__init__.py", content=b"", mode=0o644),
+        WorkspacePutFileInfo(
+            path="work/agent/models.py",
+            content=(example_root / "agent" / "models.py").read_bytes(),
+            mode=0o644,
+        ),
+        WorkspacePutFileInfo(path="work/agent/review_rules.py",
+                             content=(example_root / "agent" / "review_rules.py").read_bytes(),
+                             mode=0o644),
+        WorkspacePutFileInfo(path="work/agent/sanitizer.py",
+                             content=(example_root / "agent" / "sanitizer.py").read_bytes(),
+                             mode=0o644),
+        WorkspacePutFileInfo(path="work/skills/code-review/scripts/rule_runner.py",
+                             content=rule_runner_path.read_bytes(),
+                             mode=0o755),
+        WorkspacePutFileInfo(path="work/inputs/parsed_input.json", content=input_path.read_bytes(), mode=0o600),
+        WorkspacePutFileInfo(path="work/inputs/skill_manifest.json", content=manifest_path.read_bytes(), mode=0o600),
+    ]
+
+
+def _run_async(coro: Coroutine[Any, Any, Any]) -> Any:
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(coro)
+
+    box: dict[str, Any] = {}
+
+    def runner() -> None:
+        try:
+            box["result"] = asyncio.run(coro)
+        except BaseException as ex:  # pragma: no cover - only used from async callers
+            box["error"] = ex
+
+    thread = threading.Thread(target=runner, daemon=True)
+    thread.start()
+    thread.join()
+    if "error" in box:
+        raise box["error"]
+    return box.get("result")
+
+
+def _truncate(text: str, limit: int) -> tuple[str, bool]:
+    encoded = text.encode("utf-8")
+    if len(encoded) <= limit:
+        return text, False
+    trimmed = encoded[:limit].decode("utf-8", errors="ignore")
+    return trimmed, True
+
+
+def _failure_result(message: str) -> dict[str, Any]:
+    return {
+        "schema_version": "code-review.rules.v1",
+        "skill_name": "code-review",
+        "findings": [],
+        "diagnostics": [redact_text(message)],
+    }

--- a/examples/skills_code_review_agent/agent/sanitizer.py
+++ b/examples/skills_code_review_agent/agent/sanitizer.py
@@ -20,6 +20,7 @@ _ASSIGNMENT_RE = re.compile(
     r"(?i)\b(?P<key>[A-Za-z0-9_.-]*(?:api[_-]?key|secret|token|password|passwd|pwd)[A-Za-z0-9_.-]*)"
     r"(?P<sep>\s*[:=]\s*)"
     r"(?P<quote>['\"]?)"
+    r"(?!\[REDACTED\])"
     r"(?P<value>[^'\"\s,;)}\]]{4,})"
     r"(?P=quote)")
 _URL_PASSWORD_RE = re.compile(r"(?P<prefix>[a-z][a-z0-9+.-]*://[^:\s/@]+:)(?P<password>[^@\s/]+)(?P<suffix>@)",

--- a/examples/skills_code_review_agent/agent/sanitizer.py
+++ b/examples/skills_code_review_agent/agent/sanitizer.py
@@ -24,6 +24,7 @@ _ASSIGNMENT_RE = re.compile(
     r"(?P=quote)")
 _URL_PASSWORD_RE = re.compile(r"(?P<prefix>[a-z][a-z0-9+.-]*://[^:\s/@]+:)(?P<password>[^@\s/]+)(?P<suffix>@)",
                               re.IGNORECASE)
+_JWT_RE = re.compile(r"\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\b")
 _TOKEN_LITERAL_RE = re.compile(
     r"\b(?:sk-[A-Za-z0-9_-]{8,}|pk-[A-Za-z0-9_-]{8,}|ghp_[A-Za-z0-9_]{8,}|gho_[A-Za-z0-9_]{8,}|"
     r"github_pat_[A-Za-z0-9_]{8,}|xox[bp]-[A-Za-z0-9-]{8,}|AKIA[0-9A-Z]{16}|ASIA[0-9A-Z]{16})\b")
@@ -35,6 +36,7 @@ def redact_text(text: str) -> str:
     redacted = _BEARER_RE.sub(f"Bearer {_REDACTED}", redacted)
     redacted = _URL_PASSWORD_RE.sub(lambda match: f"{match.group('prefix')}{_REDACTED}{match.group('suffix')}",
                                     redacted)
+    redacted = _JWT_RE.sub(_REDACTED, redacted)
     redacted = _ASSIGNMENT_RE.sub(lambda match: f"{match.group('key')}{match.group('sep')}{_REDACTED}", redacted)
     return _TOKEN_LITERAL_RE.sub(_REDACTED, redacted)
 

--- a/examples/skills_code_review_agent/agent/sanitizer.py
+++ b/examples/skills_code_review_agent/agent/sanitizer.py
@@ -1,0 +1,52 @@
+# Tencent is pleased to support the open source community by making tRPC-Agent-Python available.
+#
+# Copyright (C) 2026 Tencent. All rights reserved.
+#
+# tRPC-Agent-Python is licensed under Apache-2.0.
+"""Redaction helpers for review findings and execution artifacts."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+_REDACTED = "[REDACTED]"
+_PRIVATE_KEY_RE = re.compile(
+    r"-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----.*?-----END [A-Z0-9 ]*PRIVATE KEY-----",
+    re.DOTALL,
+)
+_BEARER_RE = re.compile(r"(?i)\bBearer\s+[A-Za-z0-9._~+/=-]{8,}")
+_ASSIGNMENT_RE = re.compile(
+    r"(?i)\b(?P<key>[A-Za-z0-9_.-]*(?:api[_-]?key|secret|token|password|passwd|pwd)[A-Za-z0-9_.-]*)"
+    r"(?P<sep>\s*[:=]\s*)"
+    r"(?P<quote>['\"]?)"
+    r"(?P<value>[^'\"\s,;)}\]]{4,})"
+    r"(?P=quote)")
+_URL_PASSWORD_RE = re.compile(r"(?P<prefix>[a-z][a-z0-9+.-]*://[^:\s/@]+:)(?P<password>[^@\s/]+)(?P<suffix>@)",
+                              re.IGNORECASE)
+_TOKEN_LITERAL_RE = re.compile(
+    r"\b(?:sk-[A-Za-z0-9_-]{8,}|pk-[A-Za-z0-9_-]{8,}|ghp_[A-Za-z0-9_]{8,}|gho_[A-Za-z0-9_]{8,}|"
+    r"github_pat_[A-Za-z0-9_]{8,}|xox[bp]-[A-Za-z0-9-]{8,}|AKIA[0-9A-Z]{16}|ASIA[0-9A-Z]{16})\b")
+
+
+def redact_text(text: str) -> str:
+    """Redact common secret shapes from a text payload."""
+    redacted = _PRIVATE_KEY_RE.sub(_REDACTED, text)
+    redacted = _BEARER_RE.sub(f"Bearer {_REDACTED}", redacted)
+    redacted = _URL_PASSWORD_RE.sub(lambda match: f"{match.group('prefix')}{_REDACTED}{match.group('suffix')}",
+                                    redacted)
+    redacted = _ASSIGNMENT_RE.sub(lambda match: f"{match.group('key')}{match.group('sep')}{_REDACTED}", redacted)
+    return _TOKEN_LITERAL_RE.sub(_REDACTED, redacted)
+
+
+def redact_mapping(value: Any) -> Any:
+    """Recursively redact strings inside JSON-like structures."""
+    if isinstance(value, str):
+        return redact_text(value)
+    if isinstance(value, list):
+        return [redact_mapping(item) for item in value]
+    if isinstance(value, tuple):
+        return [redact_mapping(item) for item in value]
+    if isinstance(value, dict):
+        return {key: redact_mapping(item) for key, item in value.items()}
+    return value

--- a/examples/skills_code_review_agent/agent/skill_loader.py
+++ b/examples/skills_code_review_agent/agent/skill_loader.py
@@ -1,0 +1,189 @@
+# Tencent is pleased to support the open source community by making tRPC-Agent-Python available.
+#
+# Copyright (C) 2026 Tencent. All rights reserved.
+#
+# tRPC-Agent-Python is licensed under Apache-2.0.
+"""Load the example code-review Skill as deterministic local metadata."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import asdict
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+class SkillLoadError(ValueError):
+    """Raised when a local Skill bundle is missing or invalid."""
+
+
+@dataclass(frozen=True)
+class SkillManifest:
+    """Stable resource manifest for a local Skill bundle."""
+
+    name: str
+    description: str
+    root: str
+    skill_md: str
+    rules: list[str]
+    scripts: list[str]
+    docs: list[str]
+    digest: str
+    frontmatter: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable manifest."""
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class LoadedSkill:
+    """A loaded Skill manifest plus readable resources."""
+
+    manifest: SkillManifest
+    body: str
+    resources: dict[str, str]
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable loaded-skill view."""
+        return {
+            "manifest": self.manifest.to_dict(),
+            "body": self.body,
+            "resources": dict(sorted(self.resources.items())),
+        }
+
+
+def load_skill(skill_dir: str | Path) -> LoadedSkill:
+    """Read a Skill bundle without registering or executing it."""
+    root = Path(skill_dir).expanduser().resolve()
+    if not root.is_dir():
+        raise SkillLoadError(f"skill directory not found: {root}")
+    skill_path = root / "SKILL.md"
+    if not skill_path.is_file():
+        raise SkillLoadError(f"SKILL.md not found: {skill_path}")
+
+    frontmatter, body = _parse_skill_markdown(_read_text(skill_path, root))
+    name = str(frontmatter.get("name", "")).strip()
+    description = str(frontmatter.get("description", "")).strip()
+    if not name:
+        raise SkillLoadError("SKILL.md front matter must define a non-empty name")
+    if not description:
+        raise SkillLoadError("SKILL.md front matter must define a non-empty description")
+    if not _is_safe_skill_name(name):
+        raise SkillLoadError(f"invalid skill name: {name!r}")
+    _validate_frontmatter_paths(frontmatter)
+
+    resources = _collect_resources(root)
+    rules = [path for path in resources if path.startswith("rules/") and path.endswith(".md")]
+    scripts = [path for path in resources if path.startswith("scripts/")]
+    docs = [path for path in resources if path.endswith(".md") and path not in {"SKILL.md", *rules}]
+    digest = _compute_digest({"SKILL.md": _read_text(skill_path, root), **resources})
+    manifest = SkillManifest(
+        name=name,
+        description=description,
+        root=str(root),
+        skill_md="SKILL.md",
+        rules=rules,
+        scripts=scripts,
+        docs=docs,
+        digest=digest,
+        frontmatter=frontmatter,
+    )
+    return LoadedSkill(
+        manifest=manifest,
+        body=body.replace("__BASE_DIR__", str(root)),
+        resources={
+            path: content.replace("__BASE_DIR__", str(root))
+            for path, content in resources.items()
+        },
+    )
+
+
+def _parse_skill_markdown(content: str) -> tuple[dict[str, Any], str]:
+    text = content.replace("\r\n", "\n")
+    if not text.startswith("---\n"):
+        raise SkillLoadError("SKILL.md must start with YAML front matter")
+    end = text.find("\n---\n", 4)
+    if end < 0:
+        raise SkillLoadError("SKILL.md front matter is not closed")
+    try:
+        frontmatter = yaml.safe_load(text[4:end]) or {}
+    except yaml.YAMLError as ex:
+        raise SkillLoadError(f"invalid SKILL.md YAML front matter: {ex}") from ex
+    if not isinstance(frontmatter, dict):
+        raise SkillLoadError("SKILL.md front matter must be a mapping")
+    return {str(key): value for key, value in frontmatter.items()}, text[end + 5:]
+
+
+def _collect_resources(root: Path) -> dict[str, str]:
+    resources: dict[str, str] = {}
+    for path in sorted(root.rglob("*")):
+        relative = _relative_resource_path(root, path)
+        if relative is None or relative == "SKILL.md":
+            continue
+        if path.is_dir():
+            continue
+        if relative in resources:
+            raise SkillLoadError(f"duplicate skill resource path: {relative}")
+        resources[relative] = _read_text(path, root)
+    return dict(sorted(resources.items()))
+
+
+def _relative_resource_path(root: Path, path: Path) -> str | None:
+    rel = path.relative_to(root)
+    parts = rel.parts
+    if "__pycache__" in parts or path.suffix in {".pyc", ".pyo"}:
+        return None
+    if any(part.startswith(".") for part in parts):
+        return None
+    if any(part == ".." for part in parts) or rel.is_absolute():
+        raise SkillLoadError(f"unsafe skill resource path: {rel}")
+    _assert_inside(root, path)
+    return rel.as_posix()
+
+
+def _assert_inside(root: Path, path: Path) -> None:
+    try:
+        path.resolve().relative_to(root.resolve())
+    except ValueError as ex:
+        raise SkillLoadError(f"skill resource escapes root: {path}") from ex
+
+
+def _read_text(path: Path, root: Path) -> str:
+    _assert_inside(root, path)
+    try:
+        return path.read_text(encoding="utf-8")
+    except UnicodeDecodeError as ex:
+        raise SkillLoadError(f"skill resource is not UTF-8 text: {path}") from ex
+
+
+def _compute_digest(resources: dict[str, str]) -> str:
+    digest = hashlib.sha256()
+    for path, content in sorted(resources.items()):
+        digest.update(path.encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(content.encode("utf-8"))
+        digest.update(b"\0")
+    return digest.hexdigest()
+
+
+def _validate_frontmatter_paths(frontmatter: dict[str, Any]) -> None:
+    for key in ("rules", "scripts", "docs"):
+        values = frontmatter.get(key, [])
+        if values in (None, ""):
+            continue
+        if not isinstance(values, list):
+            raise SkillLoadError(f"SKILL.md front matter field {key} must be a list")
+        for value in values:
+            if not isinstance(value, str):
+                raise SkillLoadError(f"SKILL.md front matter field {key} contains a non-string path")
+            path = Path(value)
+            if path.is_absolute() or ".." in path.parts:
+                raise SkillLoadError(f"unsafe path in SKILL.md front matter: {value}")
+
+
+def _is_safe_skill_name(name: str) -> bool:
+    return all(char.isalnum() or char in {"-", "_", "."} for char in name) and "/" not in name and "\\" not in name

--- a/examples/skills_code_review_agent/agent/store.py
+++ b/examples/skills_code_review_agent/agent/store.py
@@ -1,0 +1,464 @@
+# Tencent is pleased to support the open source community by making tRPC-Agent-Python available.
+#
+# Copyright (C) 2026 Tencent. All rights reserved.
+#
+# tRPC-Agent-Python is licensed under Apache-2.0.
+"""SQLite persistence for the code-review example."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+from typing import Any
+from typing import Callable
+from typing import Protocol
+
+from .models import FilterEvent
+from .models import Finding
+from .models import InputSummary
+from .models import ReviewReport
+from .models import ReviewTask
+from .models import SandboxRun
+from .models import utc_now_iso
+from .sanitizer import redact_mapping
+
+
+class ReviewStoreProtocol(Protocol):
+    """Minimal persistence contract consumed by the review pipeline."""
+
+    def __enter__(self) -> "ReviewStoreProtocol":
+        ...
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        ...
+
+    def save_review(
+        self,
+        *,
+        task: ReviewTask,
+        input_summary: InputSummary,
+        findings: list[Finding],
+        warnings: list[Finding],
+        needs_human_review: list[Finding],
+        filter_events: list[FilterEvent],
+        sandbox_runs: list[SandboxRun],
+        report: ReviewReport,
+        report_json_path: str | Path,
+        report_md_path: str | Path,
+    ) -> None:
+        ...
+
+
+ReviewStoreFactory = Callable[[str | Path], ReviewStoreProtocol]
+
+
+class ReviewStore:
+    """Small sqlite3-backed store for review task artifacts."""
+
+    def __init__(self, db_path: str | Path):
+        self.db_path = Path(db_path)
+        self._conn: sqlite3.Connection | None = None
+
+    def __enter__(self) -> "ReviewStore":
+        self.open()
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.close()
+
+    def open(self) -> None:
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._conn = sqlite3.connect(self.db_path)
+        self._conn.row_factory = sqlite3.Row
+        self._conn.execute("PRAGMA foreign_keys=ON")
+        self._create_schema()
+
+    def close(self) -> None:
+        if self._conn is not None:
+            self._conn.close()
+            self._conn = None
+
+    def save_review(
+        self,
+        *,
+        task: ReviewTask,
+        input_summary: InputSummary,
+        findings: list[Finding],
+        warnings: list[Finding],
+        needs_human_review: list[Finding],
+        filter_events: list[FilterEvent],
+        sandbox_runs: list[SandboxRun],
+        report: ReviewReport,
+        report_json_path: str | Path,
+        report_md_path: str | Path,
+    ) -> None:
+        """Persist a complete review result."""
+        conn = self._require_conn()
+        with conn:
+            self._upsert_task(task)
+            self._upsert_input_summary(task.id, input_summary)
+            self._insert_findings(task.id, "finding", findings)
+            self._insert_findings(task.id, "warning", warnings)
+            self._insert_findings(task.id, "needs_human_review", needs_human_review)
+            self._insert_filter_events(filter_events)
+            self._insert_sandbox_runs(sandbox_runs)
+            self._upsert_metrics(task.id, report)
+            self._upsert_report(task.id, report, report_json_path, report_md_path)
+
+    def get_task(self, task_id: str) -> dict[str, Any] | None:
+        return self._fetch_one("SELECT * FROM review_task WHERE id = ?", (task_id, ))
+
+    def get_input_summary(self, task_id: str) -> dict[str, Any] | None:
+        row = self._fetch_one("SELECT * FROM input_diff WHERE task_id = ?", (task_id, ))
+        if row and row.get("summary_json"):
+            row["summary_json"] = json.loads(row["summary_json"])
+        return row
+
+    def list_findings(self, task_id: str) -> list[dict[str, Any]]:
+        return self._fetch_all("SELECT * FROM finding WHERE task_id = ? ORDER BY route, severity, category, file, line",
+                               (task_id, ))
+
+    def list_filter_events(self, task_id: str) -> list[dict[str, Any]]:
+        rows = self._fetch_all("SELECT * FROM filter_event WHERE task_id = ? ORDER BY created_at, id", (task_id, ))
+        for row in rows:
+            row["metadata_json"] = json.loads(row["metadata_json"] or "{}")
+        return rows
+
+    def list_sandbox_runs(self, task_id: str) -> list[dict[str, Any]]:
+        return self._fetch_all("SELECT * FROM sandbox_run WHERE task_id = ? ORDER BY created_at, id", (task_id, ))
+
+    def get_report(self, task_id: str) -> dict[str, Any] | None:
+        row = self._fetch_one("SELECT * FROM report WHERE task_id = ?", (task_id, ))
+        if row and row.get("report_json"):
+            row["report_json"] = json.loads(row["report_json"])
+        return row
+
+    def get_metrics(self, task_id: str) -> dict[str, Any] | None:
+        row = self._fetch_one("SELECT * FROM review_metrics WHERE task_id = ?", (task_id, ))
+        if row:
+            row["severity_distribution_json"] = json.loads(row["severity_distribution_json"] or "{}")
+            row["category_distribution_json"] = json.loads(row["category_distribution_json"] or "{}")
+            row["exception_distribution_json"] = json.loads(row["exception_distribution_json"] or "{}")
+        return row
+
+    def _create_schema(self) -> None:
+        conn = self._require_conn()
+        conn.executescript("""
+            CREATE TABLE IF NOT EXISTS review_task (
+              id TEXT PRIMARY KEY,
+              input_type TEXT NOT NULL,
+              input_ref TEXT NOT NULL,
+              status TEXT NOT NULL,
+              summary TEXT NOT NULL,
+              created_at TEXT NOT NULL,
+              finished_at TEXT
+            );
+
+            CREATE TABLE IF NOT EXISTS input_diff (
+              task_id TEXT PRIMARY KEY,
+              raw_diff_sha256 TEXT NOT NULL,
+              file_count INTEGER NOT NULL,
+              hunk_count INTEGER NOT NULL,
+              added_lines INTEGER NOT NULL,
+              deleted_lines INTEGER NOT NULL,
+              summary_json TEXT NOT NULL,
+              FOREIGN KEY(task_id) REFERENCES review_task(id) ON DELETE CASCADE
+            );
+
+            CREATE TABLE IF NOT EXISTS finding (
+              id INTEGER PRIMARY KEY AUTOINCREMENT,
+              task_id TEXT NOT NULL,
+              fingerprint TEXT NOT NULL,
+              route TEXT NOT NULL,
+              severity TEXT NOT NULL,
+              category TEXT NOT NULL,
+              file TEXT NOT NULL,
+              line INTEGER,
+              title TEXT NOT NULL,
+              evidence TEXT NOT NULL,
+              recommendation TEXT NOT NULL,
+              confidence REAL NOT NULL,
+              source TEXT NOT NULL,
+              UNIQUE(task_id, fingerprint, route),
+              FOREIGN KEY(task_id) REFERENCES review_task(id) ON DELETE CASCADE
+            );
+
+            CREATE TABLE IF NOT EXISTS filter_event (
+              id TEXT PRIMARY KEY,
+              task_id TEXT NOT NULL,
+              decision TEXT NOT NULL,
+              reason_code TEXT NOT NULL,
+              target_type TEXT NOT NULL,
+              target TEXT NOT NULL,
+              command TEXT NOT NULL,
+              runtime TEXT,
+              cwd TEXT NOT NULL,
+              script_path TEXT NOT NULL,
+              timeout_sec REAL,
+              output_limit_bytes INTEGER,
+              metadata_json TEXT NOT NULL,
+              created_at TEXT NOT NULL,
+              FOREIGN KEY(task_id) REFERENCES review_task(id) ON DELETE CASCADE
+            );
+
+            CREATE TABLE IF NOT EXISTS sandbox_run (
+              id TEXT PRIMARY KEY,
+              task_id TEXT NOT NULL,
+              runtime TEXT NOT NULL,
+              command TEXT NOT NULL,
+              status TEXT NOT NULL,
+              exit_code INTEGER,
+              duration_ms INTEGER NOT NULL,
+              stdout TEXT NOT NULL,
+              stderr TEXT NOT NULL,
+              timeout_sec REAL,
+              output_limit_bytes INTEGER,
+              stdout_truncated INTEGER NOT NULL,
+              stderr_truncated INTEGER NOT NULL,
+              error_type TEXT NOT NULL,
+              created_at TEXT NOT NULL,
+              FOREIGN KEY(task_id) REFERENCES review_task(id) ON DELETE CASCADE
+            );
+
+            CREATE TABLE IF NOT EXISTS review_metrics (
+              task_id TEXT PRIMARY KEY,
+              total_duration_ms INTEGER NOT NULL,
+              sandbox_duration_ms INTEGER NOT NULL,
+              tool_call_count INTEGER NOT NULL,
+              interception_count INTEGER NOT NULL,
+              finding_count INTEGER NOT NULL,
+              warning_count INTEGER NOT NULL,
+              needs_human_review_count INTEGER NOT NULL,
+              severity_distribution_json TEXT NOT NULL,
+              category_distribution_json TEXT NOT NULL,
+              exception_distribution_json TEXT NOT NULL,
+              created_at TEXT NOT NULL,
+              FOREIGN KEY(task_id) REFERENCES review_task(id) ON DELETE CASCADE
+            );
+
+            CREATE TABLE IF NOT EXISTS report (
+              task_id TEXT PRIMARY KEY,
+              json_path TEXT NOT NULL,
+              md_path TEXT NOT NULL,
+              report_json TEXT NOT NULL,
+              created_at TEXT NOT NULL,
+              FOREIGN KEY(task_id) REFERENCES review_task(id) ON DELETE CASCADE
+            );
+            """)
+
+    def _upsert_task(self, task: ReviewTask) -> None:
+        payload = redact_mapping(task.to_dict())
+        self._require_conn().execute(
+            """
+            INSERT INTO review_task (id, input_type, input_ref, status, summary, created_at, finished_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(id) DO UPDATE SET
+              input_type=excluded.input_type,
+              input_ref=excluded.input_ref,
+              status=excluded.status,
+              summary=excluded.summary,
+              finished_at=excluded.finished_at
+            """,
+            (
+                payload["id"],
+                payload["input_type"],
+                payload["input_ref"],
+                payload["status"],
+                payload["summary"],
+                payload["created_at"],
+                payload["finished_at"],
+            ),
+        )
+
+    def _upsert_input_summary(self, task_id: str, input_summary: InputSummary) -> None:
+        payload = redact_mapping(input_summary.to_dict())
+        self._require_conn().execute(
+            """
+            INSERT INTO input_diff (
+              task_id, raw_diff_sha256, file_count, hunk_count, added_lines, deleted_lines, summary_json
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(task_id) DO UPDATE SET
+              raw_diff_sha256=excluded.raw_diff_sha256,
+              file_count=excluded.file_count,
+              hunk_count=excluded.hunk_count,
+              added_lines=excluded.added_lines,
+              deleted_lines=excluded.deleted_lines,
+              summary_json=excluded.summary_json
+            """,
+            (
+                task_id,
+                payload["raw_diff_sha256"],
+                payload["file_count"],
+                payload["hunk_count"],
+                payload["added_lines"],
+                payload["deleted_lines"],
+                json.dumps(payload, ensure_ascii=False, sort_keys=True),
+            ),
+        )
+
+    def _insert_findings(self, task_id: str, route: str, findings: list[Finding]) -> None:
+        for finding in findings:
+            payload = redact_mapping(finding.to_dict())
+            self._require_conn().execute(
+                """
+                INSERT OR IGNORE INTO finding (
+                  task_id, fingerprint, route, severity, category, file, line, title,
+                  evidence, recommendation, confidence, source
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    task_id,
+                    payload["fingerprint"] or "",
+                    route,
+                    payload["severity"],
+                    payload["category"],
+                    payload["file"],
+                    payload["line"],
+                    payload["title"],
+                    payload["evidence"],
+                    payload["recommendation"],
+                    payload["confidence"],
+                    payload["source"],
+                ),
+            )
+
+    def _insert_filter_events(self, events: list[FilterEvent]) -> None:
+        for event in events:
+            payload = redact_mapping(event.to_dict())
+            self._require_conn().execute(
+                """
+                INSERT OR REPLACE INTO filter_event (
+                  id, task_id, decision, reason_code, target_type, target, command, runtime,
+                  cwd, script_path, timeout_sec, output_limit_bytes, metadata_json, created_at
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    payload["id"],
+                    payload["task_id"],
+                    payload["decision"],
+                    payload["reason_code"],
+                    payload["target_type"],
+                    payload["target"],
+                    payload["command"],
+                    payload["runtime"],
+                    payload["cwd"],
+                    payload["script_path"],
+                    payload["timeout_sec"],
+                    payload["output_limit_bytes"],
+                    json.dumps(payload["metadata"], ensure_ascii=False, sort_keys=True),
+                    payload["created_at"],
+                ),
+            )
+
+    def _insert_sandbox_runs(self, runs: list[SandboxRun]) -> None:
+        for run in runs:
+            payload = redact_mapping(run.to_dict())
+            self._require_conn().execute(
+                """
+                INSERT OR REPLACE INTO sandbox_run (
+                  id, task_id, runtime, command, status, exit_code, duration_ms, stdout, stderr,
+                  timeout_sec, output_limit_bytes, stdout_truncated, stderr_truncated, error_type, created_at
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    payload["id"],
+                    payload["task_id"],
+                    payload["runtime"],
+                    payload["command"],
+                    payload["status"],
+                    payload["exit_code"],
+                    payload["duration_ms"],
+                    payload["stdout"],
+                    payload["stderr"],
+                    payload["timeout_sec"],
+                    payload["output_limit_bytes"],
+                    int(bool(payload["stdout_truncated"])),
+                    int(bool(payload["stderr_truncated"])),
+                    payload["error_type"],
+                    payload["created_at"],
+                ),
+            )
+
+    def _upsert_metrics(self, task_id: str, report: ReviewReport) -> None:
+        payload = redact_mapping(report.metrics.to_dict())
+        self._require_conn().execute(
+            """
+            INSERT INTO review_metrics (
+              task_id, total_duration_ms, sandbox_duration_ms, tool_call_count, interception_count,
+              finding_count, warning_count, needs_human_review_count, severity_distribution_json,
+              category_distribution_json, exception_distribution_json, created_at
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(task_id) DO UPDATE SET
+              total_duration_ms=excluded.total_duration_ms,
+              sandbox_duration_ms=excluded.sandbox_duration_ms,
+              tool_call_count=excluded.tool_call_count,
+              interception_count=excluded.interception_count,
+              finding_count=excluded.finding_count,
+              warning_count=excluded.warning_count,
+              needs_human_review_count=excluded.needs_human_review_count,
+              severity_distribution_json=excluded.severity_distribution_json,
+              category_distribution_json=excluded.category_distribution_json,
+              exception_distribution_json=excluded.exception_distribution_json,
+              created_at=excluded.created_at
+            """,
+            (
+                task_id,
+                payload["total_duration_ms"],
+                payload["sandbox_duration_ms"],
+                payload["tool_call_count"],
+                payload["interception_count"],
+                payload["finding_count"],
+                payload["warning_count"],
+                payload["needs_human_review_count"],
+                json.dumps(payload["severity_distribution"], ensure_ascii=False, sort_keys=True),
+                json.dumps(payload["category_distribution"], ensure_ascii=False, sort_keys=True),
+                json.dumps(payload["exception_distribution"], ensure_ascii=False, sort_keys=True),
+                utc_now_iso(),
+            ),
+        )
+
+    def _upsert_report(
+        self,
+        task_id: str,
+        report: ReviewReport,
+        report_json_path: str | Path,
+        report_md_path: str | Path,
+    ) -> None:
+        payload = redact_mapping(report.to_dict())
+        self._require_conn().execute(
+            """
+            INSERT INTO report (task_id, json_path, md_path, report_json, created_at)
+            VALUES (?, ?, ?, ?, ?)
+            ON CONFLICT(task_id) DO UPDATE SET
+              json_path=excluded.json_path,
+              md_path=excluded.md_path,
+              report_json=excluded.report_json,
+              created_at=excluded.created_at
+            """,
+            (
+                task_id,
+                str(report_json_path),
+                str(report_md_path),
+                json.dumps(payload, ensure_ascii=False, sort_keys=True),
+                utc_now_iso(),
+            ),
+        )
+
+    def _fetch_one(self, query: str, params: tuple[Any, ...]) -> dict[str, Any] | None:
+        row = self._require_conn().execute(query, params).fetchone()
+        return dict(row) if row is not None else None
+
+    def _fetch_all(self, query: str, params: tuple[Any, ...]) -> list[dict[str, Any]]:
+        rows = self._require_conn().execute(query, params).fetchall()
+        return [dict(row) for row in rows]
+
+    def _require_conn(self) -> sqlite3.Connection:
+        if self._conn is None:
+            raise RuntimeError("ReviewStore is not open")
+        return self._conn

--- a/examples/skills_code_review_agent/fixtures/async_leak.diff
+++ b/examples/skills_code_review_agent/fixtures/async_leak.diff
@@ -1,0 +1,10 @@
+diff --git a/client.py b/client.py
+index 1111111..2222222 100644
+--- a/client.py
++++ b/client.py
+@@ -1,2 +1,5 @@
+ import httpx
+ 
++async def fetch(url):
++    client = httpx.AsyncClient()
++    return await client.get(url)

--- a/examples/skills_code_review_agent/fixtures/clean.diff
+++ b/examples/skills_code_review_agent/fixtures/clean.diff
@@ -1,0 +1,19 @@
+diff --git a/app.py b/app.py
+index 1111111..2222222 100644
+--- a/app.py
++++ b/app.py
+@@ -1,3 +1,4 @@
+ def greet(name):
+     return f"Hello, {name}"
+ 
++print(greet("review"))
+diff --git a/tests/test_app.py b/tests/test_app.py
+new file mode 100644
+--- /dev/null
++++ b/tests/test_app.py
+@@ -0,0 +1,5 @@
++from app import greet
++
++
++def test_greet():
++    assert greet("review") == "Hello, review"

--- a/examples/skills_code_review_agent/fixtures/db_lifecycle.diff
+++ b/examples/skills_code_review_agent/fixtures/db_lifecycle.diff
@@ -1,0 +1,10 @@
+diff --git a/storage.py b/storage.py
+index 1111111..2222222 100644
+--- a/storage.py
++++ b/storage.py
+@@ -1,2 +1,5 @@
+ import sqlite3
+ 
++def load_user(path, query):
++    connection = sqlite3.connect(path)
++    return connection.execute(query).fetchall()

--- a/examples/skills_code_review_agent/fixtures/duplicate.diff
+++ b/examples/skills_code_review_agent/fixtures/duplicate.diff
@@ -1,0 +1,14 @@
+diff --git a/app.py b/app.py
+index 1111111..2222222 100644
+--- a/app.py
++++ b/app.py
+@@ -1 +1,2 @@
+ old = True
++result = eval(user_input)
+diff --git a/app.py b/app.py
+index 1111111..2222222 100644
+--- a/app.py
++++ b/app.py
+@@ -1 +1,2 @@
+ old = True
++result = eval(user_input)

--- a/examples/skills_code_review_agent/fixtures/missing_tests.diff
+++ b/examples/skills_code_review_agent/fixtures/missing_tests.diff
@@ -1,0 +1,10 @@
+diff --git a/payment.py b/payment.py
+index 1111111..2222222 100644
+--- a/payment.py
++++ b/payment.py
+@@ -1,2 +1,5 @@
+ def charge(amount):
+     return amount
+ 
++def refund(amount):
++    return -amount

--- a/examples/skills_code_review_agent/fixtures/sandbox_failure.diff
+++ b/examples/skills_code_review_agent/fixtures/sandbox_failure.diff
@@ -1,0 +1,19 @@
+diff --git a/check.py b/check.py
+index 1111111..2222222 100644
+--- a/check.py
++++ b/check.py
+@@ -1,2 +1,4 @@
+ def check(value):
+     return value > 0
+ 
++result = check(1)
+diff --git a/tests/test_check.py b/tests/test_check.py
+new file mode 100644
+--- /dev/null
++++ b/tests/test_check.py
+@@ -0,0 +1,4 @@
++from check import check
++
++
++def test_check():
++    assert check(1)

--- a/examples/skills_code_review_agent/fixtures/secret.diff
+++ b/examples/skills_code_review_agent/fixtures/secret.diff
@@ -1,0 +1,10 @@
+diff --git a/config.py b/config.py
+index 1111111..2222222 100644
+--- a/config.py
++++ b/config.py
+@@ -1,2 +1,5 @@
+ import os
+ 
++API_KEY = "sk-live-1234567890abcdef"
++PASSWORD = "correct-horse-battery-staple"
++AUTHORIZATION = "Bearer very-long-token-value-123456"

--- a/examples/skills_code_review_agent/fixtures/secret.diff
+++ b/examples/skills_code_review_agent/fixtures/secret.diff
@@ -5,6 +5,6 @@ index 1111111..2222222 100644
 @@ -1,2 +1,5 @@
  import os
  
-+API_KEY = "sk-live-1234567890abcdef"
-+PASSWORD = "correct-horse-battery-staple"
-+AUTHORIZATION = "Bearer very-long-token-value-123456"
++API_KEY = "example-sensitive-api-key-value"
++PASSWORD = "example-sensitive-password-value"
++AUTHORIZATION = "Bearer example-sensitive-bearer-token"

--- a/examples/skills_code_review_agent/fixtures/security.diff
+++ b/examples/skills_code_review_agent/fixtures/security.diff
@@ -1,0 +1,11 @@
+diff --git a/app.py b/app.py
+index 1111111..2222222 100644
+--- a/app.py
++++ b/app.py
+@@ -1,2 +1,5 @@
+ import subprocess
+ 
++def run_user_code(user_input):
++    return eval(user_input)
++
++subprocess.run(user_input, shell=True)

--- a/examples/skills_code_review_agent/run_review.py
+++ b/examples/skills_code_review_agent/run_review.py
@@ -43,8 +43,7 @@ def build_parser() -> argparse.ArgumentParser:
                         help="SQLite path. Default follows --output-dir as review.sqlite3 unless explicitly set.")
     parser.add_argument("--dry-run",
                         action="store_true",
-                        default=True,
-                        help="Keep execution in non-sandbox dry-run mode.")
+                        help="Explicitly select the default non-sandbox dry-run runtime.")
     parser.add_argument(
         "--runtime",
         choices=[runtime.value for runtime in RuntimeKind],
@@ -80,7 +79,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         input_ref=input_ref,
         output_dir=args.output_dir,
         db_path=_resolve_db_path(args),
-        runtime=RuntimeKind(args.runtime),
+        runtime=RuntimeKind.DRY_RUN if args.dry_run else RuntimeKind(args.runtime),
         allow_local=args.allow_local,
         timeout_sec=args.timeout_sec,
         output_limit_bytes=args.output_limit_bytes,
@@ -125,6 +124,8 @@ def _resolve_input(args: argparse.Namespace) -> tuple[InputType, str]:
 
 
 def _validate_args(parser: argparse.ArgumentParser, args: argparse.Namespace) -> None:
+    if args.dry_run and args.runtime != RuntimeKind.DRY_RUN.value:
+        parser.error("--dry-run cannot be combined with a non-dry-run --runtime")
     if args.runtime == RuntimeKind.LOCAL_DEV.value and not args.allow_local:
         parser.error("--runtime local-dev requires --allow-local")
     if not str(args.output_dir).strip():

--- a/examples/skills_code_review_agent/run_review.py
+++ b/examples/skills_code_review_agent/run_review.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+
+# Tencent is pleased to support the open source community by making tRPC-Agent-Python available.
+#
+# Copyright (C) 2026 Tencent. All rights reserved.
+#
+# tRPC-Agent-Python is licensed under Apache-2.0.
+"""Run the deterministic skills code-review example pipeline."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Sequence
+
+try:
+    from .agent.input_parser import InputParseError
+    from .agent.models import InputType
+    from .agent.models import RuntimeKind
+    from .agent.pipeline import ReviewPipelineConfig
+    from .agent.pipeline import run_review_pipeline
+    from .agent.skill_loader import SkillLoadError
+except ImportError:  # pragma: no cover - supports direct script execution
+    from agent.input_parser import InputParseError
+    from agent.models import InputType
+    from agent.models import RuntimeKind
+    from agent.pipeline import ReviewPipelineConfig
+    from agent.pipeline import run_review_pipeline
+    from agent.skill_loader import SkillLoadError
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the command-line parser."""
+    parser = argparse.ArgumentParser(description="Run the deterministic skills code-review example.")
+    input_group = parser.add_mutually_exclusive_group(required=True)
+    input_group.add_argument("--diff-file", help="Path to a unified diff or patch file.")
+    input_group.add_argument("--repo-path", help="Path to a Git repository with worktree changes.")
+    input_group.add_argument("--fixture", help="Fixture name or explicit fixture path.")
+    input_group.add_argument("--file-list", help="Path to a UTF-8 file list to review as added files.")
+    parser.add_argument("--output-dir", default="output", help="Directory for review artifacts.")
+    parser.add_argument("--db-path",
+                        default="output/review.sqlite3",
+                        help="SQLite path. Default follows --output-dir as review.sqlite3 unless explicitly set.")
+    parser.add_argument("--dry-run",
+                        action="store_true",
+                        default=True,
+                        help="Keep execution in non-sandbox dry-run mode.")
+    parser.add_argument(
+        "--runtime",
+        choices=[runtime.value for runtime in RuntimeKind],
+        default=RuntimeKind.DRY_RUN.value,
+        help="Requested runtime for rule execution. Default: dry-run.",
+    )
+    parser.add_argument("--allow-local", action="store_true", help="Allow the unsafe local-dev runtime.")
+    parser.add_argument("--timeout-sec",
+                        type=float,
+                        default=30.0,
+                        help="Maximum rule-runner execution time in seconds.")
+    parser.add_argument("--output-limit-bytes",
+                        type=int,
+                        default=65536,
+                        help="Maximum captured stdout/stderr bytes per stream.")
+    parser.add_argument("--container-image",
+                        default="python:3-slim",
+                        help="Container image for --runtime container. Default: python:3-slim.")
+    parser.add_argument("--docker-base-url",
+                        default="",
+                        help="Optional Docker daemon base URL for --runtime container.")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the review pipeline."""
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    _validate_args(parser, args)
+    input_type, input_ref = _resolve_input(args)
+    config = ReviewPipelineConfig(
+        input_type=input_type,
+        input_ref=input_ref,
+        output_dir=args.output_dir,
+        db_path=_resolve_db_path(args),
+        runtime=RuntimeKind(args.runtime),
+        allow_local=args.allow_local,
+        timeout_sec=args.timeout_sec,
+        output_limit_bytes=args.output_limit_bytes,
+        container_image=args.container_image,
+        docker_base_url=args.docker_base_url,
+    )
+
+    try:
+        result = run_review_pipeline(config)
+    except (InputParseError, SkillLoadError, OSError, UnicodeError, ValueError, RuntimeError) as ex:
+        parser.error(str(ex))
+
+    print("Code review pipeline completed.")
+    print(f"task_id={result.task.id}")
+    print(f"input_type={input_type.value}")
+    print(f"files={result.input_summary.file_count}")
+    print(f"hunks={result.input_summary.hunk_count}")
+    print(f"runtime={args.runtime}")
+    for name in (
+            "parsed_input",
+            "skill_manifest",
+            "rule_result",
+            "findings",
+            "filter_events",
+            "sandbox_runs",
+            "review_report_json",
+            "review_report_md",
+            "db_path",
+    ):
+        print(f"{name}={result.artifact_paths[name]}")
+    return 0
+
+
+def _resolve_input(args: argparse.Namespace) -> tuple[InputType, str]:
+    if args.diff_file:
+        return InputType.DIFF_FILE, args.diff_file
+    if args.repo_path:
+        return InputType.REPO_PATH, args.repo_path
+    if args.file_list:
+        return InputType.FILE_LIST, args.file_list
+    return InputType.FIXTURE, args.fixture
+
+
+def _validate_args(parser: argparse.ArgumentParser, args: argparse.Namespace) -> None:
+    if args.runtime == RuntimeKind.LOCAL_DEV.value and not args.allow_local:
+        parser.error("--runtime local-dev requires --allow-local")
+    if not str(args.output_dir).strip():
+        parser.error("--output-dir must not be empty")
+    if not str(args.db_path).strip():
+        parser.error("--db-path must not be empty")
+    if args.timeout_sec <= 0:
+        parser.error("--timeout-sec must be greater than 0")
+    if args.output_limit_bytes <= 0:
+        parser.error("--output-limit-bytes must be greater than 0")
+    if not str(args.container_image).strip():
+        parser.error("--container-image must not be empty")
+    if _resolve_db_path(args).expanduser().is_dir():
+        parser.error("--db-path must be a file path")
+
+
+def _resolve_db_path(args: argparse.Namespace) -> Path:
+    if args.db_path == "output/review.sqlite3":
+        return Path(args.output_dir) / "review.sqlite3"
+    return Path(args.db_path)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/skills_code_review_agent/sample_outputs/review_report.json
+++ b/examples/skills_code_review_agent/sample_outputs/review_report.json
@@ -1,0 +1,186 @@
+{
+  "conclusion": "High risk findings require changes before merge.",
+  "findings": [
+    {
+      "category": "secret",
+      "confidence": 0.95,
+      "evidence": "API key assignment = [REDACTED]",
+      "file": "config.py",
+      "fingerprint": "9b84f43c60e40c43c1ac575c8f7905bf8cf8fa31b92c65c77448a29555854d30",
+      "line": 3,
+      "recommendation": "Move secrets to a managed secret store or environment configuration.",
+      "severity": "critical",
+      "source": "rule",
+      "title": "Hard-coded secret in changed code"
+    },
+    {
+      "category": "secret",
+      "confidence": 0.95,
+      "evidence": "secret assignment = [REDACTED]",
+      "file": "config.py",
+      "fingerprint": "c9c7b48e03948431aad61c539c4c531c7c332a9e65b153b531574525b76e369a",
+      "line": 4,
+      "recommendation": "Move secrets to a managed secret store or environment configuration.",
+      "severity": "critical",
+      "source": "rule",
+      "title": "Hard-coded secret in changed code"
+    }
+  ],
+  "interceptions": [
+    {
+      "budget_ms": null,
+      "command": "python skills/code-review/scripts/rule_runner.py --input output/parsed_input.json --manifest output/skill_manifest.json --output output/rule_result.json",
+      "created_at": "2026-07-31T03:00:58.023030+00:00",
+      "cwd": ".",
+      "decision": "allow",
+      "id": "filter-event-sample",
+      "metadata": {
+        "input": "output/parsed_input.json",
+        "manifest": "output/skill_manifest.json",
+        "output": "output/rule_result.json"
+      },
+      "network_host": "",
+      "output_limit_bytes": 65536,
+      "path": "",
+      "reason": "execution request allowed by example policy",
+      "reason_code": "unknown",
+      "runtime": "dry-run",
+      "script_path": "skills/code-review/scripts/rule_runner.py",
+      "skill_name": "",
+      "target": "python skills/code-review/scripts/rule_runner.py --input output/parsed_input.json --manifest output/skill_manifest.json --output output/rule_result.json",
+      "target_type": "command",
+      "task_id": "review-sample-secret",
+      "timeout_sec": 30.0,
+      "tool_name": ""
+    }
+  ],
+  "metrics": {
+    "category_distribution": {
+      "secret": 2,
+      "test": 1
+    },
+    "exception_distribution": {},
+    "finding_count": 2,
+    "interception_count": 0,
+    "needs_human_review_count": 0,
+    "sandbox_duration_ms": 1,
+    "severity_distribution": {
+      "critical": 2,
+      "low": 1
+    },
+    "tool_call_count": 1,
+    "total_duration_ms": 21,
+    "warning_count": 1
+  },
+  "needs_human_review": [],
+  "sandbox_runs": [
+    {
+      "command": "python skills/code-review/scripts/rule_runner.py --input output/parsed_input.json --manifest output/skill_manifest.json --output output/rule_result.json",
+      "created_at": "2026-07-31T03:00:58.023040+00:00",
+      "duration_ms": 1,
+      "error_type": "",
+      "exit_code": 0,
+      "id": "sandbox-run-sample",
+      "output_limit_bytes": 65536,
+      "runtime": "dry-run",
+      "status": "success",
+      "stderr": "",
+      "stderr_truncated": false,
+      "stdout": "{\"schema_version\": \"code-review.rules.v1\", \"skill_name\": \"code-review\", \"findings\": [{\"severity\": \"critical\", \"category\": \"secret\", \"file\": \"config.py\", \"title\": \"Hard-coded secret in changed code\", \"evidence\": \"API key assignment = [REDACTED]\", \"recommendation\": \"Move secrets to a managed secret store or environment configuration.\", \"confidence\": 0.95, \"source\": \"rule\", \"line\": 3}, {\"severity\": \"critical\", \"category\": \"secret\", \"file\": \"config.py\", \"title\": \"Hard-coded secret in changed code\", \"evidence\": \"secret assignment = [REDACTED]\", \"recommendation\": \"Move secrets to a managed secret store or environment configuration.\", \"confidence\": 0.95, \"source\": \"rule\", \"line\": 4}], \"diagnostics\": []}",
+      "stdout_truncated": false,
+      "task_id": "review-sample-secret",
+      "timeout_sec": 30.0
+    }
+  ],
+  "stats": {
+    "added_lines": 3,
+    "deleted_lines": 0,
+    "files": 1,
+    "hunks": 1,
+    "input_summary": {
+      "added_lines": 3,
+      "changed_files": [
+        {
+          "added_lines": 3,
+          "candidate_lines": [
+            3,
+            4,
+            5
+          ],
+          "deleted_lines": 0,
+          "hunks": [
+            {
+              "lines": [
+                {
+                  "content": "import os",
+                  "line_type": "context",
+                  "new_line": 1,
+                  "old_line": 1
+                },
+                {
+                  "content": "",
+                  "line_type": "context",
+                  "new_line": 2,
+                  "old_line": 2
+                },
+                {
+                  "content": "API key assignment = [REDACTED]",
+                  "line_type": "added",
+                  "new_line": 3,
+                  "old_line": null
+                },
+                {
+                  "content": "secret assignment = [REDACTED]",
+                  "line_type": "added",
+                  "new_line": 4,
+                  "old_line": null
+                },
+                {
+                  "content": "authorization header = Bearer [REDACTED]",
+                  "line_type": "added",
+                  "new_line": 5,
+                  "old_line": null
+                }
+              ],
+              "new_count": 5,
+              "new_start": 1,
+              "old_count": 2,
+              "old_start": 1,
+              "section_header": ""
+            }
+          ],
+          "is_binary": false,
+          "old_path": "config.py",
+          "path": "config.py",
+          "status": "modified"
+        }
+      ],
+      "deleted_lines": 0,
+      "diagnostics": [],
+      "file_count": 1,
+      "hunk_count": 1,
+      "input_ref": "fixtures/secret.diff",
+      "input_type": "fixture",
+      "parser_version": "code-review.input.v1",
+      "raw_diff_sha256": "c7443e7d240ce96931d892af90208017be68d994bdb5d084fbfca67ee2d891bb",
+      "summary": "1 file(s), 1 hunk(s), 3 added, 0 deleted",
+      "task_id": "review-sample-secret",
+      "warnings": []
+    }
+  },
+  "task_id": "review-sample-secret",
+  "warnings": [
+    {
+      "category": "test",
+      "confidence": 0.65,
+      "evidence": "1 source file(s) changed without a test or fixture change.",
+      "file": "config.py",
+      "fingerprint": "fa5be8a7a785151d5b1476b5a590d7c6a88a66c0b22ae51e71a3b96f82d94d7e",
+      "line": 3,
+      "recommendation": "Add or update focused tests or fixtures for the changed behavior.",
+      "severity": "low",
+      "source": "rule",
+      "title": "Source change has no matching test update"
+    }
+  ]
+}

--- a/examples/skills_code_review_agent/sample_outputs/review_report.json
+++ b/examples/skills_code_review_agent/sample_outputs/review_report.json
@@ -4,9 +4,9 @@
     {
       "category": "secret",
       "confidence": 0.95,
-      "evidence": "API key assignment = [REDACTED]",
+      "evidence": "API_KEY = [REDACTED]",
       "file": "config.py",
-      "fingerprint": "9b84f43c60e40c43c1ac575c8f7905bf8cf8fa31b92c65c77448a29555854d30",
+      "fingerprint": "e1f456643416568b0f3f9b07a3b16deb93fbc853517f126ca2049e6ece0b96a6",
       "line": 3,
       "recommendation": "Move secrets to a managed secret store or environment configuration.",
       "severity": "critical",
@@ -16,9 +16,9 @@
     {
       "category": "secret",
       "confidence": 0.95,
-      "evidence": "secret assignment = [REDACTED]",
+      "evidence": "PASSWORD = [REDACTED]",
       "file": "config.py",
-      "fingerprint": "c9c7b48e03948431aad61c539c4c531c7c332a9e65b153b531574525b76e369a",
+      "fingerprint": "d4c6c78cbd559108b08cab42da5efefcbb17d2339dc3ad4d8636b5b65be9c993",
       "line": 4,
       "recommendation": "Move secrets to a managed secret store or environment configuration.",
       "severity": "critical",
@@ -86,7 +86,7 @@
       "status": "success",
       "stderr": "",
       "stderr_truncated": false,
-      "stdout": "{\"schema_version\": \"code-review.rules.v1\", \"skill_name\": \"code-review\", \"findings\": [{\"severity\": \"critical\", \"category\": \"secret\", \"file\": \"config.py\", \"title\": \"Hard-coded secret in changed code\", \"evidence\": \"API key assignment = [REDACTED]\", \"recommendation\": \"Move secrets to a managed secret store or environment configuration.\", \"confidence\": 0.95, \"source\": \"rule\", \"line\": 3}, {\"severity\": \"critical\", \"category\": \"secret\", \"file\": \"config.py\", \"title\": \"Hard-coded secret in changed code\", \"evidence\": \"secret assignment = [REDACTED]\", \"recommendation\": \"Move secrets to a managed secret store or environment configuration.\", \"confidence\": 0.95, \"source\": \"rule\", \"line\": 4}], \"diagnostics\": []}",
+      "stdout": "{\"schema_version\": \"code-review.rules.v1\", \"skill_name\": \"code-review\", \"findings\": [{\"severity\": \"critical\", \"category\": \"secret\", \"file\": \"config.py\", \"title\": \"Hard-coded secret in changed code\", \"evidence\": \"API_KEY = [REDACTED]\", \"recommendation\": \"Move secrets to a managed secret store or environment configuration.\", \"confidence\": 0.95, \"source\": \"rule\", \"line\": 3, \"fingerprint\": \"e1f456643416568b0f3f9b07a3b16deb93fbc853517f126ca2049e6ece0b96a6\"}, {\"severity\": \"critical\", \"category\": \"secret\", \"file\": \"config.py\", \"title\": \"Hard-coded secret in changed code\", \"evidence\": \"PASSWORD = [REDACTED]\", \"recommendation\": \"Move secrets to a managed secret store or environment configuration.\", \"confidence\": 0.95, \"source\": \"rule\", \"line\": 4, \"fingerprint\": \"d4c6c78cbd559108b08cab42da5efefcbb17d2339dc3ad4d8636b5b65be9c993\"}, {\"severity\": \"low\", \"category\": \"test\", \"file\": \"config.py\", \"title\": \"Source change has no matching test update\", \"evidence\": \"1 of 1 source file(s) changed without a matching test or fixture change.\", \"recommendation\": \"Add or update focused tests or fixtures for the changed behavior.\", \"confidence\": 0.65, \"source\": \"rule\", \"line\": 3, \"fingerprint\": \"76730d280c24ac82c79a31750d044662efb5274603ebe47bde3282bbbdbcd70b\"}], \"diagnostics\": []}",
       "stdout_truncated": false,
       "task_id": "review-sample-secret",
       "timeout_sec": 30.0
@@ -124,19 +124,19 @@
                   "old_line": 2
                 },
                 {
-                  "content": "API key assignment = [REDACTED]",
+                  "content": "API_KEY = [REDACTED]",
                   "line_type": "added",
                   "new_line": 3,
                   "old_line": null
                 },
                 {
-                  "content": "secret assignment = [REDACTED]",
+                  "content": "PASSWORD = [REDACTED]",
                   "line_type": "added",
                   "new_line": 4,
                   "old_line": null
                 },
                 {
-                  "content": "authorization header = Bearer [REDACTED]",
+                  "content": "AUTHORIZATION = \"Bearer [REDACTED]\"",
                   "line_type": "added",
                   "new_line": 5,
                   "old_line": null
@@ -162,7 +162,7 @@
       "input_ref": "fixtures/secret.diff",
       "input_type": "fixture",
       "parser_version": "code-review.input.v1",
-      "raw_diff_sha256": "c7443e7d240ce96931d892af90208017be68d994bdb5d084fbfca67ee2d891bb",
+      "raw_diff_sha256": "b9753e180fd9a2fe9257bed084d8e17318be1b4976ee684eb3992d35a4c8b07e",
       "summary": "1 file(s), 1 hunk(s), 3 added, 0 deleted",
       "task_id": "review-sample-secret",
       "warnings": []
@@ -173,9 +173,9 @@
     {
       "category": "test",
       "confidence": 0.65,
-      "evidence": "1 source file(s) changed without a test or fixture change.",
+      "evidence": "1 of 1 source file(s) changed without a matching test or fixture change.",
       "file": "config.py",
-      "fingerprint": "fa5be8a7a785151d5b1476b5a590d7c6a88a66c0b22ae51e71a3b96f82d94d7e",
+      "fingerprint": "76730d280c24ac82c79a31750d044662efb5274603ebe47bde3282bbbdbcd70b",
       "line": 3,
       "recommendation": "Add or update focused tests or fixtures for the changed behavior.",
       "severity": "low",

--- a/examples/skills_code_review_agent/sample_outputs/review_report.md
+++ b/examples/skills_code_review_agent/sample_outputs/review_report.md
@@ -1,0 +1,52 @@
+# Code Review Report
+
+- Task: `review-sample-secret`
+- Conclusion: High risk findings require changes before merge.
+- Findings: 2
+- Warnings: 1
+- Needs human review: 0
+
+## Metrics
+
+- Total duration: 21 ms
+- Sandbox duration: 1 ms
+- Tool calls: 1
+- Interceptions: 0
+- Severity distribution: `{"critical": 2, "low": 1}`
+- Category distribution: `{"secret": 2, "test": 1}`
+
+## Findings
+
+- **Hard-coded secret in changed code** `critical` `secret`
+  - Location: `config.py:3`
+  - Evidence: API key assignment = [REDACTED]
+  - Recommendation: Move secrets to a managed secret store or environment configuration.
+- **Hard-coded secret in changed code** `critical` `secret`
+  - Location: `config.py:4`
+  - Evidence: secret assignment = [REDACTED]
+  - Recommendation: Move secrets to a managed secret store or environment configuration.
+
+## Warnings
+
+- **Source change has no matching test update** `low` `test`
+  - Location: `config.py:3`
+  - Evidence: 1 source file(s) changed without a test or fixture change.
+  - Recommendation: Add or update focused tests or fixtures for the changed behavior.
+
+## Needs Human Review
+
+None.
+
+## Filter Events
+
+- `allow` `unknown`: execution request allowed by example policy
+
+## Sandbox Runs
+
+- `dry-run` `success` exit=0 duration=1ms
+
+## Fix Suggestions
+
+- Address critical and high findings before merging.
+- Add focused tests for changed source behavior.
+- Review any governance or sandbox items before trusting execution output.

--- a/examples/skills_code_review_agent/sample_outputs/review_report.md
+++ b/examples/skills_code_review_agent/sample_outputs/review_report.md
@@ -19,18 +19,18 @@
 
 - **Hard-coded secret in changed code** `critical` `secret`
   - Location: `config.py:3`
-  - Evidence: API key assignment = [REDACTED]
+  - Evidence: API_KEY = [REDACTED]
   - Recommendation: Move secrets to a managed secret store or environment configuration.
 - **Hard-coded secret in changed code** `critical` `secret`
   - Location: `config.py:4`
-  - Evidence: secret assignment = [REDACTED]
+  - Evidence: PASSWORD = [REDACTED]
   - Recommendation: Move secrets to a managed secret store or environment configuration.
 
 ## Warnings
 
 - **Source change has no matching test update** `low` `test`
   - Location: `config.py:3`
-  - Evidence: 1 source file(s) changed without a test or fixture change.
+  - Evidence: 1 of 1 source file(s) changed without a matching test or fixture change.
   - Recommendation: Add or update focused tests or fixtures for the changed behavior.
 
 ## Needs Human Review

--- a/examples/skills_code_review_agent/skills/code-review/SKILL.md
+++ b/examples/skills_code_review_agent/skills/code-review/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: code-review
+description: Review normalized source-code changes for security, reliability, resource, testing, secret, and database risks.
+rules:
+  - rules/security.md
+  - rules/async-resource.md
+  - rules/testing-db.md
+  - rules/runtime.md
+scripts:
+  - scripts/rule_runner.py
+outputs:
+  schema_version: code-review.rules.v1
+---
+
+# Code Review Skill
+
+Use this Skill to inspect normalized code changes produced by the example input
+parser. The primary input is an `InputSummary` JSON document containing changed
+files, hunks, context lines, added/deleted line numbers, candidate review lines,
+parser diagnostics, and a stable input digest.
+
+## Inputs
+
+- `parsed_input.json`: normalized input summary for a diff, fixture, or Git worktree.
+- `skill_manifest.json`: manifest produced by the local Skill loader.
+
+Rule scripts must analyze only the supplied structured inputs. They must not
+scan arbitrary host paths, read credentials, call the network, or infer source
+state outside the review workspace prepared by the caller.
+
+## Rules
+
+Review guidance lives under `rules/`:
+
+- `rules/security.md`
+- `rules/async-resource.md`
+- `rules/testing-db.md`
+- `rules/runtime.md`
+
+Each rule document uses rule intent, examples, and trigger conditions so later
+deterministic checks and human reviewers share the same vocabulary.
+
+## Script Entry
+
+The script entrypoint is `scripts/rule_runner.py` from `__BASE_DIR__`. It accepts
+JSON paths with `--input` and `--manifest`, and can write JSON to `--output`.
+Governance and sandbox layers must approve runtime, command, working directory,
+environment variables, timeout, and output limits before executing it.
+
+## Output
+
+The rule runner returns structured JSON with:
+
+- `schema_version`
+- `skill_name`
+- `findings`
+- `diagnostics`
+
+Findings include `severity`, `category`, `file`, `line`, `title`, `evidence`,
+`recommendation`, `confidence`, `source`, and `fingerprint`.

--- a/examples/skills_code_review_agent/skills/code-review/rules/async-resource.md
+++ b/examples/skills_code_review_agent/skills/code-review/rules/async-resource.md
@@ -1,0 +1,58 @@
+# Async And Resource Lifecycle Review Rules
+
+## Await And Cancellation Correctness
+
+Rule: asynchronous code must await coroutines, preserve cancellation, and avoid
+blocking the event loop with file, network, subprocess, or CPU-heavy work.
+
+Example:
+
+```python
+async def handle():
+    client.fetch(url)
+    except Exception:
+        return None
+```
+
+Trigger conditions:
+
+- Changed lines call known async APIs without `await` or task management.
+- `CancelledError` can be swallowed by broad `except Exception` or `except BaseException` paths.
+- Synchronous file, HTTP, sleep, subprocess, or database calls are added inside
+  `async def` without an executor or async alternative.
+
+## Resource Ownership
+
+Rule: files, streams, locks, subprocesses, HTTP clients, database sessions, and
+temporary directories must be closed or cleaned up on success and failure paths.
+
+Example:
+
+```python
+client = httpx.AsyncClient()
+return await client.get(url)
+```
+
+Trigger conditions:
+
+- Changed code creates resources without a `with`, `async with`, `try/finally`,
+  explicit close, or lifecycle owner.
+- New subprocesses lack timeout and cleanup.
+- Error paths return early before cleanup.
+
+## Bounded Work
+
+Rule: new loops, retries, streaming reads, subprocess calls, and network calls
+must have bounded timeout, retry, and output behavior.
+
+Example:
+
+```python
+while True:
+    await queue.get()
+```
+
+Trigger conditions:
+
+- Infinite loops, unbounded retries, or large reads are introduced.
+- Timeouts are removed or set only at a higher layer not visible in the diff.

--- a/examples/skills_code_review_agent/skills/code-review/rules/runtime.md
+++ b/examples/skills_code_review_agent/skills/code-review/rules/runtime.md
@@ -1,0 +1,54 @@
+# Runtime And Sandbox Review Rules
+
+## Script Execution Boundaries
+
+Rule: review scripts must run in a governed workspace with explicit command,
+working directory, timeout, output limit, and environment allowlist.
+
+Example:
+
+```bash
+python scripts/rule_runner.py --input parsed_input.json --manifest skill_manifest.json
+```
+
+Trigger conditions:
+
+- A proposed command reads outside the staged workspace.
+- Runtime selection requests local execution without explicit approval.
+- Environment variables, network hosts, or writable paths are not allowlisted.
+
+## Failure Recording
+
+Rule: timeout, denied execution, missing runtime, parser errors, and command
+failures must be recorded as diagnostics or governance events rather than
+discarded.
+
+Example:
+
+```json
+{"status": "timeout", "timeout_sec": 30, "stderr": "..."}
+```
+
+Trigger conditions:
+
+- Changed code catches sandbox failures and returns success.
+- Output truncation is not surfaced to reports or metrics.
+- Failure evidence may contain credentials and needs redaction before storage.
+
+## Output Discipline
+
+Rule: rule and sandbox output must stay structured, size-limited, and safe for
+JSON, SQLite, and Markdown rendering.
+
+Example:
+
+```json
+{"schema_version": "code-review.rules.v1", "findings": []}
+```
+
+Trigger conditions:
+
+- Scripts print ad hoc prose instead of JSON.
+- Large stdout/stderr is stored without truncation metadata.
+- Findings omit severity, category, file, evidence, recommendation, confidence,
+  or source.

--- a/examples/skills_code_review_agent/skills/code-review/rules/security.md
+++ b/examples/skills_code_review_agent/skills/code-review/rules/security.md
@@ -1,0 +1,59 @@
+# Security And Secret Review Rules
+
+## Dangerous Execution
+
+Rule: changed code must not pass untrusted input into `eval`, `exec`, dynamic
+imports, shell commands, deserializers, template rendering, or archive extraction
+without clear validation and containment.
+
+Example:
+
+```python
+subprocess.run("deploy " + request.args["target"], shell=True)
+```
+
+Trigger conditions:
+
+- Changed lines introduce `shell=True`, string-built commands, `eval`, `exec`,
+  `pickle.loads`, permissive YAML loading, or path-sensitive extraction.
+- User, request, environment, database, queue, or file content reaches execution
+  or filesystem APIs without validation.
+- Evidence is present in changed lines or immediate hunk context.
+
+## Path And Permission Boundaries
+
+Rule: changed code must keep reads, writes, extraction, and deletion inside an
+approved workspace or application-owned directory.
+
+Example:
+
+```python
+target = Path("/tmp/uploads") / request.json["name"]
+target.unlink()
+```
+
+Trigger conditions:
+
+- New path joins use user-controlled segments without normalization checks.
+- Absolute paths, `..`, recursive deletion, chmod, chown, or world-writable
+  temporary files are introduced.
+- Review confidence should drop when the diff omits caller trust boundaries.
+
+## Sensitive Information Disclosure
+
+Rule: changed code and test data must not expose API keys, bearer tokens,
+passwords, private keys, connection strings, cookies, or authorization headers.
+
+Example:
+
+```python
+logger.info("connecting with password=%s", password)
+API_KEY = "sk-live-1234567890"
+```
+
+Trigger conditions:
+
+- Credential-like literals appear in changed lines.
+- Logs, exceptions, telemetry, reports, or database rows include secret-bearing
+  variables or headers.
+- Recommendations must preserve evidence without copying full secret values.

--- a/examples/skills_code_review_agent/skills/code-review/rules/security.md
+++ b/examples/skills_code_review_agent/skills/code-review/rules/security.md
@@ -48,7 +48,7 @@ Example:
 
 ```python
 logger.info("connecting with password=%s", password)
-API_KEY = "sk-live-1234567890"
+API_KEY = "example-sensitive-api-key-value"
 ```
 
 Trigger conditions:

--- a/examples/skills_code_review_agent/skills/code-review/rules/testing-db.md
+++ b/examples/skills_code_review_agent/skills/code-review/rules/testing-db.md
@@ -1,0 +1,56 @@
+# Testing And Database Lifecycle Review Rules
+
+## Test Coverage For Behavior Changes
+
+Rule: changes that add branches, error handling, security checks, parsing logic,
+or persistence behavior should include focused tests for success and failure
+paths.
+
+Example:
+
+```python
+def parse_token(value):
+    return value.split(":", 1)[1]
+```
+
+Trigger conditions:
+
+- Source files change but no nearby test, fixture, or snapshot changes appear.
+- New error handling lacks negative tests.
+- Security, parser, or database behavior changes without regression fixtures.
+
+## Database Transactions
+
+Rule: transactions must commit, roll back, and release connections deterministically.
+
+Example:
+
+```python
+conn = pool.acquire()
+conn.execute("insert into audit values (?)", [value])
+return True
+```
+
+Trigger conditions:
+
+- Changed code opens sessions/connections/cursors without context managers or
+  finally cleanup.
+- Transactions can return or raise before commit/rollback.
+- SQL uses string interpolation with untrusted values.
+
+## Migration And Schema Safety
+
+Rule: schema changes must be reversible or compatible with existing data and
+must not silently drop columns, tables, indexes, or constraints.
+
+Example:
+
+```sql
+DROP TABLE findings;
+```
+
+Trigger conditions:
+
+- Destructive DDL appears without migration notes or tests.
+- New non-null columns lack defaults or backfill logic.
+- Index or constraint changes can alter query semantics.

--- a/examples/skills_code_review_agent/skills/code-review/scripts/rule_runner.py
+++ b/examples/skills_code_review_agent/skills/code-review/scripts/rule_runner.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+
+# Tencent is pleased to support the open source community by making tRPC-Agent-Python available.
+#
+# Copyright (C) 2026 Tencent. All rights reserved.
+#
+# tRPC-Agent-Python is licensed under Apache-2.0.
+"""Validate normalized review input and emit the rule-runner JSON contract."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+try:
+    from agent.models import ChangedFile
+    from agent.models import ChangedLine
+    from agent.models import DiffHunk
+    from agent.models import InputSummary
+    from agent.models import InputType
+    from agent.review_rules import run_review_rules
+    from agent.sanitizer import redact_mapping
+except ImportError:  # pragma: no cover - supports direct script execution from the Skill directory
+    sys.path.insert(0, str(Path(__file__).parents[3]))
+    from agent.models import ChangedFile
+    from agent.models import ChangedLine
+    from agent.models import DiffHunk
+    from agent.models import InputSummary
+    from agent.models import InputType
+    from agent.review_rules import run_review_rules
+    from agent.sanitizer import redact_mapping
+
+SCHEMA_VERSION = "code-review.rules.v1"
+SKILL_NAME = "code-review"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the rule-runner command parser."""
+    parser = argparse.ArgumentParser(description="Validate code-review structured inputs.")
+    parser.add_argument("--input", required=True, help="Path to normalized InputSummary JSON.")
+    parser.add_argument("--manifest", required=True, help="Path to loaded Skill manifest JSON.")
+    parser.add_argument("--output", help="Optional output JSON path. Defaults to stdout.")
+    return parser
+
+
+def run(input_path: str | Path, manifest_path: str | Path) -> dict[str, Any]:
+    """Validate input and manifest JSON and return deterministic findings."""
+    input_payload = _read_json_object(Path(input_path), "input")
+    manifest_payload = _read_json_object(Path(manifest_path), "manifest")
+    manifest = manifest_payload.get("manifest", manifest_payload)
+    if not isinstance(manifest, dict):
+        raise ValueError("manifest JSON must be an object")
+
+    required_input = {"task_id", "input_type", "input_ref", "changed_files", "raw_diff_sha256"}
+    missing_input = sorted(required_input.difference(input_payload))
+    if missing_input:
+        raise ValueError(f"input JSON is missing fields: {', '.join(missing_input)}")
+    if not isinstance(input_payload["changed_files"], list):
+        raise ValueError("input JSON field changed_files must be a list")
+    if manifest.get("name") != SKILL_NAME:
+        raise ValueError(f"manifest skill name must be {SKILL_NAME!r}")
+    if not manifest.get("digest"):
+        raise ValueError("manifest JSON is missing digest")
+    input_summary = _input_summary_from_dict(input_payload)
+    findings = [finding.to_dict() for finding in run_review_rules(input_summary)]
+
+    return redact_mapping({
+        "schema_version": SCHEMA_VERSION,
+        "skill_name": SKILL_NAME,
+        "findings": findings,
+        "diagnostics": list(input_payload.get("diagnostics", [])),
+    })
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entrypoint."""
+    args = build_parser().parse_args(argv)
+    try:
+        result = run(args.input, args.manifest)
+        rendered = json.dumps(result, ensure_ascii=True, indent=2, sort_keys=True) + "\n"
+        if args.output:
+            output = Path(args.output)
+            output.parent.mkdir(parents=True, exist_ok=True)
+            output.write_text(rendered, encoding="utf-8")
+        else:
+            sys.stdout.write(rendered)
+        return 0
+    except (OSError, ValueError) as ex:
+        print(f"rule_runner: {ex}", file=sys.stderr)
+        return 2
+
+
+def _read_json_object(path: Path, label: str) -> dict[str, Any]:
+    if not path.is_file():
+        raise ValueError(f"{label} file not found: {path}")
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as ex:
+        raise ValueError(f"{label} file is not valid JSON: {path}") from ex
+    if not isinstance(payload, dict):
+        raise ValueError(f"{label} JSON must be an object")
+    return payload
+
+
+def _input_summary_from_dict(payload: dict[str, Any]) -> InputSummary:
+    changed_files = []
+    for file_payload in payload.get("changed_files", []):
+        hunks = []
+        for hunk_payload in file_payload.get("hunks", []):
+            lines = [
+                ChangedLine(
+                    line_type=str(line_payload.get("line_type", "")),
+                    content=str(line_payload.get("content", "")),
+                    old_line=line_payload.get("old_line"),
+                    new_line=line_payload.get("new_line"),
+                ) for line_payload in hunk_payload.get("lines", [])
+            ]
+            hunks.append(
+                DiffHunk(
+                    old_start=int(hunk_payload.get("old_start", 0)),
+                    old_count=int(hunk_payload.get("old_count", 0)),
+                    new_start=int(hunk_payload.get("new_start", 0)),
+                    new_count=int(hunk_payload.get("new_count", 0)),
+                    section_header=str(hunk_payload.get("section_header", "")),
+                    lines=lines,
+                ))
+        changed_files.append(
+            ChangedFile(
+                path=str(file_payload.get("path", "")),
+                old_path=str(file_payload.get("old_path", "")),
+                status=str(file_payload.get("status", "modified")),
+                hunks=hunks,
+                added_lines=int(file_payload.get("added_lines", 0)),
+                deleted_lines=int(file_payload.get("deleted_lines", 0)),
+                candidate_lines=[int(line) for line in file_payload.get("candidate_lines", [])],
+                is_binary=bool(file_payload.get("is_binary", False)),
+            ))
+    return InputSummary(
+        task_id=str(payload["task_id"]),
+        input_type=InputType(str(payload["input_type"])),
+        input_ref=str(payload["input_ref"]),
+        changed_files=changed_files,
+        raw_diff_sha256=str(payload.get("raw_diff_sha256", "")),
+        file_count=int(payload.get("file_count", len(changed_files))),
+        hunk_count=int(payload.get("hunk_count", 0)),
+        added_lines=int(payload.get("added_lines", 0)),
+        deleted_lines=int(payload.get("deleted_lines", 0)),
+        summary=str(payload.get("summary", "")),
+        diagnostics=[str(item) for item in payload.get("diagnostics", [])],
+        parser_version=str(payload.get("parser_version", "code-review.input.v1")),
+        warnings=[str(item) for item in payload.get("warnings", [])],
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/skills_code_review_agent/tests/__init__.py
+++ b/examples/skills_code_review_agent/tests/__init__.py
@@ -1,0 +1,6 @@
+# Tencent is pleased to support the open source community by making tRPC-Agent-Python available.
+#
+# Copyright (C) 2026 Tencent. All rights reserved.
+#
+# tRPC-Agent-Python is licensed under Apache-2.0.
+"""Tests for the skills code review agent example."""

--- a/examples/skills_code_review_agent/tests/secret_samples.py
+++ b/examples/skills_code_review_agent/tests/secret_samples.py
@@ -1,0 +1,89 @@
+# Tencent is pleased to support the open source community by making tRPC-Agent-Python available.
+#
+# Copyright (C) 2026 Tencent. All rights reserved.
+#
+# tRPC-Agent-Python is licensed under Apache-2.0.
+"""Scanner-safe secret sample builders for business tests."""
+
+from __future__ import annotations
+
+
+def openai_like_token() -> str:
+    return _join("sk", "-", "alpha", "beta", "token", "value")
+
+
+def openai_live_like_token() -> str:
+    return _join("sk", "-", "live", "-", "alpha", "beta", "token", "value")
+
+
+def github_pat_like_token() -> str:
+    return _join("github", "_", "pat", "_", "alpha", "beta", "token", "value")
+
+
+def github_classic_like_token() -> str:
+    return _join("ghp", "_", "alpha", "beta", "token", "value")
+
+
+def github_oauth_like_token() -> str:
+    return _join("gho", "_", "alpha", "beta", "token", "value")
+
+
+def slack_like_token() -> str:
+    return _join("xoxb", "-", "alpha", "-", "beta", "-", "token", "-", "value")
+
+
+def aws_access_key_like_token() -> str:
+    return _join("AKIA", "QWER", "TYUI", "OPAS", "DFGH")
+
+
+def aws_session_key_like_token() -> str:
+    return _join("ASIA", "QWER", "TYUI", "OPAS", "DFGH")
+
+
+def bearer_like_token() -> str:
+    return _join("bearer", "-", "alpha", "-", "beta", "-", "token", "-", "value")
+
+
+def jwt_like_token() -> str:
+    return ".".join([
+        _join("eyJ", "hbGci", "OiJI", "UzI1NiJ9"),
+        _join("eyJ", "zdWIi", "OiIxMjMifQ"),
+        "signature",
+    ])
+
+
+def db_password_like_value() -> str:
+    return _join("db", "-", "password", "-", "value")
+
+
+def generic_api_key_value() -> str:
+    return _join("example", "-", "sensitive", "-", "api", "-", "key", "-", "value")
+
+
+def generic_password_value() -> str:
+    return _join("example", "-", "sensitive", "-", "password", "-", "value")
+
+
+def generic_bearer_value() -> str:
+    return _join("example", "-", "sensitive", "-", "bearer", "-", "token")
+
+
+def generic_secret_value() -> str:
+    return _join("example", "-", "sensitive", "-", "secret", "-", "value")
+
+
+def forbidden_provider_literals() -> list[str]:
+    return [
+        _join("sk", "-", "live", "-", "1234567890abcdef"),
+        _join("sk", "-", "abcdefghijklmnop"),
+        _join("ghp", "_", "abcdefghijklmnop"),
+        _join("gho", "_", "abcdefghijklmnop"),
+        _join("github", "_", "pat", "_", "abcdefghijklmnop"),
+        _join("xoxb", "-", "1234567890", "-", "abcdefghijklmnop"),
+        _join("AKIA", "ABCDEFGHIJKLMNOP"),
+        _join("ASIA", "ABCDEFGHIJKLMNOP"),
+    ]
+
+
+def _join(*parts: str) -> str:
+    return "".join(parts)

--- a/examples/skills_code_review_agent/tests/secret_samples.py
+++ b/examples/skills_code_review_agent/tests/secret_samples.py
@@ -56,6 +56,18 @@ def db_password_like_value() -> str:
     return _join("db", "-", "password", "-", "value")
 
 
+def client_secret_like_value() -> str:
+    return _join("example", "-", "client", "-", "secret", "-", "value")
+
+
+def refresh_token_like_value() -> str:
+    return _join("example", "-", "refresh", "-", "token", "-", "value")
+
+
+def private_key_body_value() -> str:
+    return _join("example", "-", "private", "-", "key", "-", "body")
+
+
 def generic_api_key_value() -> str:
     return _join("example", "-", "sensitive", "-", "api", "-", "key", "-", "value")
 

--- a/examples/skills_code_review_agent/tests/test_cli_inputs.py
+++ b/examples/skills_code_review_agent/tests/test_cli_inputs.py
@@ -51,6 +51,31 @@ def test_fixture_input_writes_normalized_intermediate_artifacts(tmp_path: Path):
     assert "files=2" in result.stdout
 
 
+def test_explicit_dry_run_uses_dry_run_runtime(tmp_path: Path):
+    output = tmp_path / "dry-run"
+
+    result = _run_cli("--fixture", "clean", "--dry-run", "--output-dir", str(output))
+
+    assert result.returncode == 0, result.stderr
+    assert "runtime=dry-run" in result.stdout
+    assert _read_report(output)["sandbox_runs"][0]["runtime"] == "dry-run"
+
+
+def test_dry_run_rejects_non_dry_runtime(tmp_path: Path):
+    result = _run_cli(
+        "--fixture",
+        "clean",
+        "--dry-run",
+        "--runtime",
+        "container",
+        "--output-dir",
+        str(tmp_path / "out"),
+    )
+
+    assert result.returncode != 0
+    assert "--dry-run cannot be combined with a non-dry-run --runtime" in result.stderr
+
+
 def test_file_list_input_reviews_text_files(tmp_path: Path):
     source = tmp_path / "listed.py"
     source.write_text("eval(user_input)\n", encoding="utf-8")

--- a/examples/skills_code_review_agent/tests/test_cli_inputs.py
+++ b/examples/skills_code_review_agent/tests/test_cli_inputs.py
@@ -1,0 +1,193 @@
+# Tencent is pleased to support the open source community by making tRPC-Agent-Python available.
+#
+# Copyright (C) 2026 Tencent. All rights reserved.
+#
+# tRPC-Agent-Python is licensed under Apache-2.0.
+"""Business tests for the code-review input CLI."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from examples.skills_code_review_agent.agent import ReviewStore
+
+
+def test_diff_input_writes_normalized_intermediate_artifacts(tmp_path: Path):
+    diff = tmp_path / "change.diff"
+    diff.write_text(_sample_diff(), encoding="utf-8")
+    output = tmp_path / "out"
+
+    result = _run_cli("--diff-file", str(diff), "--output-dir", str(output))
+
+    assert result.returncode == 0, result.stderr
+    assert "input_type=diff_file" in result.stdout
+    assert "files=1" in result.stdout
+
+
+def test_repo_input_writes_normalized_intermediate_artifacts(tmp_path: Path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    (repo / "new.py").write_text("print('new')\n", encoding="utf-8")
+    output = tmp_path / "out"
+
+    result = _run_cli("--repo-path", str(repo), "--output-dir", str(output))
+
+    assert result.returncode == 0, result.stderr
+    assert "input_type=repo_path" in result.stdout
+    assert "files=1" in result.stdout
+
+
+def test_fixture_input_writes_normalized_intermediate_artifacts(tmp_path: Path):
+    output = tmp_path / "out"
+
+    result = _run_cli("--fixture", "clean", "--output-dir", str(output))
+
+    assert result.returncode == 0, result.stderr
+    assert "input_type=fixture" in result.stdout
+    assert "files=2" in result.stdout
+
+
+def test_file_list_input_reviews_text_files(tmp_path: Path):
+    source = tmp_path / "listed.py"
+    source.write_text("eval(user_input)\n", encoding="utf-8")
+    file_list = tmp_path / "files.txt"
+    file_list.write_text(str(source), encoding="utf-8")
+    output = tmp_path / "out"
+
+    result = _run_cli("--file-list", str(file_list), "--output-dir", str(output))
+
+    assert result.returncode == 0, result.stderr
+    assert "input_type=file_list" in result.stdout
+    assert "files=1" in result.stdout
+
+
+def test_unsupported_runtime_is_rejected(tmp_path: Path):
+    result = _run_cli("--fixture", "clean", "--runtime", "unsafe", "--output-dir", str(tmp_path))
+
+    assert result.returncode != 0
+    assert "invalid choice" in result.stderr
+
+
+def test_local_runtime_requires_explicit_allow_local(tmp_path: Path):
+    result = _run_cli("--fixture", "clean", "--runtime", "local-dev", "--output-dir", str(tmp_path))
+
+    assert result.returncode != 0
+    assert "--runtime local-dev requires --allow-local" in result.stderr
+
+
+def test_container_and_cube_runtime_write_human_review_artifacts(tmp_path: Path):
+    container_output = tmp_path / "container"
+    container = _run_cli(
+        "--fixture",
+        "clean",
+        "--runtime",
+        "container",
+        "--docker-base-url",
+        "unix:///tmp/skills-code-review-agent-missing-docker.sock",
+        "--output-dir",
+        str(container_output),
+    )
+    assert container.returncode == 0, container.stderr
+    container_report = _read_report(container_output)
+    assert container_report["sandbox_runs"][0]["status"] == "needs_human_review"
+    assert container_report["interceptions"][0]["decision"] == "needs_human_review"
+
+    cube_output = tmp_path / "cube"
+    cube = _run_cli("--fixture", "clean", "--runtime", "cube", "--output-dir", str(cube_output))
+    assert cube.returncode == 0, cube.stderr
+    cube_report = _read_report(cube_output)
+    assert cube_report["sandbox_runs"][0]["status"] == "needs_human_review"
+    assert cube_report["interceptions"][0]["decision"] == "needs_human_review"
+
+
+def test_local_runtime_with_allow_executes_rule_runner(tmp_path: Path):
+    output = tmp_path / "out"
+
+    result = _run_cli("--fixture", "clean", "--runtime", "local-dev", "--allow-local", "--output-dir", str(output))
+
+    assert result.returncode == 0, result.stderr
+    report = _read_report(output)
+    assert report["sandbox_runs"][0]["status"] == "success"
+    assert report["sandbox_runs"][0]["exit_code"] == 0
+
+
+def test_missing_input_path_returns_clear_error(tmp_path: Path):
+    missing = tmp_path / "missing.diff"
+
+    result = _run_cli("--diff-file", str(missing), "--output-dir", str(tmp_path / "out"))
+
+    assert result.returncode != 0
+    assert "diff file not found" in result.stderr
+
+
+def test_cli_creates_database_and_final_reports(tmp_path: Path):
+    output = tmp_path / "out"
+
+    result = _run_cli("--fixture", "clean", "--output-dir", str(output))
+
+    assert result.returncode == 0, result.stderr
+    task_id = _stdout_value(result.stdout, "task_id")
+    db_path = _stdout_value(result.stdout, "db_path")
+    with ReviewStore(db_path) as store:
+        assert store.get_task(task_id)["status"] == "done"
+        assert store.get_report(task_id)["report_json"]["task_id"] == task_id
+
+
+def test_cli_module_execution_works(tmp_path: Path):
+    output = tmp_path / "out"
+    root = Path(__file__).parents[1]
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "examples.skills_code_review_agent.run_review",
+            "--fixture",
+            "clean",
+            "--output-dir",
+            str(output),
+        ],
+        cwd=root.parents[1],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "input_type=fixture" in result.stdout
+
+
+def _run_cli(*args: str) -> subprocess.CompletedProcess[str]:
+    root = Path(__file__).parents[1]
+    return subprocess.run(
+        [sys.executable, "run_review.py", *args],
+        cwd=root,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _read_report(output: Path) -> dict:
+    return json.loads((output / "review_report.json").read_text(encoding="utf-8"))
+
+
+def _stdout_value(stdout: str, key: str) -> str:
+    prefix = f"{key}="
+    for line in stdout.splitlines():
+        if line.startswith(prefix):
+            return line[len(prefix):]
+    raise AssertionError(f"missing stdout key: {key}")
+
+
+def _sample_diff() -> str:
+    return """diff --git a/app.py b/app.py
+--- a/app.py
++++ b/app.py
+@@ -1 +1 @@
+-old
++new
+"""

--- a/examples/skills_code_review_agent/tests/test_code_review_example.py
+++ b/examples/skills_code_review_agent/tests/test_code_review_example.py
@@ -23,6 +23,9 @@ from examples.skills_code_review_agent.agent import dedupe_findings
 from examples.skills_code_review_agent.agent import parse_fixture
 from examples.skills_code_review_agent.agent import run_review_pipeline
 from examples.skills_code_review_agent.agent import run_review_rules
+from examples.skills_code_review_agent.tests.secret_samples import generic_api_key_value
+from examples.skills_code_review_agent.tests.secret_samples import generic_bearer_value
+from examples.skills_code_review_agent.tests.secret_samples import generic_password_value
 
 
 @pytest.mark.parametrize(
@@ -112,15 +115,15 @@ def test_secret_fixture_redacts_every_persisted_boundary(tmp_path: Path):
     assert any(item.category is FindingCategory.SECRET for item in result.findings)
 
     report_text = json.dumps(result.report.to_dict())
-    assert "sk-live-1234567890abcdef" not in report_text
-    assert "correct-horse-battery-staple" not in report_text
-    assert "very-long-token-value-123456" not in report_text
+    assert generic_api_key_value() not in report_text
+    assert generic_password_value() not in report_text
+    assert generic_bearer_value() not in report_text
 
     with ReviewStore(output_dir / "review.sqlite3") as store:
         rows = store.list_findings(result.task.id)
         assert rows
-        assert "sk-live-1234567890abcdef" not in json.dumps(rows)
-        assert "correct-horse-battery-staple" not in json.dumps(rows)
+        assert generic_api_key_value() not in json.dumps(rows)
+        assert generic_password_value() not in json.dumps(rows)
 
 
 def test_public_fixture_parser_preserves_added_line_locations():

--- a/examples/skills_code_review_agent/tests/test_code_review_example.py
+++ b/examples/skills_code_review_agent/tests/test_code_review_example.py
@@ -1,0 +1,130 @@
+# Tencent is pleased to support the open source community by making tRPC-Agent-Python available.
+#
+# Copyright (C) 2026 Tencent. All rights reserved.
+#
+# tRPC-Agent-Python is licensed under Apache-2.0.
+"""Public fixture regression tests for the skills code-review example."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from examples.skills_code_review_agent.agent import FindingCategory
+from examples.skills_code_review_agent.agent import InputType
+from examples.skills_code_review_agent.agent import ReviewPipelineConfig
+from examples.skills_code_review_agent.agent import ReviewStore
+from examples.skills_code_review_agent.agent import RuntimeKind
+from examples.skills_code_review_agent.agent import SandboxStatus
+from examples.skills_code_review_agent.agent import dedupe_findings
+from examples.skills_code_review_agent.agent import parse_fixture
+from examples.skills_code_review_agent.agent import run_review_pipeline
+from examples.skills_code_review_agent.agent import run_review_rules
+
+
+@pytest.mark.parametrize(
+    ("fixture", "category"),
+    (
+        ("clean", None),
+        ("security", FindingCategory.SECURITY),
+        ("async_leak", FindingCategory.ASYNC),
+        ("db_lifecycle", FindingCategory.DB),
+        ("missing_tests", FindingCategory.TEST),
+        ("duplicate", FindingCategory.SECURITY),
+        ("sandbox_failure", None),
+        ("secret", FindingCategory.SECRET),
+    ),
+)
+def test_public_fixture_generates_complete_review(fixture: str, category: FindingCategory | None, tmp_path: Path):
+    output_dir = tmp_path / fixture
+    result = run_review_pipeline(
+        ReviewPipelineConfig(
+            input_type=InputType.FIXTURE,
+            input_ref=fixture,
+            output_dir=output_dir,
+            db_path=output_dir / "review.sqlite3",
+        ))
+
+    assert result.task.status.value == "done"
+    assert result.report.task_id == result.task.id
+    assert result.report.metrics.total_duration_ms >= 0
+
+    with ReviewStore(output_dir / "review.sqlite3") as store:
+        assert store.get_task(result.task.id)["status"] == "done"
+        assert store.get_input_summary(result.task.id)["task_id"] == result.task.id
+        assert store.get_report(result.task.id)["report_json"]["task_id"] == result.task.id
+        assert store.list_sandbox_runs(result.task.id)
+
+    if category is not None:
+        all_findings = [*result.findings, *result.warnings, *result.needs_human_review]
+        assert category in {finding.category for finding in all_findings}
+
+    if fixture == "clean":
+        assert result.findings == []
+        assert result.warnings == []
+    elif fixture == "missing_tests":
+        assert any(item.category is FindingCategory.TEST for item in result.warnings)
+        assert all(item.category is not FindingCategory.TEST for item in result.findings)
+    elif fixture == "duplicate":
+        rule_findings = run_review_rules(parse_fixture(fixture, task_id="dedupe-check"))
+        assert len(rule_findings) > len(dedupe_findings(rule_findings))
+
+
+def test_sandbox_failure_fixture_is_persisted_and_does_not_crash(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+
+    def raise_timeout(*args, **kwargs):
+        raise subprocess.TimeoutExpired(cmd=["python", "rule_runner.py"], timeout=1, output="password=secret-value")
+
+    monkeypatch.setattr("examples.skills_code_review_agent.agent.sandbox.subprocess.run", raise_timeout)
+    output_dir = tmp_path / "sandbox-failure"
+    result = run_review_pipeline(
+        ReviewPipelineConfig(
+            input_type=InputType.FIXTURE,
+            input_ref="sandbox_failure",
+            output_dir=output_dir,
+            db_path=output_dir / "review.sqlite3",
+            runtime=RuntimeKind.LOCAL_DEV,
+            allow_local=True,
+            timeout_sec=1,
+        ))
+
+    assert result.sandbox_runs[0].status is SandboxStatus.TIMEOUT
+    assert any(item.category is FindingCategory.SANDBOX for item in result.needs_human_review)
+    assert "secret-value" not in json.dumps(result.report.to_dict())
+    with ReviewStore(output_dir / "review.sqlite3") as store:
+        sandbox_rows = store.list_sandbox_runs(result.task.id)
+        assert sandbox_rows[0]["status"] == "timeout"
+        assert "secret-value" not in json.dumps(sandbox_rows)
+
+
+def test_secret_fixture_redacts_every_persisted_boundary(tmp_path: Path):
+    output_dir = tmp_path / "secret"
+    result = run_review_pipeline(
+        ReviewPipelineConfig(
+            input_type=InputType.FIXTURE,
+            input_ref="secret",
+            output_dir=output_dir,
+            db_path=output_dir / "review.sqlite3",
+        ))
+    assert any(item.category is FindingCategory.SECRET for item in result.findings)
+
+    report_text = json.dumps(result.report.to_dict())
+    assert "sk-live-1234567890abcdef" not in report_text
+    assert "correct-horse-battery-staple" not in report_text
+    assert "very-long-token-value-123456" not in report_text
+
+    with ReviewStore(output_dir / "review.sqlite3") as store:
+        rows = store.list_findings(result.task.id)
+        assert rows
+        assert "sk-live-1234567890abcdef" not in json.dumps(rows)
+        assert "correct-horse-battery-staple" not in json.dumps(rows)
+
+
+def test_public_fixture_parser_preserves_added_line_locations():
+    summary = parse_fixture("security", task_id="parser-check")
+    assert summary.file_count == 1
+    assert summary.changed_files[0].candidate_lines == [3, 4, 5, 6]
+    assert summary.changed_files[0].hunks[0].lines[-1].new_line == 6

--- a/examples/skills_code_review_agent/tests/test_governance.py
+++ b/examples/skills_code_review_agent/tests/test_governance.py
@@ -77,6 +77,42 @@ def test_shell_payload_split_rm_flags_are_denied(tmp_path: Path):
         assert event.reason_code is FilterReasonCode.HIGH_RISK_COMMAND
 
 
+def test_sensitive_redirect_variants_are_denied(tmp_path: Path):
+    commands = [
+        ["bash", "-lc", "echo value >/etc/passwd"],
+        ["bash", "-lc", "echo value 2>/var/log/example"],
+        ["bash", "-lc", "echo value > /usr/local/example"],
+        ["tee", "/etc/passwd"],
+        ["cp", "/tmp/source", "/etc/passwd"],
+        ["dd", "if=/tmp/source", "of=/dev/sda"],
+    ]
+
+    for command in commands:
+        event = evaluate_execution_request("task", _request(tmp_path, RuntimeKind.DRY_RUN, command=command))
+        assert event.reason_code is FilterReasonCode.HIGH_RISK_COMMAND
+
+
+def test_shell_newline_and_substitution_are_denied(tmp_path: Path):
+    commands = [
+        ["bash", "-lc", "echo safe\nrm -r -f /tmp/example"],
+        ["bash", "-lc", "echo $(rm -rf /tmp/example)"],
+        ["bash", "-lc", "echo `rm -rf /tmp/example`"],
+    ]
+
+    for command in commands:
+        event = evaluate_execution_request("task", _request(tmp_path, RuntimeKind.DRY_RUN, command=command))
+        assert event.reason_code is FilterReasonCode.HIGH_RISK_COMMAND
+
+
+def test_safe_temporary_write_is_not_blocked(tmp_path: Path):
+    event = evaluate_execution_request(
+        "task",
+        _request(tmp_path, RuntimeKind.DRY_RUN, command=["tee", str(tmp_path / "result.txt")]),
+    )
+
+    assert event.decision is FilterDecision.ALLOW
+
+
 def test_network_command_needs_human_review(tmp_path: Path):
     request = _request(tmp_path, RuntimeKind.DRY_RUN, command=["curl", "https://example.com"])
 

--- a/examples/skills_code_review_agent/tests/test_governance.py
+++ b/examples/skills_code_review_agent/tests/test_governance.py
@@ -54,19 +54,27 @@ def test_dangerous_command_is_denied(tmp_path: Path):
 
 
 def test_recursive_flag_variants_are_denied(tmp_path: Path):
-    rm_event = evaluate_execution_request(
-        "task",
-        _request(tmp_path, RuntimeKind.DRY_RUN, command=["rm", "--recursive", "--force",
-                                                         str(tmp_path)]),
-    )
-    chmod_event = evaluate_execution_request(
-        "task",
-        _request(tmp_path, RuntimeKind.DRY_RUN, command=["chmod", "--recursive", "777",
-                                                         str(tmp_path)]),
-    )
+    commands = [
+        ["rm", "--recursive", "--force", str(tmp_path)],
+        ["rm", "--force", "--recursive", str(tmp_path)],
+        ["rm", "-r", "-f", str(tmp_path)],
+        ["rm", "-f", "-r", str(tmp_path)],
+        ["chmod", "--recursive", "777", str(tmp_path)],
+    ]
 
-    assert rm_event.reason_code is FilterReasonCode.HIGH_RISK_COMMAND
-    assert chmod_event.reason_code is FilterReasonCode.HIGH_RISK_COMMAND
+    for command in commands:
+        event = evaluate_execution_request("task", _request(tmp_path, RuntimeKind.DRY_RUN, command=command))
+        assert event.reason_code is FilterReasonCode.HIGH_RISK_COMMAND
+
+
+def test_shell_payload_split_rm_flags_are_denied(tmp_path: Path):
+    for payload in ("rm -r -f /tmp/example", "rm -f -r /tmp/example"):
+        event = evaluate_execution_request(
+            "task",
+            _request(tmp_path, RuntimeKind.DRY_RUN, command=["bash", "-lc", payload]),
+        )
+
+        assert event.reason_code is FilterReasonCode.HIGH_RISK_COMMAND
 
 
 def test_network_command_needs_human_review(tmp_path: Path):

--- a/examples/skills_code_review_agent/tests/test_governance.py
+++ b/examples/skills_code_review_agent/tests/test_governance.py
@@ -1,0 +1,120 @@
+# Tencent is pleased to support the open source community by making tRPC-Agent-Python available.
+#
+# Copyright (C) 2026 Tencent. All rights reserved.
+#
+# tRPC-Agent-Python is licensed under Apache-2.0.
+"""Business tests for example-local execution governance."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from examples.skills_code_review_agent.agent import ExecutionRequest
+from examples.skills_code_review_agent.agent import FilterDecision
+from examples.skills_code_review_agent.agent import FilterReasonCode
+from examples.skills_code_review_agent.agent import RuntimeKind
+from examples.skills_code_review_agent.agent import evaluate_execution_request
+
+
+def test_dry_run_rule_runner_command_is_allowed(tmp_path: Path):
+    request = _request(tmp_path, RuntimeKind.DRY_RUN)
+
+    event = evaluate_execution_request("task", request)
+
+    assert event.decision is FilterDecision.ALLOW
+
+
+def test_local_dev_requires_explicit_allow_local(tmp_path: Path):
+    event = evaluate_execution_request("task", _request(tmp_path, RuntimeKind.LOCAL_DEV, allow_local=False))
+
+    assert event.decision is FilterDecision.DENY
+    assert event.reason_code is FilterReasonCode.LOCAL_RUNTIME_DENIED
+
+
+def test_local_dev_is_allowed_when_explicit(tmp_path: Path):
+    event = evaluate_execution_request("task", _request(tmp_path, RuntimeKind.LOCAL_DEV, allow_local=True))
+
+    assert event.decision is FilterDecision.ALLOW
+
+
+def test_container_and_cube_need_human_review(tmp_path: Path):
+    for runtime in (RuntimeKind.CONTAINER, RuntimeKind.CUBE):
+        event = evaluate_execution_request("task", _request(tmp_path, runtime))
+        assert event.decision is FilterDecision.ALLOW
+
+
+def test_dangerous_command_is_denied(tmp_path: Path):
+    request = _request(tmp_path, RuntimeKind.DRY_RUN, command=["rm", "-rf", str(tmp_path)])
+
+    event = evaluate_execution_request("task", request)
+
+    assert event.decision is FilterDecision.DENY
+    assert event.reason_code is FilterReasonCode.HIGH_RISK_COMMAND
+
+
+def test_network_command_needs_human_review(tmp_path: Path):
+    request = _request(tmp_path, RuntimeKind.DRY_RUN, command=["curl", "https://example.com"])
+
+    event = evaluate_execution_request("task", request)
+
+    assert event.decision is FilterDecision.NEEDS_HUMAN_REVIEW
+    assert event.reason_code is FilterReasonCode.NETWORK_DENIED
+
+
+def test_forbidden_path_is_denied(tmp_path: Path):
+    request = ExecutionRequest(
+        command=["python", "rule_runner.py"],
+        runtime=RuntimeKind.DRY_RUN,
+        cwd="/etc",
+        script_path=str(tmp_path / "rule_runner.py"),
+        allowed_roots=(str(tmp_path), ),
+    )
+
+    event = evaluate_execution_request("task", request)
+
+    assert event.decision is FilterDecision.DENY
+    assert event.reason_code is FilterReasonCode.FORBIDDEN_PATH
+
+
+def test_timeout_and_output_budget_are_denied(tmp_path: Path):
+    timeout_event = evaluate_execution_request("task", _request(tmp_path, RuntimeKind.DRY_RUN, timeout_sec=121))
+    output_event = evaluate_execution_request("task", _request(tmp_path, RuntimeKind.DRY_RUN, output_limit_bytes=0))
+
+    assert timeout_event.reason_code is FilterReasonCode.BUDGET_EXCEEDED
+    assert output_event.reason_code is FilterReasonCode.OUTPUT_LIMIT_EXCEEDED
+
+
+def test_environment_allowlist_is_enforced_and_redacted(tmp_path: Path):
+    allowed = evaluate_execution_request("task", _request(tmp_path, RuntimeKind.DRY_RUN, env={"PATH": "/usr/bin"}))
+    denied = evaluate_execution_request(
+        "task",
+        _request(tmp_path, RuntimeKind.DRY_RUN, env={"API_KEY": "sk-live-secretvalue"}),
+    )
+
+    assert allowed.decision is FilterDecision.ALLOW
+    assert denied.decision is FilterDecision.DENY
+    assert denied.reason_code is FilterReasonCode.ENV_NOT_ALLOWED
+    assert "secretvalue" not in str(denied.to_dict())
+
+
+def _request(
+    tmp_path: Path,
+    runtime: RuntimeKind,
+    *,
+    command: list[str] | None = None,
+    allow_local: bool = False,
+    timeout_sec: float = 30,
+    output_limit_bytes: int = 65536,
+    env: dict[str, str] | None = None,
+) -> ExecutionRequest:
+    return ExecutionRequest(
+        command=command or ["python", "rule_runner.py"],
+        runtime=runtime,
+        cwd=str(tmp_path),
+        script_path=str(tmp_path / "rule_runner.py"),
+        allowed_roots=(str(tmp_path), ),
+        allow_local=allow_local,
+        timeout_sec=timeout_sec,
+        output_limit_bytes=output_limit_bytes,
+        env=env or {},
+    )

--- a/examples/skills_code_review_agent/tests/test_governance.py
+++ b/examples/skills_code_review_agent/tests/test_governance.py
@@ -14,6 +14,7 @@ from examples.skills_code_review_agent.agent import FilterDecision
 from examples.skills_code_review_agent.agent import FilterReasonCode
 from examples.skills_code_review_agent.agent import RuntimeKind
 from examples.skills_code_review_agent.agent import evaluate_execution_request
+from examples.skills_code_review_agent.tests.secret_samples import openai_live_like_token
 
 
 def test_dry_run_rule_runner_command_is_allowed(tmp_path: Path):
@@ -52,6 +53,22 @@ def test_dangerous_command_is_denied(tmp_path: Path):
     assert event.reason_code is FilterReasonCode.HIGH_RISK_COMMAND
 
 
+def test_recursive_flag_variants_are_denied(tmp_path: Path):
+    rm_event = evaluate_execution_request(
+        "task",
+        _request(tmp_path, RuntimeKind.DRY_RUN, command=["rm", "--recursive", "--force",
+                                                         str(tmp_path)]),
+    )
+    chmod_event = evaluate_execution_request(
+        "task",
+        _request(tmp_path, RuntimeKind.DRY_RUN, command=["chmod", "--recursive", "777",
+                                                         str(tmp_path)]),
+    )
+
+    assert rm_event.reason_code is FilterReasonCode.HIGH_RISK_COMMAND
+    assert chmod_event.reason_code is FilterReasonCode.HIGH_RISK_COMMAND
+
+
 def test_network_command_needs_human_review(tmp_path: Path):
     request = _request(tmp_path, RuntimeKind.DRY_RUN, command=["curl", "https://example.com"])
 
@@ -59,6 +76,25 @@ def test_network_command_needs_human_review(tmp_path: Path):
 
     assert event.decision is FilterDecision.NEEDS_HUMAN_REVIEW
     assert event.reason_code is FilterReasonCode.NETWORK_DENIED
+
+
+def test_argv_aware_network_detection_reduces_false_positives(tmp_path: Path):
+    binary_event = evaluate_execution_request(
+        "task",
+        _request(tmp_path, RuntimeKind.DRY_RUN, command=["/usr/bin/curl", "https://example.com"]),
+    )
+    literal_event = evaluate_execution_request(
+        "task",
+        _request(tmp_path, RuntimeKind.DRY_RUN, command=["echo", "curl"]),
+    )
+    shell_event = evaluate_execution_request(
+        "task",
+        _request(tmp_path, RuntimeKind.DRY_RUN, command=["bash", "-lc", "curl https://example.com"]),
+    )
+
+    assert binary_event.reason_code is FilterReasonCode.NETWORK_DENIED
+    assert literal_event.decision is FilterDecision.ALLOW
+    assert shell_event.reason_code is FilterReasonCode.NETWORK_DENIED
 
 
 def test_forbidden_path_is_denied(tmp_path: Path):
@@ -76,6 +112,33 @@ def test_forbidden_path_is_denied(tmp_path: Path):
     assert event.reason_code is FilterReasonCode.FORBIDDEN_PATH
 
 
+def test_referenced_paths_must_stay_within_allowed_roots(tmp_path: Path):
+    outside_input = tmp_path.parent / "outside-input.json"
+    outside_manifest = tmp_path.parent / "outside-manifest.json"
+    outside_output = tmp_path.parent / "outside-output.json"
+
+    input_event = evaluate_execution_request(
+        "task",
+        _request(tmp_path, RuntimeKind.DRY_RUN, referenced_paths=(str(outside_input), )),
+    )
+    manifest_event = evaluate_execution_request(
+        "task",
+        _request(tmp_path, RuntimeKind.DRY_RUN, referenced_paths=(str(tmp_path / "in.json"), str(outside_manifest))),
+    )
+    output_event = evaluate_execution_request(
+        "task",
+        _request(
+            tmp_path,
+            RuntimeKind.DRY_RUN,
+            referenced_paths=(str(tmp_path / "in.json"), str(tmp_path / "manifest.json"), str(outside_output)),
+        ),
+    )
+
+    assert input_event.reason_code is FilterReasonCode.FORBIDDEN_PATH
+    assert manifest_event.reason_code is FilterReasonCode.FORBIDDEN_PATH
+    assert output_event.reason_code is FilterReasonCode.FORBIDDEN_PATH
+
+
 def test_timeout_and_output_budget_are_denied(tmp_path: Path):
     timeout_event = evaluate_execution_request("task", _request(tmp_path, RuntimeKind.DRY_RUN, timeout_sec=121))
     output_event = evaluate_execution_request("task", _request(tmp_path, RuntimeKind.DRY_RUN, output_limit_bytes=0))
@@ -88,7 +151,7 @@ def test_environment_allowlist_is_enforced_and_redacted(tmp_path: Path):
     allowed = evaluate_execution_request("task", _request(tmp_path, RuntimeKind.DRY_RUN, env={"PATH": "/usr/bin"}))
     denied = evaluate_execution_request(
         "task",
-        _request(tmp_path, RuntimeKind.DRY_RUN, env={"API_KEY": "sk-live-secretvalue"}),
+        _request(tmp_path, RuntimeKind.DRY_RUN, env={"API_KEY": openai_live_like_token()}),
     )
 
     assert allowed.decision is FilterDecision.ALLOW
@@ -98,14 +161,15 @@ def test_environment_allowlist_is_enforced_and_redacted(tmp_path: Path):
 
 
 def _request(
-    tmp_path: Path,
-    runtime: RuntimeKind,
-    *,
-    command: list[str] | None = None,
-    allow_local: bool = False,
-    timeout_sec: float = 30,
-    output_limit_bytes: int = 65536,
-    env: dict[str, str] | None = None,
+        tmp_path: Path,
+        runtime: RuntimeKind,
+        *,
+        command: list[str] | None = None,
+        allow_local: bool = False,
+        timeout_sec: float = 30,
+        output_limit_bytes: int = 65536,
+        env: dict[str, str] | None = None,
+        referenced_paths: tuple[str, ...] = (),
 ) -> ExecutionRequest:
     return ExecutionRequest(
         command=command or ["python", "rule_runner.py"],
@@ -117,4 +181,5 @@ def _request(
         timeout_sec=timeout_sec,
         output_limit_bytes=output_limit_bytes,
         env=env or {},
+        referenced_paths=referenced_paths,
     )

--- a/examples/skills_code_review_agent/tests/test_input_parser.py
+++ b/examples/skills_code_review_agent/tests/test_input_parser.py
@@ -1,0 +1,222 @@
+# Tencent is pleased to support the open source community by making tRPC-Agent-Python available.
+#
+# Copyright (C) 2026 Tencent. All rights reserved.
+#
+# tRPC-Agent-Python is licensed under Apache-2.0.
+"""Business tests for unified diff normalization."""
+
+from __future__ import annotations
+
+from examples.skills_code_review_agent.agent import InputType
+from examples.skills_code_review_agent.agent import parse_file_list
+from examples.skills_code_review_agent.agent import parse_unified_diff
+
+
+def test_parser_preserves_added_line_numbers():
+    summary = parse_unified_diff(
+        """diff --git a/src/app.py b/src/app.py
+index 1111111..2222222 100644
+--- a/src/app.py
++++ b/src/app.py
+@@ -2,3 +2,4 @@ def run():
+     value = 1
+-    return value
++    value = value + 1
++    return value
+""",
+        task_id="task-1",
+    )
+
+    changed = summary.changed_files[0]
+    assert summary.input_type is InputType.DIFF_FILE
+    assert changed.path == "src/app.py"
+    assert changed.candidate_lines == [3, 4]
+    assert changed.hunks[0].lines[2].new_line == 3
+    assert changed.hunks[0].lines[1].old_line == 3
+
+
+def test_new_file_candidate_lines_are_added_lines_only():
+    summary = parse_unified_diff(
+        """diff --git a/new.py b/new.py
+new file mode 100644
+--- /dev/null
++++ b/new.py
+@@ -0,0 +1,3 @@
++first
++
++third
+""",
+        task_id="task-2",
+    )
+
+    changed = summary.changed_files[0]
+    assert changed.status == "added"
+    assert changed.added_lines == 3
+    assert changed.deleted_lines == 0
+    assert changed.candidate_lines == [1, 2, 3]
+
+
+def test_deleted_file_preserves_old_path():
+    summary = parse_unified_diff(
+        """diff --git a/removed.txt b/removed.txt
+deleted file mode 100644
+--- a/removed.txt
++++ /dev/null
+@@ -1,2 +0,0 @@
+-one
+-two
+""",
+        task_id="task-3",
+    )
+
+    changed = summary.changed_files[0]
+    assert changed.status == "deleted"
+    assert changed.old_path == "removed.txt"
+    assert changed.path == "removed.txt"
+    assert changed.candidate_lines == []
+
+
+def test_rename_preserves_old_and_new_paths():
+    summary = parse_unified_diff(
+        """diff --git a/old.py b/new.py
+similarity index 88%
+rename from old.py
+rename to new.py
+--- a/old.py
++++ b/new.py
+@@ -1 +1 @@
+-old_name()
++new_name()
+""",
+        task_id="task-4",
+    )
+
+    changed = summary.changed_files[0]
+    assert changed.status == "renamed"
+    assert changed.old_path == "old.py"
+    assert changed.path == "new.py"
+    assert changed.candidate_lines == [1]
+
+
+def test_multi_file_multi_hunk_diff_is_counted():
+    summary = parse_unified_diff(
+        """diff --git a/a.py b/a.py
+--- a/a.py
++++ b/a.py
+@@ -1 +1 @@
+-a = 1
++a = 2
+@@ -10 +10,2 @@ section
+ keep = True
++extra = True
+diff --git a/b.py b/b.py
+--- a/b.py
++++ b/b.py
+@@ -3 +3 @@
+-b = 1
++b = 2
+""",
+        task_id="task-5",
+    )
+
+    assert summary.file_count == 2
+    assert summary.hunk_count == 3
+    assert summary.added_lines == 3
+    assert summary.deleted_lines == 2
+    assert summary.changed_files[0].hunks[1].section_header == "section"
+
+
+def test_context_lines_are_preserved():
+    summary = parse_unified_diff(
+        """diff --git a/app.py b/app.py
+--- a/app.py
++++ b/app.py
+@@ -1,3 +1,3 @@
+ def run():
+-    return 1
++    return 2
+ # tail
+""",
+        task_id="task-6",
+    )
+
+    lines = summary.changed_files[0].hunks[0].lines
+    assert [line.line_type for line in lines] == ["context", "deleted", "added", "context"]
+    assert lines[0].old_line == 1
+    assert lines[0].new_line == 1
+
+
+def test_binary_patch_records_diagnostic_without_failure():
+    summary = parse_unified_diff(
+        """diff --git a/image.bin b/image.bin
+new file mode 100644
+Binary files /dev/null and b/image.bin differ
+""",
+        task_id="task-7",
+    )
+
+    changed = summary.changed_files[0]
+    assert changed.status == "added"
+    assert changed.is_binary is True
+    assert changed.hunks == []
+    assert any("binary patch" in item for item in summary.diagnostics)
+
+
+def test_malformed_hunk_keeps_parsed_content_and_diagnostics():
+    summary = parse_unified_diff(
+        """diff --git a/good.py b/good.py
+--- a/good.py
++++ b/good.py
+@@ -1 +1 @@
+-old
++new
+diff --git a/bad.py b/bad.py
+--- a/bad.py
++++ b/bad.py
+@@ broken
++lost
+""",
+        task_id="task-8",
+    )
+
+    assert summary.file_count == 2
+    assert summary.changed_files[0].candidate_lines == [1]
+    assert any("malformed hunk header" in item for item in summary.diagnostics)
+
+
+def test_empty_diff_returns_stable_empty_summary():
+    summary = parse_unified_diff("", task_id="task-9")
+
+    assert summary.changed_files == []
+    assert summary.file_count == 0
+    assert summary.raw_diff_sha256 == "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+
+
+def test_same_diff_has_same_sha256_digest():
+    diff = """diff --git a/a.py b/a.py
+--- a/a.py
++++ b/a.py
+@@ -1 +1 @@
+-a
++b
+"""
+
+    first = parse_unified_diff(diff, task_id="task-a")
+    second = parse_unified_diff(diff, task_id="task-b")
+
+    assert first.raw_diff_sha256 == second.raw_diff_sha256
+
+
+def test_file_list_input_builds_added_file_summary(tmp_path):
+    source = tmp_path / "app.py"
+    source.write_text("print('hello')\n", encoding="utf-8")
+    file_list = tmp_path / "files.txt"
+    file_list.write_text("# comment\napp.py\nmissing.py\n", encoding="utf-8")
+
+    summary = parse_file_list(file_list, task_id="task-file-list")
+
+    assert summary.input_type is InputType.FILE_LIST
+    assert summary.file_count == 1
+    assert summary.changed_files[0].status == "added"
+    assert summary.changed_files[0].candidate_lines == [1]
+    assert any("missing.py" in item for item in summary.diagnostics)

--- a/examples/skills_code_review_agent/tests/test_pipeline.py
+++ b/examples/skills_code_review_agent/tests/test_pipeline.py
@@ -11,6 +11,8 @@ import json
 import subprocess
 from pathlib import Path
 
+import examples.skills_code_review_agent.agent.pipeline as pipeline_module
+import examples.skills_code_review_agent.agent.report as report_module
 from examples.skills_code_review_agent.agent import InputType
 from examples.skills_code_review_agent.agent import ReviewPipelineConfig
 from examples.skills_code_review_agent.agent import ReviewStore
@@ -107,3 +109,53 @@ def test_pipeline_uses_injected_store_factory(tmp_path: Path):
     assert saved
     assert saved[0]["task"].id == result.task.id
     assert saved[0]["report"].task_id == result.task.id
+
+
+def test_pipeline_routes_findings_once_and_reuses_results(tmp_path: Path, monkeypatch):
+    saved: list[dict] = []
+    route_calls = {"count": 0}
+    original_route = pipeline_module._route_findings
+
+    class FakeStore:
+
+        def __init__(self, db_path):
+            self.db_path = db_path
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return None
+
+        def save_review(self, **kwargs):
+            saved.append(kwargs)
+
+    def counting_route(*args, **kwargs):
+        route_calls["count"] += 1
+        return original_route(*args, **kwargs)
+
+    def unexpected_report_route(*args, **kwargs):
+        raise AssertionError("build_review_report should reuse precomputed routed findings")
+
+    monkeypatch.setattr(pipeline_module, "_route_findings", counting_route)
+    monkeypatch.setattr(report_module, "_route_findings", unexpected_report_route)
+
+    result = run_review_pipeline(
+        ReviewPipelineConfig(
+            input_type=InputType.FIXTURE,
+            input_ref="secret",
+            output_dir=tmp_path,
+            db_path=tmp_path / "review.sqlite3",
+            store_factory=FakeStore,
+        ))
+
+    assert route_calls["count"] == 1
+    assert saved
+    assert [item.to_dict() for item in saved[0]["findings"]] == [item.to_dict() for item in result.findings]
+    assert [item.to_dict() for item in saved[0]["warnings"]] == [item.to_dict() for item in result.warnings]
+    assert [item.to_dict()
+            for item in saved[0]["needs_human_review"]] == [item.to_dict() for item in result.needs_human_review]
+    assert [item.to_dict() for item in result.report.findings] == [item.to_dict() for item in result.findings]
+    assert [item.to_dict() for item in result.report.warnings] == [item.to_dict() for item in result.warnings]
+    assert [item.to_dict()
+            for item in result.report.needs_human_review] == [item.to_dict() for item in result.needs_human_review]

--- a/examples/skills_code_review_agent/tests/test_pipeline.py
+++ b/examples/skills_code_review_agent/tests/test_pipeline.py
@@ -1,0 +1,109 @@
+# Tencent is pleased to support the open source community by making tRPC-Agent-Python available.
+#
+# Copyright (C) 2026 Tencent. All rights reserved.
+#
+# tRPC-Agent-Python is licensed under Apache-2.0.
+"""Business tests for the end-to-end review pipeline."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+from examples.skills_code_review_agent.agent import InputType
+from examples.skills_code_review_agent.agent import ReviewPipelineConfig
+from examples.skills_code_review_agent.agent import ReviewStore
+from examples.skills_code_review_agent.agent import RuntimeKind
+from examples.skills_code_review_agent.agent import SandboxStatus
+from examples.skills_code_review_agent.agent import run_review_pipeline
+
+
+def test_dry_run_pipeline_writes_artifacts_database_and_reports(tmp_path: Path):
+    result = run_review_pipeline(
+        ReviewPipelineConfig(
+            input_type=InputType.FIXTURE,
+            input_ref="clean",
+            output_dir=tmp_path,
+            db_path=tmp_path / "review.sqlite3",
+        ))
+
+    assert result.task.status.value == "done"
+    assert result.report.task_id == result.task.id
+    assert result.sandbox_runs[0].status is SandboxStatus.SUCCESS
+    with ReviewStore(tmp_path / "review.sqlite3") as store:
+        assert store.get_task(result.task.id)["status"] == "done"
+        assert store.get_metrics(result.task.id)["finding_count"] == result.report.metrics.finding_count
+        assert store.get_report(result.task.id)["report_json"]["task_id"] == result.task.id
+
+
+def test_container_pipeline_records_human_review_without_real_container(tmp_path: Path):
+    result = run_review_pipeline(
+        ReviewPipelineConfig(
+            input_type=InputType.FIXTURE,
+            input_ref="clean",
+            output_dir=tmp_path,
+            db_path=tmp_path / "review.sqlite3",
+            runtime=RuntimeKind.CONTAINER,
+            docker_base_url="unix:///tmp/skills-code-review-agent-missing-docker.sock",
+        ))
+
+    assert result.sandbox_runs[0].status is SandboxStatus.NEEDS_HUMAN_REVIEW
+    assert result.needs_human_review
+    assert result.report.needs_human_review
+
+
+def test_sandbox_timeout_does_not_crash_pipeline(tmp_path: Path, monkeypatch):
+
+    def raise_timeout(*args, **kwargs):
+        raise subprocess.TimeoutExpired(cmd=["python"], timeout=1, output="password=plainsecret")
+
+    monkeypatch.setattr("examples.skills_code_review_agent.agent.sandbox.subprocess.run", raise_timeout)
+    result = run_review_pipeline(
+        ReviewPipelineConfig(
+            input_type=InputType.FIXTURE,
+            input_ref="clean",
+            output_dir=tmp_path,
+            db_path=tmp_path / "review.sqlite3",
+            runtime=RuntimeKind.LOCAL_DEV,
+            allow_local=True,
+            timeout_sec=1,
+        ))
+
+    assert result.sandbox_runs[0].status is SandboxStatus.TIMEOUT
+    report_text = json.dumps(result.report.to_dict())
+    assert "plainsecret" not in report_text
+    with ReviewStore(tmp_path / "review.sqlite3") as store:
+        assert store.get_metrics(result.task.id)["exception_distribution_json"]["TimeoutExpired"] == 1
+        assert store.get_report(result.task.id)
+
+
+def test_pipeline_uses_injected_store_factory(tmp_path: Path):
+    saved: list[dict] = []
+
+    class FakeStore:
+
+        def __init__(self, db_path):
+            self.db_path = db_path
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return None
+
+        def save_review(self, **kwargs):
+            saved.append(kwargs)
+
+    result = run_review_pipeline(
+        ReviewPipelineConfig(
+            input_type=InputType.FIXTURE,
+            input_ref="clean",
+            output_dir=tmp_path,
+            db_path=tmp_path / "custom.sql",
+            store_factory=FakeStore,
+        ))
+
+    assert saved
+    assert saved[0]["task"].id == result.task.id
+    assert saved[0]["report"].task_id == result.task.id

--- a/examples/skills_code_review_agent/tests/test_pipeline.py
+++ b/examples/skills_code_review_agent/tests/test_pipeline.py
@@ -19,6 +19,7 @@ from examples.skills_code_review_agent.agent import ReviewStore
 from examples.skills_code_review_agent.agent import RuntimeKind
 from examples.skills_code_review_agent.agent import SandboxStatus
 from examples.skills_code_review_agent.agent import run_review_pipeline
+from examples.skills_code_review_agent.tests.secret_samples import generic_password_value
 
 
 def test_dry_run_pipeline_writes_artifacts_database_and_reports(tmp_path: Path):
@@ -56,9 +57,10 @@ def test_container_pipeline_records_human_review_without_real_container(tmp_path
 
 
 def test_sandbox_timeout_does_not_crash_pipeline(tmp_path: Path, monkeypatch):
+    sensitive_value = generic_password_value()
 
     def raise_timeout(*args, **kwargs):
-        raise subprocess.TimeoutExpired(cmd=["python"], timeout=1, output="password=plainsecret")
+        raise subprocess.TimeoutExpired(cmd=["python"], timeout=1, output=f"password={sensitive_value}")
 
     monkeypatch.setattr("examples.skills_code_review_agent.agent.sandbox.subprocess.run", raise_timeout)
     result = run_review_pipeline(
@@ -74,7 +76,7 @@ def test_sandbox_timeout_does_not_crash_pipeline(tmp_path: Path, monkeypatch):
 
     assert result.sandbox_runs[0].status is SandboxStatus.TIMEOUT
     report_text = json.dumps(result.report.to_dict())
-    assert "plainsecret" not in report_text
+    assert sensitive_value not in report_text
     with ReviewStore(tmp_path / "review.sqlite3") as store:
         assert store.get_metrics(result.task.id)["exception_distribution_json"]["TimeoutExpired"] == 1
         assert store.get_report(result.task.id)

--- a/examples/skills_code_review_agent/tests/test_quality_gates.py
+++ b/examples/skills_code_review_agent/tests/test_quality_gates.py
@@ -8,6 +8,8 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Callable
+from dataclasses import dataclass
 from pathlib import Path
 
 from examples.skills_code_review_agent.agent import FindingCategory
@@ -22,6 +24,8 @@ from examples.skills_code_review_agent.agent import run_review_rules
 from examples.skills_code_review_agent.tests.secret_samples import aws_access_key_like_token
 from examples.skills_code_review_agent.tests.secret_samples import aws_session_key_like_token
 from examples.skills_code_review_agent.tests.secret_samples import bearer_like_token
+from examples.skills_code_review_agent.tests.secret_samples import client_secret_like_value
+from examples.skills_code_review_agent.tests.secret_samples import db_password_like_value
 from examples.skills_code_review_agent.tests.secret_samples import forbidden_provider_literals
 from examples.skills_code_review_agent.tests.secret_samples import generic_api_key_value
 from examples.skills_code_review_agent.tests.secret_samples import generic_bearer_value
@@ -33,6 +37,8 @@ from examples.skills_code_review_agent.tests.secret_samples import github_pat_li
 from examples.skills_code_review_agent.tests.secret_samples import jwt_like_token
 from examples.skills_code_review_agent.tests.secret_samples import openai_like_token
 from examples.skills_code_review_agent.tests.secret_samples import openai_live_like_token
+from examples.skills_code_review_agent.tests.secret_samples import private_key_body_value
+from examples.skills_code_review_agent.tests.secret_samples import refresh_token_like_value
 from examples.skills_code_review_agent.tests.secret_samples import slack_like_token
 
 
@@ -81,32 +87,46 @@ def test_high_risk_recall_and_false_positive_quality_gate():
     assert false_positive_rate <= 0.15
 
 
+@dataclass(frozen=True)
+class _RedactionCase:
+    name: str
+    build: Callable[[], tuple[str, list[str]]]
+
+
 def test_redaction_quality_gate_covers_common_secret_shapes():
+    # Secret-shaped values are assembled at runtime to keep tracked tests safe
+    # for CodeCC and secret scanning while preserving redaction coverage.
     cases = [
-        (f"Authorization: Bearer {bearer_like_token()}", [bearer_like_token()]),
-        (f"api_key={openai_like_token()}", [openai_like_token()]),
-        (f"OPENAI_API_KEY='{openai_live_like_token()}'", [openai_live_like_token()]),
-        ("password=supersecret", ["supersecret"]),
-        ("passwd: hunter2", ["hunter2"]),
-        ("pwd='local-password'", ["local-password"]),
-        (f"secret = '{generic_secret_value()}'", [generic_secret_value()]),
-        (f"token={github_pat_like_token()}", [github_pat_like_token()]),
-        (f"token={github_classic_like_token()}", [github_classic_like_token()]),
-        (f"token={github_oauth_like_token()}", [github_oauth_like_token()]),
-        (f"slack_token={slack_like_token()}", [slack_like_token()]),
-        (f"aws_key={aws_access_key_like_token()}", [aws_access_key_like_token()]),
-        (f"aws_session={aws_session_key_like_token()}", [aws_session_key_like_token()]),
-        ("DATABASE_URL=postgres://user:plainpass@db/app", ["plainpass"]),
-        ("mysql://root:rootpass@localhost/db", ["rootpass"]),
-        ("redis://default:redispass@localhost:6379/0", ["redispass"]),
-        ("private_key=-----BEGIN PRIVATE KEY-----\\nbody\\n-----END PRIVATE KEY-----", ["body"]),
-        ("client_secret=abc123456789", ["abc123456789"]),
-        ("refresh-token=rt_abcdefghijklmnop", ["rt_abcdefghijklmnop"]),
-        (f"jwt_token={jwt_like_token()}", [jwt_like_token().split('.')[0]]),
+        _value_case("bearer", bearer_like_token, lambda value: f"Authorization: Bearer {value}"),
+        _assignment_case("api key", ("api", "_", "key"), openai_like_token),
+        _assignment_case("OpenAI API key", ("OPENAI", "_", "API", "_", "KEY"), openai_live_like_token, quote="'"),
+        _assignment_case("password", ("pass", "word"), generic_password_value),
+        _assignment_case("passwd", ("pass", "wd"), generic_password_value, separator=":"),
+        _assignment_case("pwd", ("p", "wd"), generic_password_value, quote="'"),
+        _assignment_case("secret", ("secret", ), generic_secret_value, quote="'"),
+        _assignment_case("GitHub PAT", ("token", ), github_pat_like_token),
+        _assignment_case("GitHub classic token", ("token", ), github_classic_like_token),
+        _assignment_case("GitHub OAuth token", ("token", ), github_oauth_like_token),
+        _assignment_case("Slack token", ("slack", "_", "token"), slack_like_token),
+        _assignment_case("AWS key", ("aws", "_", "key"), aws_access_key_like_token),
+        _assignment_case("AWS session key", ("aws", "_", "session"), aws_session_key_like_token),
+        _url_case("Postgres URL", ("postgres", ), ("user", ), db_password_like_value, "db/app"),
+        _url_case("MySQL URL", ("mysql", ), ("root", ), db_password_like_value, "localhost/db"),
+        _url_case("Redis URL", ("redis", ), ("default", ), db_password_like_value, "localhost:6379/0"),
+        _private_key_case(),
+        _assignment_case("client secret", ("client", "_", "secret"), client_secret_like_value),
+        _assignment_case("refresh token", ("refresh", "-", "token"), refresh_token_like_value),
+        _value_case(
+            "JWT",
+            jwt_like_token,
+            lambda value: _assignment_text(("jwt", "_", "token"), value),
+            forbidden=lambda value: [value.split(".", 1)[0]],
+        ),
     ]
 
     redacted_count = 0
-    for text, forbidden_values in cases:
+    for case in cases:
+        text, forbidden_values = case.build()
         redacted = redact_text(text)
         if "[REDACTED]" in redacted and all(value not in redacted for value in forbidden_values):
             redacted_count += 1
@@ -169,3 +189,67 @@ def _diff(path: str, added_lines: list[str]) -> str:
 @@ -0,0 +1,{line_count} @@
 {rendered}
 """
+
+
+def _value_case(
+    name: str,
+    value_builder: Callable[[], str],
+    render: Callable[[str], str],
+    forbidden: Callable[[str], list[str]] | None = None,
+) -> _RedactionCase:
+
+    def build() -> tuple[str, list[str]]:
+        value = value_builder()
+        return render(value), forbidden(value) if forbidden is not None else [value]
+
+    return _RedactionCase(name=name, build=build)
+
+
+def _assignment_case(
+    name: str,
+    key_parts: tuple[str, ...],
+    value_builder: Callable[[], str],
+    *,
+    separator: str = "=",
+    quote: str = "",
+) -> _RedactionCase:
+    return _value_case(
+        name,
+        value_builder,
+        lambda value: _assignment_text(key_parts, value, separator=separator, quote=quote),
+    )
+
+
+def _assignment_text(
+    key_parts: tuple[str, ...],
+    value: str,
+    *,
+    separator: str = "=",
+    quote: str = "",
+) -> str:
+    return f"{''.join(key_parts)}{separator}{quote}{value}{quote}"
+
+
+def _url_case(
+    name: str,
+    scheme_parts: tuple[str, ...],
+    user_parts: tuple[str, ...],
+    password_builder: Callable[[], str],
+    suffix: str,
+) -> _RedactionCase:
+    return _value_case(
+        name,
+        password_builder,
+        lambda value: f"{''.join(scheme_parts)}://{''.join(user_parts)}:{value}@{suffix}",
+    )
+
+
+def _private_key_case() -> _RedactionCase:
+    return _value_case(
+        "private key",
+        private_key_body_value,
+        lambda value: _assignment_text(
+            ("private", "_", "key"),
+            f"-----BEGIN PRIVATE KEY-----\\n{value}\\n-----END PRIVATE KEY-----",
+        ),
+    )

--- a/examples/skills_code_review_agent/tests/test_quality_gates.py
+++ b/examples/skills_code_review_agent/tests/test_quality_gates.py
@@ -19,15 +19,32 @@ from examples.skills_code_review_agent.agent import parse_unified_diff
 from examples.skills_code_review_agent.agent import redact_text
 from examples.skills_code_review_agent.agent import run_review_pipeline
 from examples.skills_code_review_agent.agent import run_review_rules
+from examples.skills_code_review_agent.tests.secret_samples import aws_access_key_like_token
+from examples.skills_code_review_agent.tests.secret_samples import aws_session_key_like_token
+from examples.skills_code_review_agent.tests.secret_samples import bearer_like_token
+from examples.skills_code_review_agent.tests.secret_samples import forbidden_provider_literals
+from examples.skills_code_review_agent.tests.secret_samples import generic_api_key_value
+from examples.skills_code_review_agent.tests.secret_samples import generic_bearer_value
+from examples.skills_code_review_agent.tests.secret_samples import generic_password_value
+from examples.skills_code_review_agent.tests.secret_samples import generic_secret_value
+from examples.skills_code_review_agent.tests.secret_samples import github_classic_like_token
+from examples.skills_code_review_agent.tests.secret_samples import github_oauth_like_token
+from examples.skills_code_review_agent.tests.secret_samples import github_pat_like_token
+from examples.skills_code_review_agent.tests.secret_samples import jwt_like_token
+from examples.skills_code_review_agent.tests.secret_samples import openai_like_token
+from examples.skills_code_review_agent.tests.secret_samples import openai_live_like_token
+from examples.skills_code_review_agent.tests.secret_samples import slack_like_token
 
 
 def test_high_risk_recall_and_false_positive_quality_gate():
+    # Provider-like token samples are assembled at runtime so tracked tests stay
+    # compatible with secret scanning while still exercising the same regexes.
     positives = [
-        ("secret.py", ["API_KEY = 'sk-abcdefghijklmnop'"], FindingCategory.SECRET),
+        ("secret.py", [f"API_KEY = '{openai_like_token()}'"], FindingCategory.SECRET),
         ("exec.py", ["result = eval(user_input)"], FindingCategory.SECURITY),
         ("exec.py", ["exec(user_code)"], FindingCategory.SECURITY),
         ("shell.py", ["subprocess.run(cmd, shell=True)"], FindingCategory.SECURITY),
-        ("tokens.py", ["password = 'correct-horse-battery-staple'"], FindingCategory.SECRET),
+        ("tokens.py", [f"password = '{generic_password_value()}'"], FindingCategory.SECRET),
     ]
     hits = 0
     for path, lines, category in positives:
@@ -66,26 +83,26 @@ def test_high_risk_recall_and_false_positive_quality_gate():
 
 def test_redaction_quality_gate_covers_common_secret_shapes():
     cases = [
-        ("Authorization: Bearer abcdefghijklmnop", ["abcdefghijklmnop"]),
-        ("api_key=sk-abcdefghijklmnop", ["sk-abcdefghijklmnop"]),
-        ("OPENAI_API_KEY='sk-live-abcdefghijklmnop'", ["sk-live-abcdefghijklmnop"]),
+        (f"Authorization: Bearer {bearer_like_token()}", [bearer_like_token()]),
+        (f"api_key={openai_like_token()}", [openai_like_token()]),
+        (f"OPENAI_API_KEY='{openai_live_like_token()}'", [openai_live_like_token()]),
         ("password=supersecret", ["supersecret"]),
         ("passwd: hunter2", ["hunter2"]),
         ("pwd='local-password'", ["local-password"]),
-        ("secret = 'plain-secret-value'", ["plain-secret-value"]),
-        ("token=github_pat_abcdefghijklmnop", ["github_pat_abcdefghijklmnop"]),
-        ("token=ghp_abcdefghijklmnop", ["ghp_abcdefghijklmnop"]),
-        ("token=gho_abcdefghijklmnop", ["gho_abcdefghijklmnop"]),
-        ("slack_token=xoxb-example-value-abcdefghijklmnop", ["xoxb-example-value-abcdefghijklmnop"]),
-        ("aws_key=AKIAABCDEFGHIJKLMNOP", ["AKIAABCDEFGHIJKLMNOP"]),
-        ("aws_session=ASIAABCDEFGHIJKLMNOP", ["ASIAABCDEFGHIJKLMNOP"]),
+        (f"secret = '{generic_secret_value()}'", [generic_secret_value()]),
+        (f"token={github_pat_like_token()}", [github_pat_like_token()]),
+        (f"token={github_classic_like_token()}", [github_classic_like_token()]),
+        (f"token={github_oauth_like_token()}", [github_oauth_like_token()]),
+        (f"slack_token={slack_like_token()}", [slack_like_token()]),
+        (f"aws_key={aws_access_key_like_token()}", [aws_access_key_like_token()]),
+        (f"aws_session={aws_session_key_like_token()}", [aws_session_key_like_token()]),
         ("DATABASE_URL=postgres://user:plainpass@db/app", ["plainpass"]),
         ("mysql://root:rootpass@localhost/db", ["rootpass"]),
         ("redis://default:redispass@localhost:6379/0", ["redispass"]),
         ("private_key=-----BEGIN PRIVATE KEY-----\\nbody\\n-----END PRIVATE KEY-----", ["body"]),
         ("client_secret=abc123456789", ["abc123456789"]),
         ("refresh-token=rt_abcdefghijklmnop", ["rt_abcdefghijklmnop"]),
-        ("jwt_token=eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjMifQ.signature", ["eyJhbGciOiJIUzI1NiJ9"]),
+        (f"jwt_token={jwt_like_token()}", [jwt_like_token().split('.')[0]]),
     ]
 
     redacted_count = 0
@@ -106,9 +123,9 @@ def test_secret_fixture_does_not_leak_known_values_to_report_or_store(tmp_path: 
             db_path=tmp_path / "review.sqlite3",
         ))
     forbidden = [
-        "sk-live-1234567890abcdef",
-        "correct-horse-battery-staple",
-        "very-long-token-value-123456",
+        generic_api_key_value(),
+        generic_password_value(),
+        generic_bearer_value(),
     ]
     report_text = json.dumps(result.report.to_dict())
     assert all(value not in report_text for value in forbidden)
@@ -121,6 +138,17 @@ def test_secret_fixture_does_not_leak_known_values_to_report_or_store(tmp_path: 
             "report": store.get_report(result.task.id),
         })
     assert all(value not in stored_text for value in forbidden)
+
+
+def test_curated_secret_samples_do_not_store_blocked_provider_literals():
+    tracked = Path(__file__).read_text(encoding="utf-8")
+    helper = (Path(__file__).parent / "secret_samples.py").read_text(encoding="utf-8")
+    fixture = (Path(__file__).parents[1] / "fixtures" / "secret.diff").read_text(encoding="utf-8")
+
+    for blocked in forbidden_provider_literals():
+        assert blocked not in tracked
+        assert blocked not in helper
+        assert blocked not in fixture
 
 
 def _summary(path: str, added_lines: list[str]):

--- a/examples/skills_code_review_agent/tests/test_quality_gates.py
+++ b/examples/skills_code_review_agent/tests/test_quality_gates.py
@@ -1,0 +1,143 @@
+# Tencent is pleased to support the open source community by making tRPC-Agent-Python available.
+#
+# Copyright (C) 2026 Tencent. All rights reserved.
+#
+# tRPC-Agent-Python is licensed under Apache-2.0.
+"""Business quality gates for deterministic review and redaction behavior."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from examples.skills_code_review_agent.agent import FindingCategory
+from examples.skills_code_review_agent.agent import FindingSeverity
+from examples.skills_code_review_agent.agent import InputType
+from examples.skills_code_review_agent.agent import ReviewPipelineConfig
+from examples.skills_code_review_agent.agent import ReviewStore
+from examples.skills_code_review_agent.agent import parse_unified_diff
+from examples.skills_code_review_agent.agent import redact_text
+from examples.skills_code_review_agent.agent import run_review_pipeline
+from examples.skills_code_review_agent.agent import run_review_rules
+
+
+def test_high_risk_recall_and_false_positive_quality_gate():
+    positives = [
+        ("secret.py", ["API_KEY = 'sk-abcdefghijklmnop'"], FindingCategory.SECRET),
+        ("exec.py", ["result = eval(user_input)"], FindingCategory.SECURITY),
+        ("exec.py", ["exec(user_code)"], FindingCategory.SECURITY),
+        ("shell.py", ["subprocess.run(cmd, shell=True)"], FindingCategory.SECURITY),
+        ("tokens.py", ["password = 'correct-horse-battery-staple'"], FindingCategory.SECRET),
+    ]
+    hits = 0
+    for path, lines, category in positives:
+        findings = run_review_rules(_summary(path, lines))
+        high_risk = [
+            item for item in findings
+            if item.category is category and item.severity in {FindingSeverity.HIGH, FindingSeverity.CRITICAL}
+        ]
+        hits += int(bool(high_risk))
+
+    negatives = [
+        ("files.py", ["with open('safe.txt') as handle:", "    data = handle.read()"]),
+        ("async_client.py", [
+            "async def fetch(url):",
+            "    async with httpx.AsyncClient() as client:",
+            "        return await client.get(url)",
+        ]),
+        ("db.py", ["with sqlite3.connect(path) as conn:", "    conn.execute('select 1')"]),
+        ("app.py", ["message = 'token bucket rate limiter'"]),
+        ("tests/test_app.py", ["assert normalize('value') == 'value'"]),
+    ]
+    unexpected = []
+    for path, lines in negatives:
+        unexpected.extend([
+            item for item in run_review_rules(_summary(path, lines))
+            if item.confidence >= 0.7 and item.category in {FindingCategory.SECURITY, FindingCategory.SECRET}
+        ])
+
+    recall = hits / len(positives)
+    high_confidence_total = hits + len(unexpected)
+    false_positive_rate = len(unexpected) / high_confidence_total if high_confidence_total else 0.0
+
+    assert recall >= 0.80
+    assert false_positive_rate <= 0.15
+
+
+def test_redaction_quality_gate_covers_common_secret_shapes():
+    cases = [
+        ("Authorization: Bearer abcdefghijklmnop", ["abcdefghijklmnop"]),
+        ("api_key=sk-abcdefghijklmnop", ["sk-abcdefghijklmnop"]),
+        ("OPENAI_API_KEY='sk-live-abcdefghijklmnop'", ["sk-live-abcdefghijklmnop"]),
+        ("password=supersecret", ["supersecret"]),
+        ("passwd: hunter2", ["hunter2"]),
+        ("pwd='local-password'", ["local-password"]),
+        ("secret = 'plain-secret-value'", ["plain-secret-value"]),
+        ("token=github_pat_abcdefghijklmnop", ["github_pat_abcdefghijklmnop"]),
+        ("token=ghp_abcdefghijklmnop", ["ghp_abcdefghijklmnop"]),
+        ("token=gho_abcdefghijklmnop", ["gho_abcdefghijklmnop"]),
+        ("slack_token=xoxb-example-value-abcdefghijklmnop", ["xoxb-example-value-abcdefghijklmnop"]),
+        ("aws_key=AKIAABCDEFGHIJKLMNOP", ["AKIAABCDEFGHIJKLMNOP"]),
+        ("aws_session=ASIAABCDEFGHIJKLMNOP", ["ASIAABCDEFGHIJKLMNOP"]),
+        ("DATABASE_URL=postgres://user:plainpass@db/app", ["plainpass"]),
+        ("mysql://root:rootpass@localhost/db", ["rootpass"]),
+        ("redis://default:redispass@localhost:6379/0", ["redispass"]),
+        ("private_key=-----BEGIN PRIVATE KEY-----\\nbody\\n-----END PRIVATE KEY-----", ["body"]),
+        ("client_secret=abc123456789", ["abc123456789"]),
+        ("refresh-token=rt_abcdefghijklmnop", ["rt_abcdefghijklmnop"]),
+        ("jwt_token=eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjMifQ.signature", ["eyJhbGciOiJIUzI1NiJ9"]),
+    ]
+
+    redacted_count = 0
+    for text, forbidden_values in cases:
+        redacted = redact_text(text)
+        if "[REDACTED]" in redacted and all(value not in redacted for value in forbidden_values):
+            redacted_count += 1
+
+    assert redacted_count / len(cases) >= 0.95
+
+
+def test_secret_fixture_does_not_leak_known_values_to_report_or_store(tmp_path: Path):
+    result = run_review_pipeline(
+        ReviewPipelineConfig(
+            input_type=InputType.FIXTURE,
+            input_ref="secret",
+            output_dir=tmp_path,
+            db_path=tmp_path / "review.sqlite3",
+        ))
+    forbidden = [
+        "sk-live-1234567890abcdef",
+        "correct-horse-battery-staple",
+        "very-long-token-value-123456",
+    ]
+    report_text = json.dumps(result.report.to_dict())
+    assert all(value not in report_text for value in forbidden)
+
+    with ReviewStore(tmp_path / "review.sqlite3") as store:
+        stored_text = json.dumps({
+            "findings": store.list_findings(result.task.id),
+            "filters": store.list_filter_events(result.task.id),
+            "sandbox": store.list_sandbox_runs(result.task.id),
+            "report": store.get_report(result.task.id),
+        })
+    assert all(value not in stored_text for value in forbidden)
+
+
+def _summary(path: str, added_lines: list[str]):
+    return parse_unified_diff(
+        _diff(path, added_lines),
+        task_id=f"quality-{path}",
+        input_type=InputType.DIFF_FILE,
+        input_ref=f"<quality:{path}>",
+    )
+
+
+def _diff(path: str, added_lines: list[str]) -> str:
+    rendered = "\n".join(f"+{line}" for line in added_lines)
+    line_count = max(len(added_lines), 1)
+    return f"""diff --git a/{path} b/{path}
+--- a/{path}
++++ b/{path}
+@@ -0,0 +1,{line_count} @@
+{rendered}
+"""

--- a/examples/skills_code_review_agent/tests/test_quality_gates.py
+++ b/examples/skills_code_review_agent/tests/test_quality_gates.py
@@ -80,8 +80,8 @@ def test_high_risk_recall_and_false_positive_quality_gate():
         ])
 
     recall = hits / len(positives)
-    high_confidence_total = hits + len(unexpected)
-    false_positive_rate = len(unexpected) / high_confidence_total if high_confidence_total else 0.0
+    # This is a public-corpus proxy metric, not a production security guarantee.
+    false_positive_rate = len(unexpected) / len(negatives) if negatives else 0.0
 
     assert recall >= 0.80
     assert false_positive_rate <= 0.15
@@ -91,46 +91,62 @@ def test_high_risk_recall_and_false_positive_quality_gate():
 class _RedactionCase:
     name: str
     build: Callable[[], tuple[str, list[str]]]
+    strict: bool = False
 
 
 def test_redaction_quality_gate_covers_common_secret_shapes():
     # Secret-shaped values are assembled at runtime to keep tracked tests safe
     # for CodeCC and secret scanning while preserving redaction coverage.
     cases = [
-        _value_case("bearer", bearer_like_token, lambda value: f"Authorization: Bearer {value}"),
-        _assignment_case("api key", ("api", "_", "key"), openai_like_token),
-        _assignment_case("OpenAI API key", ("OPENAI", "_", "API", "_", "KEY"), openai_live_like_token, quote="'"),
+        _value_case("bearer", bearer_like_token, lambda value: f"Authorization: Bearer {value}", strict=True),
+        _assignment_case("api key", ("api", "_", "key"), openai_like_token, strict=True),
+        _assignment_case("OpenAI API key", ("OPENAI", "_", "API", "_", "KEY"),
+                         openai_live_like_token,
+                         quote="'",
+                         strict=True),
         _assignment_case("password", ("pass", "word"), generic_password_value),
         _assignment_case("passwd", ("pass", "wd"), generic_password_value, separator=":"),
         _assignment_case("pwd", ("p", "wd"), generic_password_value, quote="'"),
         _assignment_case("secret", ("secret", ), generic_secret_value, quote="'"),
-        _assignment_case("GitHub PAT", ("token", ), github_pat_like_token),
-        _assignment_case("GitHub classic token", ("token", ), github_classic_like_token),
-        _assignment_case("GitHub OAuth token", ("token", ), github_oauth_like_token),
-        _assignment_case("Slack token", ("slack", "_", "token"), slack_like_token),
-        _assignment_case("AWS key", ("aws", "_", "key"), aws_access_key_like_token),
-        _assignment_case("AWS session key", ("aws", "_", "session"), aws_session_key_like_token),
-        _url_case("Postgres URL", ("postgres", ), ("user", ), db_password_like_value, "db/app"),
-        _url_case("MySQL URL", ("mysql", ), ("root", ), db_password_like_value, "localhost/db"),
-        _url_case("Redis URL", ("redis", ), ("default", ), db_password_like_value, "localhost:6379/0"),
+        _assignment_case("GitHub PAT", ("token", ), github_pat_like_token, strict=True),
+        _assignment_case("GitHub classic token", ("token", ), github_classic_like_token, strict=True),
+        _assignment_case("GitHub OAuth token", ("token", ), github_oauth_like_token, strict=True),
+        _assignment_case("Slack token", ("slack", "_", "token"), slack_like_token, strict=True),
+        _assignment_case("AWS key", ("aws", "_", "key"), aws_access_key_like_token, strict=True),
+        _assignment_case("AWS session key", ("aws", "_", "session"), aws_session_key_like_token, strict=True),
+        _url_case("Postgres URL", ("postgres", ), ("user", ), db_password_like_value, "db/app", strict=True),
+        _url_case("MySQL URL", ("mysql", ), ("root", ), db_password_like_value, "localhost/db", strict=True),
+        _url_case("Redis URL", ("redis", ), ("default", ), db_password_like_value, "localhost:6379/0", strict=True),
         _private_key_case(),
-        _assignment_case("client secret", ("client", "_", "secret"), client_secret_like_value),
-        _assignment_case("refresh token", ("refresh", "-", "token"), refresh_token_like_value),
+        _assignment_case("client secret", ("client", "_", "secret"), client_secret_like_value, strict=True),
+        _assignment_case("refresh token", ("refresh", "-", "token"), refresh_token_like_value, strict=True),
         _value_case(
-            "JWT",
+            "bare JWT",
             jwt_like_token,
-            lambda value: _assignment_text(("jwt", "_", "token"), value),
-            forbidden=lambda value: [value.split(".", 1)[0]],
+            lambda value: value,
+            forbidden=lambda value: [value],
+            strict=True,
+        ),
+        _assignment_case(
+            "JWT assignment",
+            ("jwt", "_", "token"),
+            jwt_like_token,
+            strict=True,
         ),
     ]
 
     redacted_count = 0
+    strict_failures = []
     for case in cases:
         text, forbidden_values = case.build()
         redacted = redact_text(text)
-        if "[REDACTED]" in redacted and all(value not in redacted for value in forbidden_values):
+        passed = "[REDACTED]" in redacted and all(value not in redacted for value in forbidden_values)
+        if case.strict and not passed:
+            strict_failures.append(case.name)
+        if passed:
             redacted_count += 1
 
+    assert not strict_failures, f"strict redaction cases failed: {strict_failures}"
     assert redacted_count / len(cases) >= 0.95
 
 
@@ -196,13 +212,15 @@ def _value_case(
     value_builder: Callable[[], str],
     render: Callable[[str], str],
     forbidden: Callable[[str], list[str]] | None = None,
+    *,
+    strict: bool = False,
 ) -> _RedactionCase:
 
     def build() -> tuple[str, list[str]]:
         value = value_builder()
         return render(value), forbidden(value) if forbidden is not None else [value]
 
-    return _RedactionCase(name=name, build=build)
+    return _RedactionCase(name=name, build=build, strict=strict)
 
 
 def _assignment_case(
@@ -212,11 +230,13 @@ def _assignment_case(
     *,
     separator: str = "=",
     quote: str = "",
+    strict: bool = False,
 ) -> _RedactionCase:
     return _value_case(
         name,
         value_builder,
         lambda value: _assignment_text(key_parts, value, separator=separator, quote=quote),
+        strict=strict,
     )
 
 
@@ -236,11 +256,14 @@ def _url_case(
     user_parts: tuple[str, ...],
     password_builder: Callable[[], str],
     suffix: str,
+    *,
+    strict: bool = False,
 ) -> _RedactionCase:
     return _value_case(
         name,
         password_builder,
         lambda value: f"{''.join(scheme_parts)}://{''.join(user_parts)}:{value}@{suffix}",
+        strict=strict,
     )
 
 
@@ -252,4 +275,5 @@ def _private_key_case() -> _RedactionCase:
             ("private", "_", "key"),
             f"-----BEGIN PRIVATE KEY-----\\n{value}\\n-----END PRIVATE KEY-----",
         ),
+        strict=True,
     )

--- a/examples/skills_code_review_agent/tests/test_repo_input.py
+++ b/examples/skills_code_review_agent/tests/test_repo_input.py
@@ -1,0 +1,121 @@
+# Tencent is pleased to support the open source community by making tRPC-Agent-Python available.
+#
+# Copyright (C) 2026 Tencent. All rights reserved.
+#
+# tRPC-Agent-Python is licensed under Apache-2.0.
+"""Business tests for Git worktree input normalization."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from examples.skills_code_review_agent.agent.input_parser import InputParseError
+from examples.skills_code_review_agent.agent.input_parser import parse_repo_path
+
+
+def test_tracked_worktree_change_is_parsed(tmp_path: Path):
+    repo = _init_repo(tmp_path / "repo")
+    (repo / "app.py").write_text("value = 1\n", encoding="utf-8")
+    _git(repo, "add", "app.py")
+    _git(repo, "commit", "-qm", "initial")
+    (repo / "app.py").write_text("value = 2\n", encoding="utf-8")
+
+    summary = parse_repo_path(repo, task_id="repo-1")
+
+    changed = summary.changed_files[0]
+    assert changed.path == "app.py"
+    assert changed.added_lines == 1
+    assert changed.deleted_lines == 1
+
+
+def test_staged_and_unstaged_changes_are_read_together(tmp_path: Path):
+    repo = _init_repo(tmp_path / "repo")
+    (repo / "app.py").write_text("value = 1\n", encoding="utf-8")
+    _git(repo, "add", "app.py")
+    _git(repo, "commit", "-qm", "initial")
+    (repo / "app.py").write_text("value = 2\n", encoding="utf-8")
+    _git(repo, "add", "app.py")
+    (repo / "other.py").write_text("flag = False\n", encoding="utf-8")
+    _git(repo, "add", "other.py")
+    (repo / "other.py").write_text("flag = True\n", encoding="utf-8")
+
+    summary = parse_repo_path(repo, task_id="repo-2")
+
+    assert {item.path for item in summary.changed_files} == {"app.py", "other.py"}
+
+
+def test_untracked_text_file_is_parsed_as_added_file(tmp_path: Path):
+    repo = _init_repo(tmp_path / "repo")
+    (repo / "new.py").write_text("print('new')\n", encoding="utf-8")
+
+    summary = parse_repo_path(repo, task_id="repo-3")
+
+    changed = summary.changed_files[0]
+    assert changed.path == "new.py"
+    assert changed.status == "added"
+    assert changed.candidate_lines == [1]
+
+
+def test_untracked_binary_file_is_marked_binary(tmp_path: Path):
+    repo = _init_repo(tmp_path / "repo")
+    (repo / "asset.bin").write_bytes(b"\x00\x01\x02")
+
+    summary = parse_repo_path(repo, task_id="repo-4")
+
+    changed = summary.changed_files[0]
+    assert changed.path == "asset.bin"
+    assert changed.status == "added"
+    assert changed.is_binary is True
+
+
+def test_deleted_file_is_identified_from_repo_diff(tmp_path: Path):
+    repo = _init_repo(tmp_path / "repo")
+    (repo / "gone.txt").write_text("gone\n", encoding="utf-8")
+    _git(repo, "add", "gone.txt")
+    _git(repo, "commit", "-qm", "initial")
+    (repo / "gone.txt").unlink()
+
+    summary = parse_repo_path(repo, task_id="repo-5")
+
+    assert summary.changed_files[0].status == "deleted"
+
+
+def test_non_git_directory_returns_clear_error(tmp_path: Path):
+    with pytest.raises(InputParseError, match="git command failed"):
+        parse_repo_path(tmp_path, task_id="repo-6")
+
+
+def test_git_timeout_returns_clear_error(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    def raise_timeout(*args, **kwargs):
+        raise subprocess.TimeoutExpired(cmd=["git"], timeout=1)
+
+    monkeypatch.setattr("examples.skills_code_review_agent.agent.input_parser.subprocess.run", raise_timeout)
+    with pytest.raises(InputParseError, match="timed out"):
+        parse_repo_path(repo, task_id="repo-7")
+
+
+def test_repo_path_with_spaces_is_supported(tmp_path: Path):
+    repo = _init_repo(tmp_path / "repo with spaces")
+    (repo / "new file.py").write_text("x = 1\n", encoding="utf-8")
+
+    summary = parse_repo_path(repo, task_id="repo-8")
+
+    assert summary.changed_files[0].path == "new file.py"
+
+
+def _init_repo(path: Path) -> Path:
+    path.mkdir()
+    _git(path, "init", "-q")
+    _git(path, "config", "user.email", "review@example.com")
+    _git(path, "config", "user.name", "Review Test")
+    return path
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True, text=True)

--- a/examples/skills_code_review_agent/tests/test_report.py
+++ b/examples/skills_code_review_agent/tests/test_report.py
@@ -1,0 +1,103 @@
+# Tencent is pleased to support the open source community by making tRPC-Agent-Python available.
+#
+# Copyright (C) 2026 Tencent. All rights reserved.
+#
+# tRPC-Agent-Python is licensed under Apache-2.0.
+"""Business tests for review report routing and rendering."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from examples.skills_code_review_agent.agent import FilterDecision
+from examples.skills_code_review_agent.agent import FilterEvent
+from examples.skills_code_review_agent.agent import Finding
+from examples.skills_code_review_agent.agent import FindingCategory
+from examples.skills_code_review_agent.agent import FindingSeverity
+from examples.skills_code_review_agent.agent import FindingSource
+from examples.skills_code_review_agent.agent import InputType
+from examples.skills_code_review_agent.agent import RuntimeKind
+from examples.skills_code_review_agent.agent import SandboxRun
+from examples.skills_code_review_agent.agent import SandboxStatus
+from examples.skills_code_review_agent.agent import build_review_report
+from examples.skills_code_review_agent.agent import dedupe_findings
+from examples.skills_code_review_agent.agent import parse_unified_diff
+from examples.skills_code_review_agent.agent import route_findings
+from examples.skills_code_review_agent.agent import write_review_report
+
+
+def test_dedupe_findings_uses_fingerprint():
+    finding = _finding("fp-1")
+
+    assert dedupe_findings([finding, _finding("fp-1")]) == [finding]
+
+
+def test_dedupe_findings_generates_missing_fingerprint():
+    finding = _finding(None)
+
+    deduped = dedupe_findings([finding])
+
+    assert deduped[0].fingerprint
+
+
+def test_route_findings_splits_low_confidence_to_warnings():
+    high = _finding("high", confidence=0.9)
+    low = _finding("low", confidence=0.5)
+
+    findings, warnings, needs_human_review = route_findings([high, low], [], [])
+
+    assert findings == [high]
+    assert warnings == [low]
+    assert needs_human_review == []
+
+
+def test_route_findings_adds_human_review_for_filter_and_sandbox():
+    event = FilterEvent(
+        task_id="task",
+        decision=FilterDecision.NEEDS_HUMAN_REVIEW,
+        reason="container runtime is unavailable",
+        target="python rule_runner.py",
+    )
+    sandbox = SandboxRun(task_id="task", runtime=RuntimeKind.CONTAINER, command="python", status=SandboxStatus.FAILED)
+
+    _findings, _warnings, needs_human_review = route_findings([], [event], [sandbox])
+
+    assert {item.category for item in needs_human_review} == {FindingCategory.GOVERNANCE, FindingCategory.SANDBOX}
+
+
+def test_write_review_report_outputs_json_and_markdown_without_secrets(tmp_path: Path):
+    input_summary = parse_unified_diff("", task_id="task", input_type=InputType.FIXTURE)
+    finding = _finding("secret", evidence="password=plainsecret", confidence=0.9)
+    report = build_review_report(
+        task_id="task",
+        input_summary=input_summary,
+        findings=[finding],
+        filter_events=[],
+        sandbox_runs=[],
+        total_duration_ms=12,
+    )
+
+    json_path, md_path = write_review_report(tmp_path, report)
+
+    report_json = json.loads(json_path.read_text(encoding="utf-8"))
+    report_md = md_path.read_text(encoding="utf-8")
+    assert report_json["metrics"]["finding_count"] == 1
+    assert "Fix Suggestions" in report_md
+    assert "plainsecret" not in json.dumps(report_json)
+    assert "plainsecret" not in report_md
+
+
+def _finding(fingerprint: str | None, *, confidence: float = 0.9, evidence: str = "eval(user_input)") -> Finding:
+    return Finding(
+        severity=FindingSeverity.HIGH,
+        category=FindingCategory.SECURITY,
+        file="app.py",
+        line=1,
+        title="Risk",
+        evidence=evidence,
+        recommendation="Avoid risky code.",
+        confidence=confidence,
+        source=FindingSource.RULE,
+        fingerprint=fingerprint,
+    )

--- a/examples/skills_code_review_agent/tests/test_report.py
+++ b/examples/skills_code_review_agent/tests/test_report.py
@@ -25,6 +25,7 @@ from examples.skills_code_review_agent.agent import dedupe_findings
 from examples.skills_code_review_agent.agent import parse_unified_diff
 from examples.skills_code_review_agent.agent import route_findings
 from examples.skills_code_review_agent.agent import write_review_report
+from examples.skills_code_review_agent.tests.secret_samples import generic_password_value
 
 
 def test_dedupe_findings_uses_fingerprint():
@@ -68,7 +69,8 @@ def test_route_findings_adds_human_review_for_filter_and_sandbox():
 
 def test_write_review_report_outputs_json_and_markdown_without_secrets(tmp_path: Path):
     input_summary = parse_unified_diff("", task_id="task", input_type=InputType.FIXTURE)
-    finding = _finding("secret", evidence="password=plainsecret", confidence=0.9)
+    sensitive_value = generic_password_value()
+    finding = _finding("secret", evidence=f"password={sensitive_value}", confidence=0.9)
     report = build_review_report(
         task_id="task",
         input_summary=input_summary,
@@ -84,8 +86,8 @@ def test_write_review_report_outputs_json_and_markdown_without_secrets(tmp_path:
     report_md = md_path.read_text(encoding="utf-8")
     assert report_json["metrics"]["finding_count"] == 1
     assert "Fix Suggestions" in report_md
-    assert "plainsecret" not in json.dumps(report_json)
-    assert "plainsecret" not in report_md
+    assert sensitive_value not in json.dumps(report_json)
+    assert sensitive_value not in report_md
 
 
 def _finding(fingerprint: str | None, *, confidence: float = 0.9, evidence: str = "eval(user_input)") -> Finding:

--- a/examples/skills_code_review_agent/tests/test_report.py
+++ b/examples/skills_code_review_agent/tests/test_report.py
@@ -36,10 +36,24 @@ def test_dedupe_findings_uses_fingerprint():
 
 def test_dedupe_findings_generates_missing_fingerprint():
     finding = _finding(None)
+    original = finding.to_dict()
 
     deduped = dedupe_findings([finding])
 
     assert deduped[0].fingerprint
+    assert deduped[0] is not finding
+    assert finding.to_dict() == original
+
+
+def test_dedupe_findings_does_not_mutate_sensitive_evidence():
+    sensitive_value = generic_password_value()
+    finding = _finding(None, evidence=f"password={sensitive_value}")
+    original = finding.to_dict()
+
+    deduped = dedupe_findings([finding])
+
+    assert "[REDACTED]" in deduped[0].evidence
+    assert finding.to_dict() == original
 
 
 def test_route_findings_splits_low_confidence_to_warnings():

--- a/examples/skills_code_review_agent/tests/test_review_rules.py
+++ b/examples/skills_code_review_agent/tests/test_review_rules.py
@@ -95,6 +95,64 @@ diff --git a/tests/test_app.py b/tests/test_app.py
     assert all(item.category is not FindingCategory.TEST for item in findings)
 
 
+def test_unrelated_test_update_does_not_suppress_missing_tests_finding():
+    diff = _diff_for_paths({
+        "app.py": ["new = 1"],
+        "tests/test_other.py": ["assert True"],
+    })
+
+    findings = run_review_rules(parse_unified_diff(diff, task_id="task-unrelated-test"))
+
+    assert _first(findings, FindingCategory.TEST).file == "app.py"
+
+
+def test_nested_related_test_update_suppresses_missing_tests_finding():
+    diff = _diff_for_paths({
+        "pkg/app.py": ["new = 1"],
+        "tests/pkg/test_app.py": ["assert new == 1"],
+    })
+
+    findings = run_review_rules(parse_unified_diff(diff, task_id="task-nested-test"))
+
+    assert all(item.category is not FindingCategory.TEST for item in findings)
+
+
+def test_partial_test_coverage_keeps_missing_tests_finding():
+    diff = _diff_for_paths({
+        "app.py": ["new = 1"],
+        "storage.py": ["new = 2"],
+        "tests/test_app.py": ["assert new == 1"],
+    })
+
+    findings = run_review_rules(parse_unified_diff(diff, task_id="task-partial-test"))
+    test_finding = _first(findings, FindingCategory.TEST)
+
+    assert test_finding.file == "storage.py"
+    assert "1 of 2" in test_finding.evidence
+
+
+def test_related_fixture_update_suppresses_missing_tests_finding():
+    diff = _diff_for_paths({
+        "payment.py": ["refund = True"],
+        "fixtures/payment.diff": ["fixture = True"],
+    })
+
+    findings = run_review_rules(parse_unified_diff(diff, task_id="task-related-fixture"))
+
+    assert all(item.category is not FindingCategory.TEST for item in findings)
+
+
+def test_unrelated_fixture_update_does_not_suppress_missing_tests_finding():
+    diff = _diff_for_paths({
+        "payment.py": ["refund = True"],
+        "fixtures/other.diff": ["fixture = True"],
+    })
+
+    findings = run_review_rules(parse_unified_diff(diff, task_id="task-unrelated-fixture"))
+
+    assert _first(findings, FindingCategory.TEST).file == "payment.py"
+
+
 def test_source_change_without_test_update_has_stable_fingerprint():
     diff = _diff_for_lines("+new = 1\n")
 
@@ -117,6 +175,19 @@ def _diff_for_lines(added_lines: str) -> str:
 @@ -1 +1,{max(1, added_lines.count(chr(10)))} @@
 -old
 {added_lines}"""
+
+
+def _diff_for_paths(files: dict[str, list[str]]) -> str:
+    blocks = []
+    for path, lines in files.items():
+        rendered = "\n".join(f"+{line}" for line in lines)
+        blocks.append(f"""diff --git a/{path} b/{path}
+--- a/{path}
++++ b/{path}
+@@ -1 +1,{max(1, len(lines))} @@
+-old
+{rendered}""")
+    return "\n".join(blocks) + "\n"
 
 
 def _first(findings, category: FindingCategory):

--- a/examples/skills_code_review_agent/tests/test_review_rules.py
+++ b/examples/skills_code_review_agent/tests/test_review_rules.py
@@ -11,10 +11,11 @@ from examples.skills_code_review_agent.agent import FindingCategory
 from examples.skills_code_review_agent.agent import FindingSeverity
 from examples.skills_code_review_agent.agent import parse_unified_diff
 from examples.skills_code_review_agent.agent import run_review_rules
+from examples.skills_code_review_agent.tests.secret_samples import openai_like_token
 
 
 def test_hard_coded_secret_is_reported_and_redacted():
-    findings = _findings("""+API_KEY = "sk-abcdefghijklmnop"\n""")
+    findings = _findings(f"""+API_KEY = "{openai_like_token()}"\n""")
 
     secret = _first(findings, FindingCategory.SECRET)
     assert secret.severity is FindingSeverity.CRITICAL

--- a/examples/skills_code_review_agent/tests/test_review_rules.py
+++ b/examples/skills_code_review_agent/tests/test_review_rules.py
@@ -11,7 +11,10 @@ from examples.skills_code_review_agent.agent import FindingCategory
 from examples.skills_code_review_agent.agent import FindingSeverity
 from examples.skills_code_review_agent.agent import parse_unified_diff
 from examples.skills_code_review_agent.agent import run_review_rules
+from examples.skills_code_review_agent.tests.secret_samples import client_secret_like_value
+from examples.skills_code_review_agent.tests.secret_samples import generic_password_value
 from examples.skills_code_review_agent.tests.secret_samples import openai_like_token
+from examples.skills_code_review_agent.tests.secret_samples import refresh_token_like_value
 
 
 def test_hard_coded_secret_is_reported_and_redacted():
@@ -21,6 +24,36 @@ def test_hard_coded_secret_is_reported_and_redacted():
     assert secret.severity is FindingSeverity.CRITICAL
     assert "abcdefghijklmnop" not in secret.evidence
     assert "[REDACTED]" in secret.evidence
+
+
+def test_unquoted_secret_assignments_are_reported_and_redacted():
+    values = [
+        openai_like_token(),
+        generic_password_value(),
+        client_secret_like_value(),
+        refresh_token_like_value(),
+    ]
+    findings = _findings("\n".join([
+        f"+API_KEY = {values[0]}",
+        f"+password: {values[1]}",
+        f"+client_secret = {values[2]}",
+        f"+refresh-token: {values[3]}",
+    ]) + "\n")
+    secrets = [item for item in findings if item.category is FindingCategory.SECRET]
+
+    assert len(secrets) == len(values)
+    assert all(item.severity is FindingSeverity.CRITICAL for item in secrets)
+    assert all(value not in item.evidence for value in values for item in secrets)
+    assert all("[REDACTED]" in item.evidence for item in secrets)
+
+
+def test_non_secret_assignments_are_not_reported_as_secrets():
+    findings = _findings("+message = 'token bucket rate limiter'\n"
+                         "+value = None\n"
+                         "+get_token()\n"
+                         "+token_count = 1\n")
+
+    assert all(item.category is not FindingCategory.SECRET for item in findings)
 
 
 def test_skill_words_are_not_secret_findings():

--- a/examples/skills_code_review_agent/tests/test_review_rules.py
+++ b/examples/skills_code_review_agent/tests/test_review_rules.py
@@ -1,0 +1,125 @@
+# Tencent is pleased to support the open source community by making tRPC-Agent-Python available.
+#
+# Copyright (C) 2026 Tencent. All rights reserved.
+#
+# tRPC-Agent-Python is licensed under Apache-2.0.
+"""Business tests for deterministic review rules."""
+
+from __future__ import annotations
+
+from examples.skills_code_review_agent.agent import FindingCategory
+from examples.skills_code_review_agent.agent import FindingSeverity
+from examples.skills_code_review_agent.agent import parse_unified_diff
+from examples.skills_code_review_agent.agent import run_review_rules
+
+
+def test_hard_coded_secret_is_reported_and_redacted():
+    findings = _findings("""+API_KEY = "sk-abcdefghijklmnop"\n""")
+
+    secret = _first(findings, FindingCategory.SECRET)
+    assert secret.severity is FindingSeverity.CRITICAL
+    assert "abcdefghijklmnop" not in secret.evidence
+    assert "[REDACTED]" in secret.evidence
+
+
+def test_skill_words_are_not_secret_findings():
+    findings = _findings("""+path = "skills_code_review_agent/skill_manifest.json"\n""")
+
+    assert all(item.category is not FindingCategory.SECRET for item in findings)
+
+
+def test_eval_exec_and_shell_true_are_high_security_findings():
+    findings = _findings("""+eval(user_input)\n+exec(code)\n+subprocess.run(cmd, shell=True)\n""")
+
+    security_findings = [item for item in findings if item.category is FindingCategory.SECURITY]
+    assert len(security_findings) == 3
+    assert all(item.severity is FindingSeverity.HIGH for item in security_findings)
+
+
+def test_async_client_without_context_is_reported():
+    findings = _findings("""+client = httpx.AsyncClient()\n+return await client.get(url)\n""")
+
+    assert _first(findings, FindingCategory.ASYNC).title == "Async client/session may not be closed"
+
+
+def test_file_handle_without_context_is_reported():
+    findings = _findings("""+handle = open(path)\n+return handle.read()\n""")
+
+    assert _first(findings, FindingCategory.RESOURCE).title == "File handle may not be closed"
+
+
+def test_database_connection_without_close_is_reported():
+    findings = _findings("""+conn = sqlite3.connect(path)\n+conn.execute(sql)\n""")
+
+    assert _first(findings, FindingCategory.DB).title == "Database connection lifecycle is not bounded"
+
+
+def test_context_managed_python_resources_do_not_report_lifecycle_findings():
+    findings = _findings("+with open(path) as handle:\n"
+                         "+    data = handle.read()\n"
+                         "+async with httpx.AsyncClient() as client:\n"
+                         "+    await client.get(url)\n"
+                         "+with sqlite3.connect(path) as conn:\n"
+                         "+    conn.execute(sql)\n")
+
+    categories = {finding.category for finding in findings}
+    assert FindingCategory.RESOURCE not in categories
+    assert FindingCategory.ASYNC not in categories
+    assert FindingCategory.DB not in categories
+
+
+def test_malformed_python_falls_back_to_regex_rules():
+    findings = _findings("""+if True\n+eval(user_input)\n""")
+
+    assert _first(findings, FindingCategory.SECURITY)
+
+
+def test_test_update_suppresses_missing_tests_finding():
+    diff = """diff --git a/app.py b/app.py
+--- a/app.py
++++ b/app.py
+@@ -1 +1 @@
+-old
++new
+diff --git a/tests/test_app.py b/tests/test_app.py
+--- a/tests/test_app.py
++++ b/tests/test_app.py
+@@ -1 +1 @@
+-assert old
++assert new
+"""
+
+    findings = run_review_rules(parse_unified_diff(diff, task_id="task-tests"))
+
+    assert all(item.category is not FindingCategory.TEST for item in findings)
+
+
+def test_source_change_without_test_update_has_stable_fingerprint():
+    diff = _diff_for_lines("+new = 1\n")
+
+    first = run_review_rules(parse_unified_diff(diff, task_id="task-a"))
+    second = run_review_rules(parse_unified_diff(diff, task_id="task-b"))
+
+    first_test = _first(first, FindingCategory.TEST)
+    second_test = _first(second, FindingCategory.TEST)
+    assert first_test.fingerprint == second_test.fingerprint
+
+
+def _findings(added_lines: str):
+    return run_review_rules(parse_unified_diff(_diff_for_lines(added_lines), task_id="task"))
+
+
+def _diff_for_lines(added_lines: str) -> str:
+    return f"""diff --git a/app.py b/app.py
+--- a/app.py
++++ b/app.py
+@@ -1 +1,{max(1, added_lines.count(chr(10)))} @@
+-old
+{added_lines}"""
+
+
+def _first(findings, category: FindingCategory):
+    for finding in findings:
+        if finding.category is category:
+            return finding
+    raise AssertionError(f"missing finding category: {category}")

--- a/examples/skills_code_review_agent/tests/test_rule_runner_contract.py
+++ b/examples/skills_code_review_agent/tests/test_rule_runner_contract.py
@@ -1,0 +1,96 @@
+# Tencent is pleased to support the open source community by making tRPC-Agent-Python available.
+#
+# Copyright (C) 2026 Tencent. All rights reserved.
+#
+# tRPC-Agent-Python is licensed under Apache-2.0.
+"""Business tests for the bundled rule-runner JSON contract."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from examples.skills_code_review_agent.agent import load_skill
+from examples.skills_code_review_agent.agent import parse_unified_diff
+
+
+def test_rule_runner_accepts_structured_input(tmp_path: Path):
+    input_path, manifest_path = _write_contract_inputs(tmp_path)
+    result = _run_rule_runner("--input", str(input_path), "--manifest", str(manifest_path))
+
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload == {
+        "diagnostics": [],
+        "findings": [],
+        "schema_version": "code-review.rules.v1",
+        "skill_name": "code-review",
+    }
+
+
+def test_rule_runner_reports_missing_required_fields(tmp_path: Path):
+    input_path = tmp_path / "input.json"
+    manifest_path = tmp_path / "manifest.json"
+    input_path.write_text(json.dumps({"changed_files": []}), encoding="utf-8")
+    manifest_path.write_text(json.dumps(load_skill(_skill_root()).manifest.to_dict()), encoding="utf-8")
+
+    result = _run_rule_runner("--input", str(input_path), "--manifest", str(manifest_path))
+
+    assert result.returncode == 2
+    assert "missing fields" in result.stderr
+
+
+def test_rule_runner_rejects_mismatched_skill_name(tmp_path: Path):
+    input_path, manifest_path = _write_contract_inputs(tmp_path)
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["name"] = "other"
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    result = _run_rule_runner("--input", str(input_path), "--manifest", str(manifest_path))
+
+    assert result.returncode == 2
+    assert "manifest skill name" in result.stderr
+
+
+def test_rule_runner_writes_output_file(tmp_path: Path):
+    input_path, manifest_path = _write_contract_inputs(tmp_path)
+    output_path = tmp_path / "out" / "result.json"
+
+    result = _run_rule_runner(
+        "--input",
+        str(input_path),
+        "--manifest",
+        str(manifest_path),
+        "--output",
+        str(output_path),
+    )
+
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(output_path.read_text(encoding="utf-8"))
+    assert set(payload) == {"schema_version", "skill_name", "findings", "diagnostics"}
+    assert payload["findings"] == []
+
+
+def _write_contract_inputs(tmp_path: Path) -> tuple[Path, Path]:
+    input_summary = parse_unified_diff("", task_id="task")
+    manifest = load_skill(_skill_root()).manifest
+    input_path = tmp_path / "parsed_input.json"
+    manifest_path = tmp_path / "skill_manifest.json"
+    input_path.write_text(json.dumps(input_summary.to_dict()), encoding="utf-8")
+    manifest_path.write_text(json.dumps(manifest.to_dict()), encoding="utf-8")
+    return input_path, manifest_path
+
+
+def _run_rule_runner(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(_skill_root() / "scripts" / "rule_runner.py"), *args],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _skill_root() -> Path:
+    return Path(__file__).parents[1] / "skills" / "code-review"

--- a/examples/skills_code_review_agent/tests/test_sandbox.py
+++ b/examples/skills_code_review_agent/tests/test_sandbox.py
@@ -7,12 +7,15 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import subprocess
+import sys
 from types import SimpleNamespace
 from pathlib import Path
 
 import examples.skills_code_review_agent.agent.sandbox as sandbox_module
+import examples.skills_code_review_agent.agent.sandbox_workspace as workspace_module
 from examples.skills_code_review_agent.agent import RuntimeKind
 from examples.skills_code_review_agent.agent import SandboxStatus
 from examples.skills_code_review_agent.agent import load_skill
@@ -153,6 +156,94 @@ def test_optional_runtime_adapter_success_is_recorded(tmp_path: Path, monkeypatc
     assert result["skill_name"] == "code-review"
 
 
+def test_cube_adapter_uses_one_event_loop_for_client_lifecycle(tmp_path: Path):
+    input_path, manifest_path = _write_inputs(tmp_path)
+    loop_ids: list[int] = []
+
+    async def create_client():
+        loop_ids.append(id(asyncio.get_running_loop()))
+        return _LoopTrackingClient(loop_ids)
+
+    def create_runtime(_client):
+        loop_ids.append(id(asyncio.get_running_loop()))
+        return _LoopTrackingWorkspaceRuntime(loop_ids)
+
+    adapter = workspace_module._CubeWorkspaceRuntimeAdapter(
+        RuntimeKind.CUBE,
+        create_client,
+        create_runtime,
+    )
+
+    async def invoke():
+        return adapter.run_rule_script(
+            "task",
+            input_path,
+            manifest_path,
+            tmp_path / "rule_result.json",
+            30,
+            65536,
+        )
+
+    sandbox_run, result = asyncio.run(invoke())
+
+    assert sandbox_run.status is SandboxStatus.SUCCESS
+    assert result["schema_version"] == "code-review.rules.v1"
+    assert len(set(loop_ids)) == 1
+
+
+def test_workspace_cleanup_is_attempted_when_creation_fails(tmp_path: Path):
+    input_path, manifest_path = _write_inputs(tmp_path)
+    manager = _FailingCreateManager()
+    runtime = _FakeWorkspaceRuntime()
+    runtime.manager_obj = manager
+    adapter = workspace_module._WorkspaceRuntimeAdapter(RuntimeKind.CONTAINER, runtime)
+
+    sandbox_run, result = adapter.run_rule_script(
+        "task",
+        input_path,
+        manifest_path,
+        tmp_path / "rule_result.json",
+        30,
+        65536,
+    )
+
+    assert sandbox_run.status is SandboxStatus.FAILED
+    assert sandbox_run.error_type == "RuntimeError"
+    assert manager.cleanup_called is True
+    assert result["findings"] == []
+
+
+def test_workspace_bundle_is_importable_and_executable(tmp_path: Path):
+    input_path, manifest_path = _write_inputs(tmp_path)
+    bundle_root = tmp_path / "bundle"
+    for file_info in workspace_module._workspace_bundle(input_path, manifest_path):
+        target = bundle_root / file_info.path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(file_info.content)
+
+    output_path = bundle_root / "work" / "outputs" / "rule_result.json"
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "work/skills/code-review/scripts/rule_runner.py",
+            "--input",
+            "work/inputs/parsed_input.json",
+            "--manifest",
+            "work/inputs/skill_manifest.json",
+            "--output",
+            "work/outputs/rule_result.json",
+        ],
+        cwd=bundle_root,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 0
+    assert output_path.is_file()
+    assert json.loads(output_path.read_text(encoding="utf-8"))["schema_version"] == "code-review.rules.v1"
+
+
 class _FakeWorkspaceRuntime:
 
     def __init__(self):
@@ -177,6 +268,48 @@ class _FakeManager:
 
     async def cleanup(self, exec_id):
         return None
+
+
+class _FailingCreateManager:
+
+    def __init__(self):
+        self.cleanup_called = False
+
+    async def create_workspace(self, exec_id):
+        raise RuntimeError("workspace creation failed")
+
+    async def cleanup(self, exec_id):
+        self.cleanup_called = True
+
+
+class _LoopTrackingClient:
+
+    def __init__(self, loop_ids: list[int]):
+        self.loop_ids = loop_ids
+
+    async def destroy(self):
+        self.loop_ids.append(id(asyncio.get_running_loop()))
+
+
+class _LoopTrackingWorkspaceRuntime(_FakeWorkspaceRuntime):
+
+    def __init__(self, loop_ids: list[int]):
+        super().__init__()
+        self.manager_obj = _LoopTrackingManager(loop_ids)
+
+
+class _LoopTrackingManager(_FakeManager):
+
+    def __init__(self, loop_ids: list[int]):
+        self.loop_ids = loop_ids
+
+    async def create_workspace(self, exec_id):
+        self.loop_ids.append(id(asyncio.get_running_loop()))
+        return await super().create_workspace(exec_id)
+
+    async def cleanup(self, exec_id):
+        self.loop_ids.append(id(asyncio.get_running_loop()))
+        await super().cleanup(exec_id)
 
 
 class _FakeFS:

--- a/examples/skills_code_review_agent/tests/test_sandbox.py
+++ b/examples/skills_code_review_agent/tests/test_sandbox.py
@@ -1,0 +1,240 @@
+# Tencent is pleased to support the open source community by making tRPC-Agent-Python available.
+#
+# Copyright (C) 2026 Tencent. All rights reserved.
+#
+# tRPC-Agent-Python is licensed under Apache-2.0.
+"""Business tests for sandbox adaptation."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from types import SimpleNamespace
+from pathlib import Path
+
+import examples.skills_code_review_agent.agent.sandbox as sandbox_module
+from examples.skills_code_review_agent.agent import RuntimeKind
+from examples.skills_code_review_agent.agent import SandboxStatus
+from examples.skills_code_review_agent.agent import load_skill
+from examples.skills_code_review_agent.agent import parse_unified_diff
+from examples.skills_code_review_agent.agent import run_rule_script
+
+
+def test_dry_run_writes_rule_result(tmp_path: Path):
+    input_path, manifest_path = _write_inputs(tmp_path)
+    output_path = tmp_path / "rule_result.json"
+
+    sandbox_run, events, result = run_rule_script(
+        "task",
+        RuntimeKind.DRY_RUN,
+        False,
+        input_path,
+        manifest_path,
+        output_path,
+    )
+
+    assert sandbox_run.status is SandboxStatus.SUCCESS
+    assert events[0].decision.value == "allow"
+    assert output_path.is_file()
+    assert result["schema_version"] == "code-review.rules.v1"
+
+
+def test_local_dev_without_allow_is_denied(tmp_path: Path):
+    input_path, manifest_path = _write_inputs(tmp_path)
+
+    sandbox_run, events, result = run_rule_script(
+        "task",
+        RuntimeKind.LOCAL_DEV,
+        False,
+        input_path,
+        manifest_path,
+        tmp_path / "rule_result.json",
+    )
+
+    assert sandbox_run.status is SandboxStatus.DENIED
+    assert events[0].reason_code.value == "local_runtime_denied"
+    assert result["findings"] == []
+
+
+def test_local_dev_with_allow_executes_rule_runner(tmp_path: Path):
+    input_path, manifest_path = _write_inputs(tmp_path)
+
+    sandbox_run, events, result = run_rule_script(
+        "task",
+        RuntimeKind.LOCAL_DEV,
+        True,
+        input_path,
+        manifest_path,
+        tmp_path / "rule_result.json",
+    )
+
+    assert sandbox_run.status is SandboxStatus.SUCCESS
+    assert sandbox_run.exit_code == 0
+    assert events[0].decision.value == "allow"
+    assert result["skill_name"] == "code-review"
+
+
+def test_container_runtime_records_human_review(tmp_path: Path, monkeypatch):
+    input_path, manifest_path = _write_inputs(tmp_path)
+    monkeypatch.setattr(
+        "examples.skills_code_review_agent.agent.sandbox._resolve_runtime_adapter",
+        lambda runtime, **kwargs: sandbox_module._RuntimeAdapterResult(
+            runtime=runtime,
+            available=False,
+            reason="container runtime is unavailable",
+        ),
+    )
+
+    sandbox_run, events, result = run_rule_script(
+        "task",
+        RuntimeKind.CONTAINER,
+        False,
+        input_path,
+        manifest_path,
+        tmp_path / "rule_result.json",
+    )
+
+    assert sandbox_run.status is SandboxStatus.NEEDS_HUMAN_REVIEW
+    assert events[0].reason_code.value == "sandbox_unavailable"
+    assert result["findings"] == []
+
+
+def test_optional_runtime_adapter_success_is_recorded(tmp_path: Path, monkeypatch):
+    input_path, manifest_path = _write_inputs(tmp_path)
+
+    monkeypatch.setattr(
+        "examples.skills_code_review_agent.agent.sandbox._resolve_runtime_adapter",
+        lambda runtime, **kwargs: sandbox_module._RuntimeAdapterResult(
+            runtime=runtime,
+            available=True,
+            adapter=sandbox_module._WorkspaceRuntimeAdapter(RuntimeKind.CONTAINER, _FakeWorkspaceRuntime()),
+        ),
+    )
+    sandbox_run, events, result = run_rule_script(
+        "task",
+        RuntimeKind.CONTAINER,
+        False,
+        input_path,
+        manifest_path,
+        tmp_path / "rule_result.json",
+    )
+
+    assert sandbox_run.status is SandboxStatus.SUCCESS
+    assert events[0].decision.value == "allow"
+    assert result["skill_name"] == "code-review"
+
+
+class _FakeWorkspaceRuntime:
+
+    def __init__(self):
+        self.fs_obj = _FakeFS()
+        self.manager_obj = _FakeManager()
+        self.runner_obj = _FakeRunner()
+
+    def manager(self):
+        return self.manager_obj
+
+    def fs(self):
+        return self.fs_obj
+
+    def runner(self):
+        return self.runner_obj
+
+
+class _FakeManager:
+
+    async def create_workspace(self, exec_id):
+        return SimpleNamespace(id=exec_id, path="/workspace/ws")
+
+    async def cleanup(self, exec_id):
+        return None
+
+
+class _FakeFS:
+
+    async def put_files(self, workspace, files):
+        assert any(file.path == "work/agent/models.py" for file in files)
+        assert any(file.path == "work/skills/code-review/scripts/rule_runner.py" for file in files)
+
+    async def collect_outputs(self, workspace, spec):
+        assert spec.max_total_bytes > 0
+        return SimpleNamespace(
+            limits_hit=False,
+            files=[
+                SimpleNamespace(
+                    name="work/outputs/rule_result.json",
+                    content=json.dumps({
+                        "schema_version": "code-review.rules.v1",
+                        "skill_name": "code-review",
+                        "findings": [],
+                        "diagnostics": [],
+                    }),
+                )
+            ],
+        )
+
+
+class _FakeRunner:
+
+    async def run_program(self, workspace, spec):
+        assert spec.cwd == "work"
+        assert spec.timeout > 0
+        assert spec.env["PYTHONPATH"] == "."
+        return SimpleNamespace(stdout="", stderr="", exit_code=0, duration=0.01, timed_out=False)
+
+
+def test_timeout_is_recorded_without_crashing(tmp_path: Path, monkeypatch):
+    input_path, manifest_path = _write_inputs(tmp_path)
+
+    def raise_timeout(*args, **kwargs):
+        raise subprocess.TimeoutExpired(cmd=["python"], timeout=1, output="password=secretvalue")
+
+    monkeypatch.setattr("examples.skills_code_review_agent.agent.sandbox.subprocess.run", raise_timeout)
+    sandbox_run, _events, result = run_rule_script(
+        "task",
+        RuntimeKind.LOCAL_DEV,
+        True,
+        input_path,
+        manifest_path,
+        tmp_path / "rule_result.json",
+        timeout_sec=1,
+    )
+
+    assert sandbox_run.status is SandboxStatus.TIMEOUT
+    assert "secretvalue" not in json.dumps(result)
+
+
+def test_stdout_is_truncated_and_redacted(tmp_path: Path, monkeypatch):
+    input_path, manifest_path = _write_inputs(tmp_path)
+
+    class Completed:
+        returncode = 0
+        stdout = "password=secretvalue " + ("x" * 100)
+        stderr = ""
+
+    monkeypatch.setattr(
+        "examples.skills_code_review_agent.agent.sandbox.subprocess.run",
+        lambda *args, **kwargs: Completed(),
+    )
+    sandbox_run, _events, _result = run_rule_script(
+        "task",
+        RuntimeKind.LOCAL_DEV,
+        True,
+        input_path,
+        manifest_path,
+        tmp_path / "rule_result.json",
+        output_limit_bytes=16,
+    )
+
+    assert sandbox_run.stdout_truncated is True
+    assert "secretvalue" not in sandbox_run.stdout
+
+
+def _write_inputs(tmp_path: Path) -> tuple[Path, Path]:
+    summary = parse_unified_diff("", task_id="task")
+    manifest = load_skill(Path(__file__).parents[1] / "skills" / "code-review").manifest
+    input_path = tmp_path / "parsed_input.json"
+    manifest_path = tmp_path / "skill_manifest.json"
+    input_path.write_text(json.dumps(summary.to_dict()), encoding="utf-8")
+    manifest_path.write_text(json.dumps(manifest.to_dict()), encoding="utf-8")
+    return input_path, manifest_path

--- a/examples/skills_code_review_agent/tests/test_sandbox.py
+++ b/examples/skills_code_review_agent/tests/test_sandbox.py
@@ -74,6 +74,35 @@ def test_local_dev_with_allow_executes_rule_runner(tmp_path: Path):
     assert result["skill_name"] == "code-review"
 
 
+def test_forbidden_referenced_input_path_is_denied_before_subprocess(tmp_path: Path, monkeypatch):
+    allowed_dir = tmp_path / "allowed"
+    denied_dir = tmp_path / "denied"
+    allowed_dir.mkdir()
+    denied_dir.mkdir()
+    input_path, manifest_path = _write_inputs(denied_dir)
+    output_path = allowed_dir / "rule_result.json"
+    called = {"value": False}
+
+    def fail_if_called(*args, **kwargs):
+        called["value"] = True
+        raise AssertionError("subprocess.run should not be called for forbidden paths")
+
+    monkeypatch.setattr("examples.skills_code_review_agent.agent.sandbox.subprocess.run", fail_if_called)
+    sandbox_run, events, result = run_rule_script(
+        "task",
+        RuntimeKind.LOCAL_DEV,
+        True,
+        input_path,
+        manifest_path,
+        output_path,
+    )
+
+    assert sandbox_run.status is SandboxStatus.DENIED
+    assert events[0].reason_code.value == "forbidden_path"
+    assert called["value"] is False
+    assert result["findings"] == []
+
+
 def test_container_runtime_records_human_review(tmp_path: Path, monkeypatch):
     input_path, manifest_path = _write_inputs(tmp_path)
     monkeypatch.setattr(

--- a/examples/skills_code_review_agent/tests/test_sanitizer.py
+++ b/examples/skills_code_review_agent/tests/test_sanitizer.py
@@ -10,7 +10,10 @@ from __future__ import annotations
 from examples.skills_code_review_agent.agent import redact_mapping
 from examples.skills_code_review_agent.agent import redact_text
 from examples.skills_code_review_agent.tests.secret_samples import bearer_like_token
+from examples.skills_code_review_agent.tests.secret_samples import db_password_like_value
+from examples.skills_code_review_agent.tests.secret_samples import generic_password_value
 from examples.skills_code_review_agent.tests.secret_samples import openai_like_token
+from examples.skills_code_review_agent.tests.secret_samples import private_key_body_value
 
 
 def test_redacts_common_secret_shapes():
@@ -18,20 +21,20 @@ def test_redacts_common_secret_shapes():
     api_key = openai_like_token()
     text = (f"Authorization: Bearer {bearer_like_token()}\n"
             f"API_KEY = \"{openai_like_token()}\"\n"
-            "password=supersecret\n"
-            "postgres://user:plainpass@db.example/app\n")
+            f"password={generic_password_value()}\n"
+            f"postgres://user:{db_password_like_value()}@db.example/app\n")
 
     redacted = redact_text(text)
 
     assert bearer not in redacted
     assert api_key not in redacted
-    assert "supersecret" not in redacted
-    assert "plainpass" not in redacted
+    assert generic_password_value() not in redacted
+    assert db_password_like_value() not in redacted
     assert "[REDACTED]" in redacted
 
 
 def test_redacts_private_key_blocks():
-    text = "-----BEGIN PRIVATE KEY-----\nsecret-body\n-----END PRIVATE KEY-----"
+    text = f"-----BEGIN PRIVATE KEY-----\n{private_key_body_value()}\n-----END PRIVATE KEY-----"
 
     assert redact_text(text) == "[REDACTED]"
 
@@ -40,7 +43,7 @@ def test_redacts_nested_json_like_payloads():
     payload = {
         "headers": [f"Bearer {bearer_like_token()}"],
         "config": {
-            "password": "password=plainsecret",
+            "password": f"password={generic_password_value()}",
             "safe": "visible",
         },
     }

--- a/examples/skills_code_review_agent/tests/test_sanitizer.py
+++ b/examples/skills_code_review_agent/tests/test_sanitizer.py
@@ -39,6 +39,12 @@ def test_redacts_private_key_blocks():
     assert redact_text(text) == "[REDACTED]"
 
 
+def test_redaction_is_idempotent_for_existing_redacted_assignments():
+    text = "API_KEY = [REDACTED]\nPASSWORD = [REDACTED]"
+
+    assert redact_text(redact_text(text)) == text
+
+
 def test_redacts_nested_json_like_payloads():
     payload = {
         "headers": [f"Bearer {bearer_like_token()}"],

--- a/examples/skills_code_review_agent/tests/test_sanitizer.py
+++ b/examples/skills_code_review_agent/tests/test_sanitizer.py
@@ -1,0 +1,53 @@
+# Tencent is pleased to support the open source community by making tRPC-Agent-Python available.
+#
+# Copyright (C) 2026 Tencent. All rights reserved.
+#
+# tRPC-Agent-Python is licensed under Apache-2.0.
+"""Business tests for redacting review artifacts."""
+
+from __future__ import annotations
+
+from examples.skills_code_review_agent.agent import redact_mapping
+from examples.skills_code_review_agent.agent import redact_text
+
+
+def test_redacts_common_secret_shapes():
+    text = ("Authorization: Bearer abcdefghijklmnop\n"
+            "API_KEY = \"sk-abcdefghijklmnop\"\n"
+            "password=supersecret\n"
+            "postgres://user:plainpass@db.example/app\n")
+
+    redacted = redact_text(text)
+
+    assert "abcdefghijklmnop" not in redacted
+    assert "supersecret" not in redacted
+    assert "plainpass" not in redacted
+    assert "[REDACTED]" in redacted
+
+
+def test_redacts_private_key_blocks():
+    text = "-----BEGIN PRIVATE KEY-----\nsecret-body\n-----END PRIVATE KEY-----"
+
+    assert redact_text(text) == "[REDACTED]"
+
+
+def test_redacts_nested_json_like_payloads():
+    payload = {
+        "headers": ["Bearer abcdefghijklmnop"],
+        "config": {
+            "password": "password=plainsecret",
+            "safe": "visible",
+        },
+    }
+
+    redacted = redact_mapping(payload)
+
+    assert redacted["headers"] == ["Bearer [REDACTED]"]
+    assert redacted["config"]["password"] == "password=[REDACTED]"
+    assert redacted["config"]["safe"] == "visible"
+
+
+def test_does_not_redact_skill_words_or_paths():
+    text = "/tmp/skills_code_review_agent/skill_manifest.json skill_name"
+
+    assert redact_text(text) == text

--- a/examples/skills_code_review_agent/tests/test_sanitizer.py
+++ b/examples/skills_code_review_agent/tests/test_sanitizer.py
@@ -9,17 +9,22 @@ from __future__ import annotations
 
 from examples.skills_code_review_agent.agent import redact_mapping
 from examples.skills_code_review_agent.agent import redact_text
+from examples.skills_code_review_agent.tests.secret_samples import bearer_like_token
+from examples.skills_code_review_agent.tests.secret_samples import openai_like_token
 
 
 def test_redacts_common_secret_shapes():
-    text = ("Authorization: Bearer abcdefghijklmnop\n"
-            "API_KEY = \"sk-abcdefghijklmnop\"\n"
+    bearer = bearer_like_token()
+    api_key = openai_like_token()
+    text = (f"Authorization: Bearer {bearer_like_token()}\n"
+            f"API_KEY = \"{openai_like_token()}\"\n"
             "password=supersecret\n"
             "postgres://user:plainpass@db.example/app\n")
 
     redacted = redact_text(text)
 
-    assert "abcdefghijklmnop" not in redacted
+    assert bearer not in redacted
+    assert api_key not in redacted
     assert "supersecret" not in redacted
     assert "plainpass" not in redacted
     assert "[REDACTED]" in redacted
@@ -33,7 +38,7 @@ def test_redacts_private_key_blocks():
 
 def test_redacts_nested_json_like_payloads():
     payload = {
-        "headers": ["Bearer abcdefghijklmnop"],
+        "headers": [f"Bearer {bearer_like_token()}"],
         "config": {
             "password": "password=plainsecret",
             "safe": "visible",

--- a/examples/skills_code_review_agent/tests/test_skill_loader.py
+++ b/examples/skills_code_review_agent/tests/test_skill_loader.py
@@ -1,0 +1,127 @@
+# Tencent is pleased to support the open source community by making tRPC-Agent-Python available.
+#
+# Copyright (C) 2026 Tencent. All rights reserved.
+#
+# tRPC-Agent-Python is licensed under Apache-2.0.
+"""Business tests for loading the local code-review Skill bundle."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from examples.skills_code_review_agent.agent import SkillLoadError
+from examples.skills_code_review_agent.agent import load_skill
+
+
+def test_skill_loader_reads_name_and_description():
+    skill = load_skill(_skill_root())
+
+    assert skill.manifest.name == "code-review"
+    assert "source-code changes" in skill.manifest.description
+
+
+def test_skill_loader_discovers_rules_scripts_and_docs():
+    skill = load_skill(_skill_root())
+
+    assert skill.manifest.rules == [
+        "rules/async-resource.md",
+        "rules/runtime.md",
+        "rules/security.md",
+        "rules/testing-db.md",
+    ]
+    assert skill.manifest.scripts == ["scripts/rule_runner.py"]
+    assert skill.manifest.docs == []
+
+
+def test_skill_loader_resources_are_stably_ordered():
+    skill = load_skill(_skill_root())
+
+    assert list(skill.resources) == sorted(skill.resources)
+
+
+def test_skill_loader_replaces_base_dir_placeholder(tmp_path: Path):
+    skill_dir = _write_skill(tmp_path)
+    (skill_dir / "README.md").write_text("root=__BASE_DIR__\n", encoding="utf-8")
+
+    skill = load_skill(skill_dir)
+
+    assert f"root={skill_dir.resolve()}" in skill.resources["README.md"]
+
+
+def test_skill_loader_digest_changes_with_file_content(tmp_path: Path):
+    skill_dir = _write_skill(tmp_path)
+    first = load_skill(skill_dir).manifest.digest
+    (skill_dir / "README.md").write_text("changed\n", encoding="utf-8")
+    second = load_skill(skill_dir).manifest.digest
+
+    assert first != second
+
+
+def test_skill_loader_reports_missing_skill_markdown(tmp_path: Path):
+    with pytest.raises(SkillLoadError, match="SKILL.md not found"):
+        load_skill(tmp_path)
+
+
+def test_skill_loader_rejects_invalid_frontmatter(tmp_path: Path):
+    skill_dir = tmp_path / "bad"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text("---\nname: [\n---\n", encoding="utf-8")
+
+    with pytest.raises(SkillLoadError, match="invalid SKILL.md YAML front matter"):
+        load_skill(skill_dir)
+
+
+def test_skill_loader_rejects_absolute_and_parent_paths(tmp_path: Path):
+    skill_dir = _write_skill(tmp_path, extra_frontmatter="rules:\n  - /tmp/rule.md\n")
+
+    with pytest.raises(SkillLoadError, match="unsafe path"):
+        load_skill(skill_dir)
+
+    skill_dir = _write_skill(tmp_path / "parent", extra_frontmatter="rules:\n  - ../rule.md\n")
+    with pytest.raises(SkillLoadError, match="unsafe path"):
+        load_skill(skill_dir)
+
+
+def test_skill_loader_rejects_symlink_escape(tmp_path: Path):
+    skill_dir = _write_skill(tmp_path)
+    outside = tmp_path / "outside.md"
+    outside.write_text("secret\n", encoding="utf-8")
+    (skill_dir / "rules").mkdir()
+    (skill_dir / "rules" / "escape.md").symlink_to(outside)
+
+    with pytest.raises(SkillLoadError, match="escapes root"):
+        load_skill(skill_dir)
+
+
+def test_hidden_resources_are_not_in_manifest(tmp_path: Path):
+    skill_dir = _write_skill(tmp_path)
+    (skill_dir / ".git").mkdir()
+    (skill_dir / ".git" / "config").write_text("ignored\n", encoding="utf-8")
+    (skill_dir / ".secret.md").write_text("ignored\n", encoding="utf-8")
+
+    skill = load_skill(skill_dir)
+
+    assert ".secret.md" not in skill.resources
+    assert all(not path.startswith(".git/") for path in skill.resources)
+
+
+def _skill_root() -> Path:
+    return Path(__file__).parents[1] / "skills" / "code-review"
+
+
+def _write_skill(tmp_path: Path, extra_frontmatter: str = "") -> Path:
+    skill_dir = tmp_path / "skill"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        f"""---
+name: code-review
+description: Test Skill
+{extra_frontmatter}---
+
+# Body
+""",
+        encoding="utf-8",
+    )
+    return skill_dir

--- a/examples/skills_code_review_agent/tests/test_store.py
+++ b/examples/skills_code_review_agent/tests/test_store.py
@@ -1,0 +1,130 @@
+# Tencent is pleased to support the open source community by making tRPC-Agent-Python available.
+#
+# Copyright (C) 2026 Tencent. All rights reserved.
+#
+# tRPC-Agent-Python is licensed under Apache-2.0.
+"""Business tests for SQLite persistence."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from examples.skills_code_review_agent.agent import FilterDecision
+from examples.skills_code_review_agent.agent import FilterEvent
+from examples.skills_code_review_agent.agent import Finding
+from examples.skills_code_review_agent.agent import FindingCategory
+from examples.skills_code_review_agent.agent import FindingSeverity
+from examples.skills_code_review_agent.agent import FindingSource
+from examples.skills_code_review_agent.agent import InputType
+from examples.skills_code_review_agent.agent import ReviewReport
+from examples.skills_code_review_agent.agent import ReviewMetrics
+from examples.skills_code_review_agent.agent import ReviewStore
+from examples.skills_code_review_agent.agent import ReviewTask
+from examples.skills_code_review_agent.agent import RuntimeKind
+from examples.skills_code_review_agent.agent import SandboxRun
+from examples.skills_code_review_agent.agent import parse_unified_diff
+
+
+def test_store_initializes_schema(tmp_path: Path):
+    db_path = tmp_path / "review.sqlite3"
+
+    with ReviewStore(db_path):
+        pass
+
+    conn = sqlite3.connect(db_path)
+    tables = {row[0] for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+    assert {"review_task", "input_diff", "finding", "filter_event", "sandbox_run", "report"}.issubset(tables)
+
+
+def test_store_saves_and_queries_review_by_task_id(tmp_path: Path):
+    db_path = tmp_path / "review.sqlite3"
+    task, input_summary, finding, event, sandbox, report = _review_objects()
+
+    with ReviewStore(db_path) as store:
+        store.save_review(
+            task=task,
+            input_summary=input_summary,
+            findings=[finding],
+            warnings=[],
+            needs_human_review=[],
+            filter_events=[event],
+            sandbox_runs=[sandbox],
+            report=report,
+            report_json_path=tmp_path / "review_report.json",
+            report_md_path=tmp_path / "review_report.md",
+        )
+        assert store.get_task(task.id)["id"] == task.id
+        assert store.get_input_summary(task.id)["summary_json"]["task_id"] == task.id
+        assert store.list_findings(task.id)[0]["fingerprint"] == "fp-1"
+        assert store.list_filter_events(task.id)[0]["metadata_json"] == {}
+        assert store.list_sandbox_runs(task.id)[0]["status"] == "success"
+        assert store.get_metrics(task.id)["finding_count"] == 1
+        assert store.get_report(task.id)["report_json"]["task_id"] == task.id
+
+
+def test_store_does_not_duplicate_same_fingerprint_route(tmp_path: Path):
+    task, input_summary, finding, event, sandbox, report = _review_objects()
+
+    with ReviewStore(tmp_path / "review.sqlite3") as store:
+        for _ in range(2):
+            store.save_review(
+                task=task,
+                input_summary=input_summary,
+                findings=[finding],
+                warnings=[],
+                needs_human_review=[],
+                filter_events=[event],
+                sandbox_runs=[sandbox],
+                report=report,
+                report_json_path=tmp_path / "review_report.json",
+                report_md_path=tmp_path / "review_report.md",
+            )
+        assert len(store.list_findings(task.id)) == 1
+
+
+def test_store_redacts_sensitive_text(tmp_path: Path):
+    task, input_summary, finding, event, sandbox, report = _review_objects()
+    finding.evidence = "password=plainsecret"
+
+    with ReviewStore(tmp_path / "review.sqlite3") as store:
+        store.save_review(
+            task=task,
+            input_summary=input_summary,
+            findings=[finding],
+            warnings=[],
+            needs_human_review=[],
+            filter_events=[event],
+            sandbox_runs=[sandbox],
+            report=report,
+            report_json_path=tmp_path / "review_report.json",
+            report_md_path=tmp_path / "review_report.md",
+        )
+        assert "plainsecret" not in store.list_findings(task.id)[0]["evidence"]
+
+
+def _review_objects():
+    task = ReviewTask(input_type=InputType.FIXTURE, input_ref="clean")
+    input_summary = parse_unified_diff("", task_id=task.id, input_type=InputType.FIXTURE)
+    finding = Finding(
+        severity=FindingSeverity.HIGH,
+        category=FindingCategory.SECURITY,
+        file="app.py",
+        line=1,
+        title="Risk",
+        evidence="eval(user_input)",
+        recommendation="Avoid eval.",
+        confidence=0.9,
+        source=FindingSource.RULE,
+        fingerprint="fp-1",
+    )
+    event = FilterEvent(task_id=task.id, decision=FilterDecision.ALLOW, reason="allowed", target="python")
+    sandbox = SandboxRun(task_id=task.id, runtime=RuntimeKind.DRY_RUN, command="python")
+    report = ReviewReport(
+        task_id=task.id,
+        findings=[finding],
+        interceptions=[event],
+        sandbox_runs=[sandbox],
+        metrics=ReviewMetrics(finding_count=1, severity_distribution={"high": 1}),
+    )
+    return task, input_summary, finding, event, sandbox, report

--- a/examples/skills_code_review_agent/tests/test_store.py
+++ b/examples/skills_code_review_agent/tests/test_store.py
@@ -24,6 +24,7 @@ from examples.skills_code_review_agent.agent import ReviewTask
 from examples.skills_code_review_agent.agent import RuntimeKind
 from examples.skills_code_review_agent.agent import SandboxRun
 from examples.skills_code_review_agent.agent import parse_unified_diff
+from examples.skills_code_review_agent.tests.secret_samples import generic_password_value
 
 
 def test_store_initializes_schema(tmp_path: Path):
@@ -85,7 +86,8 @@ def test_store_does_not_duplicate_same_fingerprint_route(tmp_path: Path):
 
 def test_store_redacts_sensitive_text(tmp_path: Path):
     task, input_summary, finding, event, sandbox, report = _review_objects()
-    finding.evidence = "password=plainsecret"
+    sensitive_value = generic_password_value()
+    finding.evidence = f"password={sensitive_value}"
 
     with ReviewStore(tmp_path / "review.sqlite3") as store:
         store.save_review(
@@ -100,7 +102,7 @@ def test_store_redacts_sensitive_text(tmp_path: Path):
             report_json_path=tmp_path / "review_report.json",
             report_md_path=tmp_path / "review_report.md",
         )
-        assert "plainsecret" not in store.list_findings(task.id)[0]["evidence"]
+        assert sensitive_value not in store.list_findings(task.id)[0]["evidence"]
 
 
 def _review_objects():


### PR DESCRIPTION
## Overview

Resolves #92 

The example now provides a deterministic end-to-end review pipeline that can:

- load the local `code-review` Skill
- parse diff / repo / fixture / file-list inputs
- run deterministic review rules
- apply example-local governance checks
- execute through `dry-run`, `local-dev`, and optional Container / Cube workspace runtimes
- persist review artifacts to SQLite
- emit `review_report.json` and `review_report.md`

The implementation remains example-local and does not modify `trpc_agent_sdk/` or any SDK public API.

## Main Changes

- Added a full `code-review` Skill package with `SKILL.md`, rule docs, and `rule_runner.py`.
- Completed normalized input parsing for unified diff, git worktree changes, fixtures, and file lists.
- Added structured findings, dedupe / routing, governance events, sandbox run records, metrics, and final report rendering.
- Implemented optional real Container / Cube workspace runtime adapters with safe fallback to `needs_human_review` when the backend is unavailable.
- Kept `dry-run` as the default path and `local-dev` behind explicit `--allow-local`.
- Added a minimal SQLite-backed review store plus a `ReviewStoreProtocol` / factory injection point for future SQL backends.
- Added redaction coverage for secrets across findings, sandbox output, reports, and database persistence.
- Added public fixture regression tests, sandbox / pipeline / store / report tests, and quantitative quality-gate tests for recall, false-positive proxy, and redaction rate.
- Updated the example README in Chinese and synchronized the design documentation.

## How To Run

From the repo root:

```bash
python -m pytest examples/skills_code_review_agent/tests -q
```

From the example directory:

```bash
cd examples/skills_code_review_agent
python run_review.py --fixture clean
python run_review.py --fixture secret --output-dir out-secret
```

Optional runtime examples:

```bash
python run_review.py --fixture clean --runtime local-dev --allow-local
python run_review.py --fixture clean --runtime container --docker-base-url unix:///var/run/docker.sock
python run_review.py --fixture clean --runtime cube
```

Cube runtime expects these environment variables when used:
- `CUBE_TEMPLATE_ID`
- `E2B_API_URL`
- `E2B_API_KEY`

## Validation

Validated locally with:

```bash
python -m pytest examples/skills_code_review_agent/tests -q
python -m py_compile examples/skills_code_review_agent/run_review.py examples/skills_code_review_agent/agent/*.py examples/skills_code_review_agent/skills/code-review/scripts/rule_runner.py examples/skills_code_review_agent/tests/*.py
python -m yapf --diff examples/skills_code_review_agent/run_review.py examples/skills_code_review_agent/agent/*.py examples/skills_code_review_agent/skills/code-review/scripts/rule_runner.py examples/skills_code_review_agent/tests/*.py
python -m flake8 examples/skills_code_review_agent
git diff -- trpc_agent_sdk
```



