### PR TITLE
发布 1.1.19 版本：r0.1 分支补发 1.1.18 修复并对齐版本号

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.1.19](https://github.com/trpc-group/trpc-agent-python/releases/tag/v1.1.19) (2026-08-21)
+
+Backports the fixes already released in 1.1.18 (LLM streaming interruption span fixes and CI extension package installation) to the `r0.1` branch, and bumps the version number to align with `main`.
+
 ## [1.1.18](https://github.com/trpc-group/trpc-agent-python/releases/tag/v1.1.18) (2026-08-21)
 
 ### Bug Fixes

--- a/pipeline_test/run_all_examples.sh
+++ b/pipeline_test/run_all_examples.sh
@@ -409,10 +409,10 @@ source "${SCRIPT_DIR}/_install_deps.sh"
 # Install optional extras required by the selected mode.
 case "$RUN_MODE" in
     all)
-        EXTRAS="graph,a2a,agent-claude,knowledge,knowledge-hf,langchain_tool,mempalace,eval"
+        EXTRAS="graph,a2a,agent-claude,knowledge,knowledge-hf,langchain_tool,mempalace,eval,deepseek-langchain"
         ;;
     run-agent)
-        EXTRAS="graph,a2a,agent-claude,knowledge,knowledge-hf,langchain_tool,mempalace"
+        EXTRAS="graph,a2a,agent-claude,knowledge,knowledge-hf,langchain_tool,mempalace,deepseek-langchain"
         ;;
     evaluation)
         EXTRAS="eval"

--- a/tests/agents/core/test_llm_processor.py
+++ b/tests/agents/core/test_llm_processor.py
@@ -371,3 +371,58 @@ class TestCallLlmAsync:
         assert mock_trace.call_args.kwargs["error_type"] == "RuntimeError"
         assert mock_trace.call_args.kwargs["error_message"] == "upstream failed"
         assert mock_report.call_args.kwargs["error_type"] == "RuntimeError"
+
+    def test_retry_swallowed_error_traces_accumulated_partial_content(self, invocation_context):
+        """The SDK-managed retry layer (retry_model_call) can swallow a raised
+        exception and yield a normal-looking terminal LlmResponse(content=None,
+        error_code=...) instead of re-raising - this arrives via the `async for`
+        loop, not through the except branches. The call_llm span's llm_response
+        attribute must still carry the partial text already streamed, instead of
+        losing it just because content is None on the terminal response."""
+        m = MockLLMModel(model_name="test-llmproc-model")
+        m._responses = [
+            LlmResponse(content=Content(parts=[Part(text="Hello")]), partial=True),
+            LlmResponse(content=Content(parts=[Part(text=", the weather")]), partial=True),
+            # Mimics models/_retry.py:_build_error_response - a normal
+            # (non-raised) terminal response with content=None and error_code
+            # set, as yielded by retry_model_call after swallowing an exception.
+            LlmResponse(
+                content=None,
+                error_code="STREAMING_ERROR",
+                error_message="simulated mid-stream network interruption",
+                custom_metadata={"error": "simulated mid-stream network interruption"},
+            ),
+        ]
+        proc = LlmProcessor(m)
+        request = LlmRequest()
+
+        async def run():
+            events = []
+            async for event in proc.call_llm_async(request, invocation_context, stream=True):
+                events.append(event)
+            return events
+
+        with patch("trpc_agent_sdk.agents.core._llm_processor.report_call_llm") as mock_report, \
+             patch("trpc_agent_sdk.agents.core._llm_processor.trace_call_llm") as mock_trace, \
+             patch("trpc_agent_sdk.agents.core._llm_processor.tracer"):
+            events = asyncio.run(run())
+
+        # The terminal error event is yielded to the agent (unaffected by the
+        # trace-only back-fill).
+        assert events[-1].error_code == "STREAMING_ERROR"
+        assert events[-1].content is None
+
+        mock_trace.assert_called_once()
+        response = mock_trace.call_args.args[3]
+        assert response.error_code == "STREAMING_ERROR"
+        assert response.error_message == "simulated mid-stream network interruption"
+        # Back-filled for tracing: content now carries the already-streamed
+        # partial text instead of being None.
+        assert response.content is not None
+        assert response.content.parts[0].text == "Hello, the weather"
+
+        # The Event yielded to the agent and the response passed to
+        # report_call_llm are unaffected - only the trace_call_llm argument is
+        # back-filled.
+        report_response = mock_report.call_args.args[2]
+        assert report_response.content is None

--- a/tests/agents/test_base_agent.py
+++ b/tests/agents/test_base_agent.py
@@ -33,6 +33,33 @@ class ConcreteAgent(BaseAgent):
         )
 
 
+class MidStreamErrorAgent(BaseAgent):
+    """Agent that streams partial text then emits a mid-stream error event."""
+
+    async def _run_async_impl(self, ctx: InvocationContext) -> AsyncGenerator[Event, None]:
+        yield Event(
+            invocation_id=ctx.invocation_id,
+            author=self.name,
+            branch=ctx.branch,
+            content=Content(parts=[Part(text="Hello")]),
+            partial=True,
+        )
+        yield Event(
+            invocation_id=ctx.invocation_id,
+            author=self.name,
+            branch=ctx.branch,
+            content=Content(parts=[Part(text=", world")]),
+            partial=True,
+        )
+        yield Event(
+            invocation_id=ctx.invocation_id,
+            author=self.name,
+            branch=ctx.branch,
+            error_code="STREAMING_ERROR",
+            error_message="simulated mid-stream network interruption",
+        )
+
+
 class MockLLMModel(LLMModel):
 
     @classmethod
@@ -240,3 +267,28 @@ class TestBaseAgentTracing:
         assert mock_trace_agent.call_args.kwargs["error_type"] == "AgentGeneratorExit"
         assert mock_trace_agent.call_args.kwargs["error_message"] == "Agent execution stopped with GeneratorExit."
         assert mock_report.call_args.kwargs["error_type"] == "AgentGeneratorExit"
+
+    def test_mid_stream_error_event_preserves_partial_text_and_marks_error(self, invocation_context):
+        """A mid-stream error event (e.g. STREAMING_ERROR from the SDK-managed
+        retry layer) must not wipe out the partial text already streamed, and
+        must mark the agent span as an error instead of silently succeeding
+        with empty output."""
+        agent = MidStreamErrorAgent(name="mid_stream_error_agent")
+        ctx = invocation_context.model_copy(update={"agent": agent})
+
+        async def run():
+            events = []
+            async for event in agent.run_async(ctx):
+                events.append(event)
+            return events
+
+        with patch("trpc_agent_sdk.agents._base_agent.report_invoke_agent") as mock_report, \
+             patch("trpc_agent_sdk.agents._base_agent.trace_agent") as mock_trace_agent, \
+             patch("trpc_agent_sdk.agents._base_agent.tracer"):
+            events = asyncio.run(run())
+
+        assert [e.error_code for e in events] == [None, None, "STREAMING_ERROR"]
+        assert mock_trace_agent.call_args.kwargs["error_type"] == "STREAMING_ERROR"
+        assert (mock_trace_agent.call_args.kwargs["error_message"] == "simulated mid-stream network interruption")
+        assert mock_trace_agent.call_args.kwargs["agent_action"] == "[INTERRUPTED]\nHello, world"
+        assert mock_report.call_args.kwargs["error_type"] == "STREAMING_ERROR"

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -311,6 +311,53 @@ class TestRunAsync:
         assert mock_trace_runner.call_args.kwargs["error_message"] == "Runner invocation stopped with GeneratorExit."
 
     @pytest.mark.asyncio
+    async def test_mid_stream_error_event_preserves_partial_text_and_marks_error(self, runner, mock_session_service,
+                                                                                 mock_agent, mock_session):
+        """A mid-stream error event (e.g. STREAMING_ERROR from the SDK-managed
+        retry layer) must not wipe out the partial text already streamed, and
+        must mark the runner span as an error instead of silently succeeding
+        with empty output."""
+        mock_session_service.get_session.return_value = mock_session
+
+        async def mock_agent_run(ctx):
+            yield Event(
+                invocation_id=ctx.invocation_id,
+                author="test_agent",
+                content=Content(parts=[Part(text="Hello")]),
+                partial=True,
+            )
+            yield Event(
+                invocation_id=ctx.invocation_id,
+                author="test_agent",
+                content=Content(parts=[Part(text=", world")]),
+                partial=True,
+            )
+            yield Event(
+                invocation_id=ctx.invocation_id,
+                author="test_agent",
+                error_code="STREAMING_ERROR",
+                error_message="simulated mid-stream network interruption",
+            )
+
+        mock_agent.run_async = mock_agent_run
+
+        with patch("trpc_agent_sdk.runners.trace_runner") as mock_trace_runner, \
+             patch("trpc_agent_sdk.runners.tracer"):
+            events = []
+            async for event in runner.run_async(
+                    user_id="test_user",
+                    session_id="test_session",
+                    new_message=Content(parts=[Part(text="Hello")]),
+                    run_config=RunConfig(streaming=True),
+            ):
+                events.append(event)
+
+        assert [e.error_code for e in events] == [None, None, "STREAMING_ERROR"]
+        assert mock_trace_runner.call_args.kwargs["error_type"] == "STREAMING_ERROR"
+        assert (mock_trace_runner.call_args.kwargs["error_message"] == "simulated mid-stream network interruption")
+        assert mock_trace_runner.call_args.kwargs["partial_text"] == "Hello, world"
+
+    @pytest.mark.asyncio
     async def test_run_async_non_streaming_mode(self, runner, mock_session_service, mock_agent, mock_session):
         """Test non-streaming mode only yields complete events."""
         # Setup

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -10,4 +10,4 @@ from trpc_agent_sdk.version import __version__
 
 def test_version():
     """Test the version module."""
-    assert __version__ == '1.1.18'
+    assert __version__ == '1.1.19'

--- a/trpc_agent_sdk/agents/_base_agent.py
+++ b/trpc_agent_sdk/agents/_base_agent.py
@@ -309,6 +309,20 @@ class BaseAgent(AgentABC):
                             for part in event.content.parts:
                                 if part.text:
                                     partial_text_parts.append(part.text)
+                    elif event.is_error():
+                        # A mid-stream error event (e.g. the SDK-managed
+                        # retry layer swallowing a raised exception into a
+                        # terminal error LlmResponse) does not supersede the
+                        # partial text already streamed to the caller -
+                        # there is no successful final content to take over
+                        # from. Preserve it as a fallback for agent_action
+                        # instead of clearing it, and surface the error so
+                        # the span isn't misreported as a successful run
+                        # with empty output.
+                        if partial_text_parts:
+                            interrupted_partial_text = "".join(partial_text_parts)
+                        error_type = event.error_code
+                        error_message = event.error_message
                     else:
                         # A non-partial event finalizes this turn's output;
                         # any partial text accumulated so far has now been
@@ -349,12 +363,17 @@ class BaseAgent(AgentABC):
                 state_end = dict(ctx.session.state)
 
                 # Build formatted action string from all non-partial events.
-                # Fall back to the accumulated (but never finalized) partial
-                # text when the run was interrupted before producing any
-                # non-partial event, so streamed output is not silently lost.
+                # Append the accumulated (but never finalized) partial text
+                # when the run was interrupted mid-stream, so streamed
+                # output is not silently lost. This can happen even after
+                # earlier non-partial events already exist (e.g. a tool
+                # call/response from turn 1 of a multi-turn run), in which
+                # case the interrupted text from a later turn is appended
+                # rather than replacing the already-collected action string.
                 agent_action = _build_action_string_from_events(non_partial_events)
-                if not agent_action and interrupted_partial_text:
-                    agent_action = f"[INTERRUPTED]\n{interrupted_partial_text}"
+                if interrupted_partial_text:
+                    interrupted_str = f"[INTERRUPTED]\n{interrupted_partial_text}"
+                    agent_action = f"{agent_action}\n\n{interrupted_str}" if agent_action else interrupted_str
 
                 # Call trace function with agent execution details
                 with trace.use_span(agent_span, end_on_exit=False):

--- a/trpc_agent_sdk/agents/core/_llm_processor.py
+++ b/trpc_agent_sdk/agents/core/_llm_processor.py
@@ -195,6 +195,21 @@ class LlmProcessor:
                     raise
                 finally:
                     response_for_trace = final_llm_response or latest_llm_response or LlmResponse()
+                    # The SDK-managed retry layer (retry_model_call in
+                    # models/_retry.py) can swallow a raised exception and
+                    # yield a normal-looking terminal LlmResponse(content=None,
+                    # error_code=...) instead of re-raising - this arrives
+                    # here via the `async for` loop above, not through the
+                    # except branches, so _build_interrupted_content() was
+                    # never called for it and any partial text already
+                    # streamed to the caller would otherwise be missing from
+                    # the call_llm span's llm_response attribute. Back-fill it
+                    # for tracing purposes only (does not affect the Event
+                    # already yielded to the agent, nor report_call_llm below).
+                    if response_for_trace.content is None and response_for_trace.error_code:
+                        interrupted_content = _build_interrupted_content()
+                        if interrupted_content is not None:
+                            response_for_trace = response_for_trace.model_copy(update={"content": interrupted_content})
                     with trace.use_span(call_llm_span, end_on_exit=False):
                         trace_call_llm(
                             context,

--- a/trpc_agent_sdk/runners.py
+++ b/trpc_agent_sdk/runners.py
@@ -518,6 +518,19 @@ class Runner:
                                 for part in event.content.parts:
                                     if part.text:
                                         temp_text_parts.append(part.text)
+                        elif event.is_error():
+                            # A mid-stream error event does not supersede the
+                            # partial text already streamed to the caller -
+                            # there is no successful final content to take
+                            # over from. Preserve it as a fallback for
+                            # runner.output instead of clearing it, and
+                            # surface the error so the span isn't
+                            # misreported as a successful run with empty
+                            # output.
+                            if temp_text_parts:
+                                trace_partial_text = "".join(temp_text_parts)
+                            trace_error_type = event.error_code
+                            trace_error_message = event.error_message
                         else:
                             # Clear accumulated parts on full event
                             temp_text_parts.clear()

--- a/trpc_agent_sdk/telemetry/_trace.py
+++ b/trpc_agent_sdk/telemetry/_trace.py
@@ -159,7 +159,13 @@ def trace_runner(
     output_str = ""
     if last_event and last_event.content and last_event.content.parts:
         output_str = _join_parts_with_thought_tag(last_event.content.parts)
-    elif partial_text:
+    if not output_str and partial_text:
+        # Fall back to the accumulated (but never finalized) partial text
+        # when the last non-streaming event has no renderable text (e.g. a
+        # function_response event has no `.text` parts) or there was no
+        # such event at all. This covers both a run interrupted before any
+        # non-partial event existed, and a later-turn interruption after an
+        # earlier turn already produced a tool call/response.
         output_str = f"[INTERRUPTED]\n{partial_text}"
     span.set_attribute(f"{_trpc_agent_span_name}.runner.output", output_str)
 

--- a/trpc_agent_sdk/version.py
+++ b/trpc_agent_sdk/version.py
@@ -9,4 +9,4 @@ TRPC Agent Version Module
 This module defines the version information for TRPC Agent
 """
 
-__version__ = '1.1.18'
+__version__ = '1.1.19'


### PR DESCRIPTION
r0.1 分支发版：

- backport 1.1.18 已包含的修复（LLM 流式中断 span 修复 #303、CI 扩展包安装 #306）
- version.py / test_version.py 升级到 1.1.19
- CHANGELOG 新增 1.1.19 区块

与 main 分支版本号对齐。