### PR TITLE
version: 发布1.1.18版本

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [1.1.18](https://github.com/trpc-group/trpc-agent-python/releases/tag/v1.1.18) (2026-08-21)
+
+### Bug Fixes
+
+* Telemetry: Fixed `agent_run` and runner spans misreporting success with empty output when LLM streaming output was interrupted mid-stream (network interruption, model business error, or a retry-swallowed failure on a later turn after a tool call).
+  * Error responses no longer clear the partial text already streamed; the span is now marked as failed and the accumulated output is preserved with an `[INTERRUPTED]` prefix.
+  * In multi-turn runs, the interrupted text is appended after already-collected turn content instead of being dropped.
+  * The `call_llm` span's `llm_response` attribute now also backfills the already-streamed content when the retry layer converts a raised exception into a terminal error response.
+
+### Internal
+
+* CI: Added extension package installation to `pipeline_test/run_all_examples.sh` so the full set of examples can be run in CI.
+
 ## [1.1.17](https://github.com/trpc-group/trpc-agent-python/releases/tag/v1.1.17) (2026-08-19)
 
 ### Features

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -10,4 +10,4 @@ from trpc_agent_sdk.version import __version__
 
 def test_version():
     """Test the version module."""
-    assert __version__ == '1.1.17'
+    assert __version__ == '1.1.18'

--- a/trpc_agent_sdk/version.py
+++ b/trpc_agent_sdk/version.py
@@ -9,4 +9,4 @@ TRPC Agent Version Module
 This module defines the version information for TRPC Agent
 """
 
-__version__ = '1.1.17'
+__version__ = '1.1.18'


### PR DESCRIPTION
## 发布内容

- 版本号从 1.1.17 升级到 1.1.18
- CHANGELOG 新增 1.1.18 记录（含流式中断 span 输出丢失修复、CI 全量示例支持）

合并后将基于此打 tag 发布 v1.1.18。
