### PR TITLE
fix(agui): defer RunErrorEvent emission to prevent premature disconnect

### DIFF
--- a/trpc_agent_sdk/server/ag_ui/_core/_agui_agent.py
+++ b/trpc_agent_sdk/server/ag_ui/_core/_agui_agent.py
@@ -1241,10 +1241,18 @@ class AgUiAgent:
                 return
 
             # Run TRPC agent
+            # Track whether the last observed trpc_event was a fatal (non-recoverable) error, so
+            # that once the stream ends we know whether the run actually terminated due to an
+            # error or completed normally. We can't emit RunErrorEvent as soon as we see an error
+            # event mid-stream because most agent types (GraphAgent, ChainAgent, etc.) continue
+            # running after a sub-agent yields an error event, and RunErrorEvent is terminal per
+            # the AG-UI protocol - compliant clients close the connection upon receiving it.
+            last_event_is_error = False
             async for trpc_event in runner.run_async(user_id=user_id,
                                                      session_id=input.thread_id,
                                                      new_message=new_message,
                                                      run_config=run_config):
+                last_event_is_error = trpc_event.is_error()
                 if not isinstance(trpc_event, LongRunningEvent):
                     # Check if custom translator should handle this event
                     if self._custom_event_translator and self._custom_event_translator.need_translate(trpc_event):
@@ -1281,6 +1289,21 @@ class AgUiAgent:
                 current_timestamp = datetime.now().timestamp()
                 ag_ui_event = event_translator._create_state_snapshot_event(final_state, current_timestamp)
                 await event_queue.put(ag_ui_event)
+
+            # The run ended - decide whether it finished normally or terminated due to an error
+            # based on whether the last trpc_event observed was an error. `trpc_event` still
+            # refers to the last event yielded by the loop above.
+            if last_event_is_error:
+                error_msg = (trpc_event.error_message or (trpc_event.custom_metadata or {}).get("error")
+                             or "Unknown error")
+                logger.error("Run for thread %s ended with a fatal error as its last event: %s", input.thread_id,
+                             error_msg)
+                await event_queue.put(
+                    RunErrorEvent(
+                        type=EventType.RUN_ERROR,
+                        message=error_msg,
+                        code=trpc_event.error_code or "MODEL_ERROR",
+                    ))
             # Signal completion - TRPC execution is done
             logger.debug("Background task sending completion signal for thread %s", input.thread_id)
             await event_queue.put(None)

--- a/trpc_agent_sdk/server/ag_ui/_core/_event_translator.py
+++ b/trpc_agent_sdk/server/ag_ui/_core/_event_translator.py
@@ -30,7 +30,6 @@ from typing import Optional
 from ag_ui.core import BaseEvent
 from ag_ui.core import CustomEvent
 from ag_ui.core import EventType
-from ag_ui.core import RunErrorEvent
 from ag_ui.core import StateDeltaEvent
 from ag_ui.core import StateSnapshotEvent
 from ag_ui.core import TextMessageContentEvent
@@ -202,9 +201,17 @@ class EventTranslator:
             # Tool execution errors (with function_response) are recoverable: the error is already
             # passed back to the LLM as a tool result, so the LLM can retry or adjust its approach.
             # Only fatal errors (LLM failures, system errors) without function_response should
-            # emit RunErrorEvent to terminate the run.
+            # be surfaced as an error to the client.
+            #
+            # NOTE (deferred decision): We deliberately do NOT emit RunErrorEvent here. Per the
+            # AG-UI protocol, RunErrorEvent is terminal and compliant clients close the connection
+            # upon receiving it. However, most agent types (GraphAgent, ChainAgent, etc.) continue
+            # running after a sub-agent yields an error event, so terminating the connection here
+            # would desynchronize the client from the still-running backend. Instead, we surface the
+            # error as a CustomEvent, and the caller (who observes the full event stream) decides
+            # whether to emit RunErrorEvent or RunFinishedEvent once the run actually ends.
             if trpc_event.is_error() and not function_responses:
-                # Fatal system/LLM error - emit RunErrorEvent to terminate the run
+                # Fatal system/LLM error - surface it via CustomEvent instead of terminating the run
                 logger.error("Fatal error (non-recoverable), error_code=%s, error_message=%s", trpc_event.error_code,
                              trpc_event.error_message)
                 # Force close any streaming message before emitting error
@@ -212,12 +219,14 @@ class EventTranslator:
                     yield close_event
                 error_msg = (trpc_event.error_message or (trpc_event.custom_metadata or {}).get("error")
                              or "Unknown error")
-                yield RunErrorEvent(
-                    type=EventType.RUN_ERROR,
-                    message=error_msg,
-                    code=trpc_event.error_code or "MODEL_ERROR",
+                yield CustomEvent(
+                    type=EventType.CUSTOM,
+                    name="trpc_error",
+                    value={
+                        "code": trpc_event.error_code or "MODEL_ERROR",
+                        "message": error_msg,
+                    },
                 )
-                return
 
             # Handle custom events or metadata
             if trpc_event.custom_metadata:


### PR DESCRIPTION
## 问题

PCG-应用宝 pcerypeng 反馈：使用 GrafAgent + AGUI 服务部署时，如果增加一个 AgentNode，该 AgentNode 返回一个带 error 的 Event，客户端与服务的连接会被断开，但此时 Agent 并没有结束，仍在持续执行。

## 根因

EventTranslator 在遇到 `is_error() and not function_responses` 的 Event 时，立即翻译为 RunErrorEvent。根据 AG-UI 协议规范，RunErrorEvent 是终止事件，合规客户端收到后会关闭连接。但服务端 SSE stream 实际保持开着——Translator 是 per-event 调用的，`return` 只结束单个 event 的翻译，外层循环继续消费后续事件。

核心矛盾：AgentNode 级别的可恢复错误与真正的致命系统错误在 Translator 层无法区分，都满足 `is_error() and not function_responses`。

## 修复方案（方案 D：延迟决策到 run 结束）

不在 error Event 出现时立即发 RunErrorEvent，等 run 结束后检查最后一个 Event 是否为 error，再决定发 RunErrorEvent 还是 RunFinishedEvent。

### 改动点

1. `_event_translator.py`：error Event 改为发 `CustomEvent(name="trpc_error", value={code, message})`，不再发 RunErrorEvent，移除 `return` 让翻译继续
2. `_agui_agent.py`：在 `_run_trpc_in_background` 的 `run_async` 循环中跟踪 `last_event_is_error`；循环结束后如果为 True，发 RunErrorEvent（用最后一个 event 的 error_code/error_message）

### 正确性

最后一个 event 是否为 error 完美捕捉了 run 是否因错误终止的运行时状态：
- LlmAgent yield error → return → 最后 event 是 error → RunErrorEvent ✅
- GraphAgent node yield error → 图继续 → 后续 node 事件 → 最后 event 非 error → RunFinishedEvent ✅
- ChainAgent 最后 sub=LlmAgent yield error → 最后 event 是 error → RunErrorEvent ✅
- ChainAgent 中间 sub error → 后续 sub 事件 → RunFinishedEvent ✅

## 测试

- test_event_translator.py + test_agui_agent.py：165 tests passed
- 完整 tests/server/ag_ui 套件：all passed, exit code 0

## 关联

- TAPD：https://tapd.woa.com/tapd_fe/20419452/story/detail/1020419452137024294