### PR TITLE
发布 1.1.19 版本：同步 main 与 r0.1 分支版本号

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.1.19](https://github.com/trpc-group/trpc-agent-python/releases/tag/v1.1.19) (2026-08-21)
+
+Version bump to keep the `main` and `r0.1` branches in sync; carries forward the fixes already included in 1.1.18 (LLM streaming interruption span fixes and CI extension package installation).
+
 ## [1.1.18](https://github.com/trpc-group/trpc-agent-python/releases/tag/v1.1.18) (2026-08-21)
 
 ### Bug Fixes

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -10,4 +10,4 @@ from trpc_agent_sdk.version import __version__
 
 def test_version():
     """Test the version module."""
-    assert __version__ == '1.1.18'
+    assert __version__ == '1.1.19'

--- a/trpc_agent_sdk/version.py
+++ b/trpc_agent_sdk/version.py
@@ -9,4 +9,4 @@ TRPC Agent Version Module
 This module defines the version information for TRPC Agent
 """
 
-__version__ = '1.1.18'
+__version__ = '1.1.19'


### PR DESCRIPTION
版本号同步发布：

- version.py / test_version.py 升级到 1.1.19
- CHANGELOG 新增 1.1.19 区块

携带 1.1.18 已包含的修复（LLM 流式中断 span 修复、CI 扩展包安装）。